### PR TITLE
refactor(api/webhook/alert): get chat ID from env and fixed markdown support

### DIFF
--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -1,8 +1,12 @@
+require('dotenv').config();
+
+const chatId = process.env.TELEGRAM_CHAT_ID;
+
 function postAlert(bot) {
 	return async (req, res) => {
 		const { body } = req;
 		try {
-			await bot.telegram.sendMessage(body.chatId, `${body.text}`, { parse_mode: body.parseMode });
+			await bot.telegram.sendMessage(chatId, `${body.text}`, { parse_mode: body.parseMode });
 			res.sendStatus(200);
 		} catch (error) {
 			console.debug('webhook/alert handler: Error sending message to bot');

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -6,7 +6,7 @@ function postAlert(bot) {
 	return async (req, res) => {
 		const { body } = req;
 		try {
-			await bot.telegram.sendMessage(chatId, `${body.text}`, { parse_mode: body.parseMode });
+			await bot.telegram.sendMessage(chatId, `${body.text}`, { parse_mode: 'MarkdownV2' });
 			res.sendStatus(200);
 		} catch (error) {
 			console.debug('webhook/alert handler: Error sending message to bot');


### PR DESCRIPTION
This PR deprecates the need to define the `chatId` and `parseMode` in the `/api/webhook/alert` endpoint body, so now you only need to define the `text` element

- [refactor(api/webhook/alert): get chat ID from env variable](https://github.com/francovp/cabros-crypto-bot-telegram/commit/e130b1acb4cf35ab1020a3862a94801757a671d7)
- [refactor(api/webhook/alert): set fixed parse_mode to MarkdownV2](https://github.com/francovp/cabros-crypto-bot-telegram/commit/017445a7cd640e4a21d1b82dc0e6f12d028b9168)