### PR TITLE
feat: add support for raw text alerts

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,8 +6,9 @@ const helmet = require('helmet');
 
 // Tell express to use body-parser's urlencoded parsing
 app.use(express.urlencoded({ extended: false }));
-// Tell express to use body-parser's JSON parsing
+// Tell express to use body-parser's JSON and text parsing
 app.use(express.json());
+app.use(express.text());
 
 // Configurar Cabeseras y CORS
 app.use(cors());

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -6,7 +6,13 @@ function postAlert(bot) {
 	return async (req, res) => {
 		const { body } = req;
 		try {
-			await bot.telegram.sendMessage(chatId, `${body.text}`, { parse_mode: 'MarkdownV2' });
+			let text = '';
+			if (typeof body === 'object' && 'text' in body) {
+				text = body.text;
+			} else {
+				text = body;
+			}
+			await bot.telegram.sendMessage(chatId, text, { parse_mode: 'MarkdownV2' });
 			res.sendStatus(200);
 		} catch (error) {
 			console.debug('webhook/alert handler: Error sending message to bot');


### PR DESCRIPTION
This PR add support to send raw text alerts in the `/api/webhook/alert` endpoint body. This is backwards compatible with the previous method using JSON alerts. 

So now it supports alerts with `Content-Type: application/json`
```json
{
    "text": "*_BTCUSDT_* está cruzando *68700*"
}
```
and `Content-Type: text/plain; charset=utf-8`
```text
*_BTCUSDT_* está cruzando *68700*
```