### PR TITLE
feat: send deployed bot system message to admin bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dist
 .tern-port
 
 .idea/
+.vscode/launch.json


### PR DESCRIPTION
Send a system message `Telegram bot deployed from commit aabbcc is running` to an admin bot defined in the `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID` environment variable when the bot initializes.