### PR TITLE
fix(formatter): improve WhatsApp markdown compatibility

### DIFF
--- a/src/services/notification/formatters/whatsappMarkdownFormatter.js
+++ b/src/services/notification/formatters/whatsappMarkdownFormatter.js
@@ -56,7 +56,14 @@ class WhatsAppMarkdownFormatter {
 
     if (summary) {
       // Unescape MarkdownV2 sequences in summary
-      const unescapedSummary = summary.replace(/\\([_*[\]()~`>#+\-=|{}.!])/g, "$1");
+      let unescapedSummary = summary.replace(/\\([_*[\]()~`>#+\-=|{}.!])/g, "$1");
+      // Convert MarkdownV2 bold (**text**) to WhatsApp bold (*text*)
+      unescapedSummary = unescapedSummary.replace(/\*\*/g, "*");
+
+      // Convert bullet points from * to - for WhatsApp compatibility
+      unescapedSummary = unescapedSummary.replace(/^\*\s+/gm, "- ");
+      unescapedSummary = unescapedSummary.replace(/\n\*\s+/g, "\n- ");
+
       message += `\n\n${unescapedSummary}`;
     }
 


### PR DESCRIPTION
Unescapes MarkdownV2 sequences, converts bold formatting, and replaces bullet points with WhatsApp-compatible styles to ensure correct rendering in WhatsApp notifications.