### PR TITLE
feat(prompts): add Langfuse-backed runtime prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,26 @@ GEMINI_API_KEY=your_google_ai_studio_api_key_here
 # Enable model metadata footer in enriched alerts (default: true)
 ENABLE_MESSAGE_FOOTER_METADATA=true
 
+# ==========================================================================
+# OPTIONAL: Langfuse Prompt Management
+# ==========================================================================
+
+# Fetch runtime prompts from Langfuse instead of local defaults (default: false)
+ENABLE_LANGFUSE_PROMPTS=false
+
+# Langfuse project credentials (required when ENABLE_LANGFUSE_PROMPTS=true)
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+
+# Langfuse region or self-hosted base URL (default: https://cloud.langfuse.com)
+LANGFUSE_BASE_URL=https://cloud.langfuse.com
+
+# Prompt label to fetch (default: latest in dev/test, production in prod-like envs)
+LANGFUSE_PROMPT_LABEL=latest
+
+# SDK cache TTL in seconds for prompt fetches (default: 0 for latest, 60 for production)
+LANGFUSE_PROMPT_CACHE_TTL_SECONDS=0
+
 # ============================================================================
 # OPTIONAL: TradingView MCP Enrichment (Webhook Signals)
 # ============================================================================

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 - 🚀 **Webhook API**: HTTP endpoint for receiving alerts from external services (e.g., TradingView)
 - 📰 **News Monitoring**: Analyze financial news and market sentiment for crypto and stock symbols with AI-powered event detection
 - 🧠 **AI Enrichment**: Optional enhancement of alerts using Google Gemini API (grounding) and optional secondary LLM (Azure AI)
+- 🧩 **Langfuse Prompt Management**: Manage all runtime LLM prompts centrally in Langfuse with local fail-open fallbacks
 - 📊 **TradingView MCP Enrichment**: Optional real-time technical analysis for webhook signals like `BTCUSDT(240) pasó a señal de VENTA`
 - 💎 **Event Detection**: Identify significant trading events (price surges, public figure mentions, regulatory announcements)
 - 💰 **Market Context**: Optional Binance integration for real-time crypto prices with Gemini fallback
@@ -41,6 +42,15 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 
 - `ENABLE_GEMINI_GROUNDING` - Enable Gemini-based alert enrichment (`true` or `false`)
 - `GEMINI_API_KEY` - Google API key for Gemini access
+
+#### Langfuse Prompt Management
+
+- `ENABLE_LANGFUSE_PROMPTS` - Fetch runtime prompts from Langfuse (`true` or `false`, default: `false`)
+- `LANGFUSE_PUBLIC_KEY` - Langfuse public key (required when Langfuse prompt management is enabled)
+- `LANGFUSE_SECRET_KEY` - Langfuse secret key (required when Langfuse prompt management is enabled)
+- `LANGFUSE_BASE_URL` - Langfuse base URL (default: `https://cloud.langfuse.com`)
+- `LANGFUSE_PROMPT_LABEL` - Prompt label to fetch (default: `latest` in local/dev/test, `production` in production-like environments)
+- `LANGFUSE_PROMPT_CACHE_TTL_SECONDS` - Prompt cache TTL in seconds (default: `0` for `latest`, `60` for `production`)
 
 #### TradingView MCP Enrichment
 
@@ -107,6 +117,7 @@ Then edit `.env` with your specific values. See `.env.example` for complete docu
 - **Required**: Core bot token and chat IDs
 - **Optional: WhatsApp**: GreenAPI integration for multi-channel alerts
 - **Optional: AI Grounding**: Gemini API for alert enrichment
+- **Optional: Prompt Management**: Langfuse-backed runtime prompts with local fallbacks
 - **Optional: TradingView MCP**: Real-time technical enrichment for webhook signals
 - **Optional: Admin Notifications**: Separate chat for deployment alerts
 - **Optional: Server Configuration**: Port, Render.com flags
@@ -166,6 +177,28 @@ When `ENABLE_GEMINI_GROUNDING=true`:
 
 - `ENABLE_GEMINI_GROUNDING` - Enable/disable enrichment (default: `false`)
 - `GEMINI_API_KEY` - Google API key with Generative AI enabled
+
+### How Langfuse Prompt Management Works
+
+When `ENABLE_LANGFUSE_PROMPTS=true`, runtime prompts are fetched from Langfuse through the centralized prompt service in `src/services/prompts/`.
+
+The local fallback prompts now live as editable text templates under `src/services/prompts/defaults/`, which makes them much easier to review, diff, and version independently from the prompt registry code.
+
+Managed prompts currently include:
+
+- search-query derivation
+- grounded summary generation
+- webhook alert enrichment
+- news analysis
+- secondary confidence enrichment
+- Gemini market price fetch query
+
+Behavior notes:
+
+- **Fail-open by design**: if Langfuse is disabled, misconfigured, unavailable, or missing a prompt, the app automatically falls back to the local prompt text files in `src/services/prompts/defaults/`.
+- **Label-based rollout**: use `LANGFUSE_PROMPT_LABEL` (for example `latest`, `staging`, or `production`) to switch prompt versions without code changes.
+- **SDK caching**: prompt fetches use the Langfuse SDK cache and can be tuned with `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`.
+- **Current architecture contract**: prompts are compiled into the existing `systemPrompt` / `userPrompt` flow, so provider routing for Gemini, Azure, and OpenRouter remains unchanged.
 
 ## TradingView Signal Enrichment with MCP
 
@@ -721,6 +754,7 @@ npm run test:coverage
 - **messageHelper**: Message truncation and formatting
 - **MarkdownV2Formatter**: Telegram MarkdownV2 text escaping
 - **WhatsAppMarkdownFormatter**: WhatsApp markdown conversion
+- **PromptService** (`src/services/prompts/`): Centralized runtime prompt registry with Langfuse fetch + local file-based fallback behavior
 
 ### Alert Processing (News Monitor)
 
@@ -795,6 +829,21 @@ GEMINI_API_KEY=your_google_ai_studio_api_key
 
 # Alerts will be enriched with AI analysis before sending
 ```
+
+### With Langfuse Prompt Management
+
+```bash
+ENABLE_LANGFUSE_PROMPTS=true
+LANGFUSE_PUBLIC_KEY=pk-lf-your-public-key
+LANGFUSE_SECRET_KEY=sk-lf-your-secret-key
+LANGFUSE_BASE_URL=https://cloud.langfuse.com
+
+# Use "latest" locally and "production" in deployed environments
+LANGFUSE_PROMPT_LABEL=latest
+LANGFUSE_PROMPT_CACHE_TTL_SECONDS=0
+```
+
+With this enabled, prompt edits can be shipped from Langfuse without redeploying the bot. If Langfuse is unavailable, the service falls back to the local prompt registry automatically.
 
 ### With News Monitoring (Gemini-only)
 

--- a/agents.md
+++ b/agents.md
@@ -18,7 +18,7 @@ Key files / entry points
 Environment and runtime behavior (discoverable)
 - NODE version: `20.x` (see `package.json` engines).
 - Required env vars: `BOT_TOKEN` (throws if missing; even when Telegram bot is disabled).
-- Optional but relevant (non-exhaustive; see feature sections below for full config): `ENABLE_TELEGRAM_BOT`, `PORT`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID`, `ENABLE_WHATSAPP_ALERTS`, `ENABLE_GEMINI_GROUNDING`, `GEMINI_API_KEY`, `BRAVE_SEARCH_API_KEY`, `BRAVE_SEARCH_ENDPOINT`, `FORCE_BRAVE_SEARCH`, `MODEL_PROVIDER`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `ENABLE_NEWS_MONITOR`, `ENABLE_SENTRY`, `SENTRY_DSN`, `LOG_LEVEL`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `RENDER`, `IS_PULL_REQUEST`, `RENDER_GIT_COMMIT`, `RENDER_GIT_REPO_SLUG`.
+- Optional but relevant (non-exhaustive; see feature sections below for full config): `ENABLE_TELEGRAM_BOT`, `PORT`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID`, `ENABLE_WHATSAPP_ALERTS`, `ENABLE_GEMINI_GROUNDING`, `GEMINI_API_KEY`, `ENABLE_LANGFUSE_PROMPTS`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_PROMPT_LABEL`, `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`, `BRAVE_SEARCH_API_KEY`, `BRAVE_SEARCH_ENDPOINT`, `FORCE_BRAVE_SEARCH`, `MODEL_PROVIDER`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `ENABLE_NEWS_MONITOR`, `ENABLE_SENTRY`, `SENTRY_DSN`, `LOG_LEVEL`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `RENDER`, `IS_PULL_REQUEST`, `RENDER_GIT_COMMIT`, `RENDER_GIT_REPO_SLUG`.
 - Bot startup is gated: bot is launched only when `ENABLE_TELEGRAM_BOT === 'true'` and not a preview environment (`RENDER==='true' && IS_PULL_REQUEST==='true'` disables it).
 - Routes under `/api` (e.g. `/api/webhook/alert`) are mounted regardless of bot launch; individual features and notification channels are gated via env flags and per-channel validation.
 
@@ -108,6 +108,7 @@ The system provides optional enrichment of webhook alerts using Google Gemini AP
 - `grounding.js` — Orchestrates Gemini GoogleSearch grounding to fetch context and sources
 - `genaiClient.js` — Wrapper around Google Generative AI client
 - `gemini.js` — Gemini API configuration and prompt management
+- `src/services/prompts/` — Central prompt registry + Langfuse-backed runtime prompt resolution with local file-backed fallbacks
 - `alert.js` — Webhook handler that optionally calls grounding service
 
 **Grounding Service Pattern**:
@@ -154,9 +155,34 @@ The system provides optional enrichment of webhook alerts using Google Gemini AP
 - `instrument.js` / `index.js` for lifecycle (loads config; grounding runs per-request when `ENABLE_GEMINI_GROUNDING=true`)
 - `src/services/grounding/grounding.js` for orchestration logic and timeout handling
 - `src/controllers/webhooks/handlers/alert/alert.js` for webhook flow and grounding integration
-- `src/services/grounding/gemini.js` for prompt templates and response parsing
+- `src/services/grounding/gemini.js` for response parsing and prompt variable assembly
+- `src/services/prompts/` for runtime prompt definitions, Langfuse labels, and local fallback behavior (`defaults/*.txt`)
 - Tests in `tests/integration/alert-grounding.test.js` for end-to-end behavior
 - Tests in `tests/unit/grounding.test.js` and `tests/unit/gemini-client.test.js` for core logic
+
+## Centralized Prompt Management (Langfuse-backed)
+
+Runtime LLM prompts are centrally managed through `src/services/prompts/`.
+
+**Current pattern**:
+- `PromptService` resolves prompts by stable key/name.
+- If `ENABLE_LANGFUSE_PROMPTS=true`, prompts are fetched from Langfuse using `LANGFUSE_PROMPT_LABEL` and `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`.
+- If Langfuse is disabled, misconfigured, unavailable, or missing a prompt, the system **fails open** to the local fallback text templates in `src/services/prompts/defaults/`.
+
+**Rules for future changes**:
+- Do **not** inline new runtime LLM prompt strings directly in feature code when they belong to production flows.
+- Register new prompts in `src/services/prompts/promptRegistry.js` with a stable Langfuse name and add matching local fallback text templates under `src/services/prompts/defaults/`.
+- Resolve prompts via `getPromptService()` from `src/services/prompts/`.
+- Keep provider routing (`genaiClient.llmCallv2`, Azure/OpenRouter clients) separate from prompt ownership.
+- Add or update unit tests in `tests/unit/prompt-service.test.js` and the affected feature tests whenever a prompt contract changes.
+
+**Current managed prompts**:
+- search-query derivation
+- grounded summary generation
+- alert enrichment
+- news analysis
+- confidence enrichment
+- Gemini market price fetch query
 
 
 ## Enriched Webhook Alert Output (004-enrich-alert-output)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google/genai": "^1.27.0",
+        "@langfuse/client": "^5.0.1",
         "@sentry/node": "^8.0.0",
         "binance": "^2.10.2",
         "cors": "^2.8.5",
@@ -3042,6 +3043,44 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@langfuse/client": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/client/-/client-5.0.1.tgz",
+      "integrity": "sha512-AeAHrYwVCnUApJ9II2Nk4mC26l09R2tgQ8YKkRT1PXp9y0fYvzZuXFCMn3Qey5kCN1isu7Jgk/dqP38bQmaw9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@langfuse/core": "^5.0.1",
+        "@langfuse/tracing": "^5.0.1",
+        "mustache": "^4.2.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@langfuse/core": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.0.1.tgz",
+      "integrity": "sha512-DirjtE+RjToRuJeVzy7EC05ebtz+ryEDBjjeRNbcQ5OQ38VaIMqWgt124ZQXfW5Rel9oobGcYDu6V5nkr2TuMg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@langfuse/tracing": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.0.1.tgz",
+      "integrity": "sha512-1LyOj6ct1piIivqMKMPcMFFWksH6MaUjA/0hY1N5IAquSnx6GQuN7Hhj/XqqZWBMWszcd2vcTRb9i6MIdDY49g==",
+      "license": "MIT",
+      "dependencies": {
+        "@langfuse/core": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -9065,6 +9104,15 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@google/genai": "^1.27.0",
+    "@langfuse/client": "^5.0.1",
     "@sentry/node": "^8.0.0",
     "binance": "^2.10.2",
     "cors": "^2.8.5",

--- a/src/controllers/webhooks/handlers/alert/grounding.js
+++ b/src/controllers/webhooks/handlers/alert/grounding.js
@@ -61,7 +61,7 @@ function mergeEnrichmentData(text, geminiEnriched, mcpEnriched) {
 	const modelName = geminiBackticked[0] || GROUNDING_MODEL_NAME;
 	const groundingFromGemini = geminiBackticked[1] || GROUNDING_MODEL_NAME;
 	const groundingProviders = mergeUnique([groundingFromGemini], ['tradingview-mcp'], 8);
-	const extraText = `*Model used*: ` + '`' + `${modelName}` + '`' + `\n*Grounding*: ` + '`' + `${groundingProviders.join('`, `')}` + '`';
+	const extraText = '*Model used*: ' + '`' + `${modelName}` + '`' + '\n*Grounding*: ' + '`' + `${groundingProviders.join('`, `')}` + '`';
 
 	return {
 		original_text: text,
@@ -88,7 +88,7 @@ async function enrichWithGemini(text, tokenUsage) {
 	const enableFooter = process.env.ENABLE_MESSAGE_FOOTER_METADATA !== 'false';
 	const modelName = modelUsed || GROUNDING_MODEL_NAME;
 	const extraText = enableFooter
-		? `*Model used*: ` + '`' + `${modelName}` + '`' + `\n*Grounding*: ` + '`' + `${GROUNDING_MODEL_NAME}` + '`'
+		? '*Model used*: ' + '`' + `${modelName}` + '`' + '\n*Grounding*: ' + '`' + `${GROUNDING_MODEL_NAME}` + '`'
 		: '';
 
 	return {

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -10,7 +10,10 @@ const { getCacheInstance } = require('./cache');
 const { getEnrichmentService } = require('../../../../services/inference/enrichmentService');
 const { AnalysisStatus, EventCategory } = require('./constants');
 const { GROUNDING_MODEL_NAME, ENABLE_NEWS_MONITOR_TEST_MODE } = require('../../../../services/grounding/config');
+const { getPromptService, PromptKeys } = require('../../../../services/prompts');
 const { MainClient } = require('binance');
+
+const promptService = getPromptService();
 
 // Placeholder for NotificationManager - will be injected
 let notificationManager = null;
@@ -346,15 +349,14 @@ class NewsAnalyzer {
 				timeoutHandle = setTimeout(() => reject(new Error('Gemini fetch timeout')), timeoutMs);
 			});
 
+			const { text: priceQuery } = await promptService.getTextPrompt(
+				PromptKeys.MARKET_PRICE_FETCH,
+				{ symbol },
+			);
+
 			// Use Gemini GoogleSearch to fetch current price
 			const priceSearchPromise = genaiClient.search({
-				query: `Get current price of ${symbol} today in USD and respond with ONLY valid JSON. Example format (respond with similar structure but with actual numbers):
-{
-  "price": 150.25,
-  "change_24h": 2.5,
-  "context": "detailed context about price and market",
-  "sources": ["url1", "url2"]
-}`,
+				query: priceQuery,
 				maxResults: 3,
 			});
 

--- a/src/services/grounding/config.js
+++ b/src/services/grounding/config.js
@@ -1,6 +1,13 @@
 // Environment variables and configuration
 require('dotenv').config();
 
+const {
+	getGroundedSummarySystemPrompt,
+	getAlertEnrichmentSystemPrompt,
+	getNewsAnalysisSystemPrompt,
+	getSearchQuerySystemPrompt,
+} = require('../prompts/localPromptTemplates');
+
 // Test mode flag for news monitoring
 const ENABLE_NEWS_MONITOR_TEST_MODE = process.env.ENABLE_NEWS_MONITOR_TEST_MODE === 'true';
 
@@ -18,7 +25,7 @@ const GROUNDING_MAX_SOURCES = parseInt(process.env.GROUNDING_MAX_SOURCES || '3',
 const GROUNDING_TIMEOUT_MS = parseInt(process.env.GROUNDING_TIMEOUT_MS || '30000', 10);
 const GROUNDING_MAX_LENGTH = parseInt(process.env.GROUNDING_MAX_LENGTH || '2000', 10);
 const MODEL_PROVIDER = process.env.MODEL_PROVIDER || 'gemini';
-const GROUNDING_MODEL_NAME = FORCE_BRAVE_SEARCH ? "brave-search" : process.env.GROUNDING_MODEL_NAME || 'gemini-2.5-flash';
+const GROUNDING_MODEL_NAME = FORCE_BRAVE_SEARCH ? 'brave-search' : process.env.GROUNDING_MODEL_NAME || 'gemini-2.5-flash';
 const GEMINI_MODEL_NAME = process.env.GEMINI_MODEL_NAME || null;
 const GEMINI_MODEL_NAME_FALLBACK = process.env.GEMINI_MODEL_NAME_FALLBACK || 'gemini-2.5-flash-lite';
 const AZURE_LLM_MODEL = process.env.AZURE_LLM_MODEL || null;
@@ -27,27 +34,16 @@ const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 const OPENROUTER_MODEL = process.env.OPENROUTER_MODEL || 'google/gemini-2.0-flash-001';
 
 // Prompt configuration
-const GEMINI_SYSTEM_PROMPT = process.env.GEMINI_SYSTEM_PROMPT || `
-You are a helpful assistant that provides concise summaries of alerts with verified context.
-Focus on:
-1. Key facts and updates
-2. Market impact or implications 
-3. Related context from reliable sources
+const GEMINI_SYSTEM_PROMPT = getGroundedSummarySystemPrompt({
+	maxLength: GROUNDING_MAX_LENGTH,
+});
 
-Keep summaries under ${GROUNDING_MAX_LENGTH} characters.
-Preserve the original language of the alert if possible.
-`.trim();
+const ALERT_ENRICHMENT_SYSTEM_PROMPT = getAlertEnrichmentSystemPrompt();
 
-const ALERT_ENRICHMENT_SYSTEM_PROMPT = 'You are a financial market analyst. Your job is to analyze alerts and provide structured insights, sentiment, and technical levels.';
-
-const NEWS_ANALYSIS_SYSTEM_PROMPT = `You are a financial market sentiment analyst specializing in crypto and stock news analysis.
-Analyze the provided news/context and detect market-moving events.`;
+const NEWS_ANALYSIS_SYSTEM_PROMPT = getNewsAnalysisSystemPrompt();
 
 // Search query prompt
-const SEARCH_QUERY_PROMPT = process.env.SEARCH_QUERY_PROMPT || `
-Extract key topics and entities from this alert to create a search query.
-Focus on recent developments, market conditions, or specific events mentioned.
-`.trim();
+const SEARCH_QUERY_PROMPT = getSearchQuerySystemPrompt();
 
 // Validation
 if (ENABLE_GEMINI_GROUNDING && !GEMINI_API_KEY) {

--- a/src/services/grounding/gemini.js
+++ b/src/services/grounding/gemini.js
@@ -1,7 +1,30 @@
 const genaiClient = require('./genaiClient');
 const { validateGeminiResponse } = require('../../lib/validation');
-const { GEMINI_SYSTEM_PROMPT, GROUNDING_MODEL_NAME, GEMINI_MODEL_NAME, GEMINI_MODEL_NAME_FALLBACK, ENABLE_NEWS_MONITOR_TEST_MODE, NEWS_ANALYSIS_SYSTEM_PROMPT } = require('./config');
+const { GROUNDING_MODEL_NAME, GEMINI_MODEL_NAME, GEMINI_MODEL_NAME_FALLBACK, ENABLE_NEWS_MONITOR_TEST_MODE } = require('./config');
 const { EventCategory } = require('../../controllers/webhooks/handlers/newsMonitor/constants');
+const { getPromptService, PromptKeys } = require('../prompts');
+
+const promptService = getPromptService();
+
+function getLanguageDirective(preserveLanguage) {
+	return preserveLanguage
+		? 'Respond in the same language as the Alert text.'
+		: '';
+}
+
+function buildContextPrompt(searchResults = []) {
+	return searchResults.length > 0
+		? `\n\nContext from verified sources:\n${searchResults
+			.map(result => `- ${result.title}\n  ${result.snippet}`)
+			.join('\n')}`
+		: '';
+}
+
+function buildContextSnippet(searchResultText = '') {
+	return searchResultText
+		? `\n\nAdditional context for the sources:\n${searchResultText}`
+		: '';
+}
 
 /**
  * Generates a summary with citations given an alert text and optional context
@@ -14,7 +37,7 @@ async function generateGroundedSummary({ text, searchResults = [], searchResultT
 	const {
 		maxLength = 250,
 		preserveLanguage = true,
-		systemPrompt = GEMINI_SYSTEM_PROMPT,
+		systemPrompt: systemPromptOverride,
 		tokenUsage,
 	} = options;
 
@@ -28,30 +51,24 @@ async function generateGroundedSummary({ text, searchResults = [], searchResultT
 		};
 	}
 
-	// Prepare prompt with language preservation if needed
-	const langDirective = preserveLanguage
-		? 'Respond in the same language as the Alert text.'
-		: '';
-
-	const contextPrompt = searchResults.length > 0
-		? `\n\nContext from verified sources:\n${searchResults
-			.map(result => `- ${result.title}\n  ${result.snippet}`)
-			.join('\n')}`
-		: '';
-
-	const contextSnippet = searchResultText
-		? `\n\nAdditional context for the sources:\n${searchResultText}`
-		: '';
-
-	// Split System and User parts
-	const fullSystemPrompt = `${systemPrompt}\n\n${langDirective}`;
-	const userPrompt = `Please analyze this alert and provide a concise summary (max ${maxLength} chars) with citations based in the context:
-
-Alert: ${text}${contextPrompt}${contextSnippet}`;
+	const languageDirective = getLanguageDirective(preserveLanguage);
+	const contextPrompt = buildContextPrompt(searchResults);
+	const contextSnippet = buildContextSnippet(searchResultText);
+	const { systemPrompt, userPrompt } = await promptService.getChatPrompt(
+		PromptKeys.GROUNDED_SUMMARY,
+		{
+			alertText: text,
+			maxLength,
+			languageDirective,
+			contextPrompt,
+			contextSnippet,
+		},
+		{ systemPromptOverride },
+	);
 
 	try {
 		const { text: summary, usage } = await genaiClient.llmCallv2({
-			systemPrompt: fullSystemPrompt,
+			systemPrompt,
 			userPrompt,
 			context: { citations: searchResults },
 			opts: { temperature: 0.2 },
@@ -100,11 +117,16 @@ async function analyzeNewsForSymbol(symbol, context, options = {}) {
 	}
 
 	try {
+		const { text: searchQuery } = await promptService.getTextPrompt(
+			PromptKeys.NEWS_ANALYSIS_SEARCH_QUERY,
+			{ symbol },
+		);
+
 		// Use Gemini GoogleSearch to fetch market news and sentiment
 		// Note: We still rely on genaiClient for search. If Gemini is not configured, this might fail or return empty
 		// depending on how genaiClient handles missing config, but here we focus on switching the LLM call.
 		const searchResult = await genaiClient.search({
-			query: `${symbol} news market sentiment events today`,
+			query: searchQuery,
 			maxResults: 3,
 		});
 		if (tokenUsage && searchResult.usage) {
@@ -123,54 +145,16 @@ async function analyzeNewsForSymbol(symbol, context, options = {}) {
 		const enrichedContext = `${context}\n\nGrounded Context from Search:\n${groundingContext}\n\nSources: ${sourcesList.join(', ')}`;
 		console.debug('[Gemini][analyzeNewsForSymbol] Enriched context for analysis:', enrichedContext);
 
-		const userPrompt = `Analyze this news/market context for symbol ${symbol}:
-
-${enrichedContext}
-
-Instructions (important):
-
-- **Task:** Read the provided news/context and detect any market-moving event related to the symbol.
-- **Output:** Respond *only* with a single, valid JSON object (no surrounding text, no markdown, no commentary).
-- **JSON schema:** Follow the example exactly. Use real values (numbers/strings) — do NOT include type annotations or ranges inside the JSON.
-
-Example JSON (respond with a similar structure using real values):
-{
-  "event_category": "price_surge",
-  "event_significance": 0.75,
-  "sentiment_score": 0.45,
-  "headline": "One-line event description",
-  "description": "Detailed explanation of the event with bulletpoints and bold text."
-}
-
-Field guidance:
-
-- **event_category** (string): one of **price_surge**, **price_decline**, **public_figure**, **regulatory**, **none**.
-- **event_significance** (number): 0.0 to 1.0 — how important the detected event is (use 0.0 for none, 1.0 for very significant).
-- **sentiment_score** (number): -1.0 to 1.0 — negative = bearish, positive = bullish.
-- **headline** (string): one concise line describing the event (max ~250 chars).
-- **description** (string): Detailed explanation with enrich text using hypen bulletpoints (not asterisks), nextline and bold text for readability (up to ~2000 chars).
-
-Event category hints:
-
-- **price_surge:** Bullish events (positive news, material price increases, upgrades, major buying pressure).
-- **price_decline:** Bearish events (negative news, material price drops, downgrades, selling pressure).
-- **public_figure:** Mentions/quotes from high-impact individuals that can move markets (e.g., Elon Musk).
-- **regulatory:** Official announcements, policy changes, fines, or legal actions.
-- **none:** No significant event detected.
-
-Conservatism and formatting rules:
-
-- Be conservative when assigning high scores — prefer 0.6+ only for well-sourced, high-credibility events.
-- Do not include any extra text before/after the JSON. If uncertain, return **event_category: "none"** with low significance.
-- Keep numeric values as plain numbers (no percent signs or units inside the JSON fields).
-
-End of instructions.`
+		const prompt = await promptService.getChatPrompt(
+			PromptKeys.NEWS_ANALYSIS,
+			{ symbol, enrichedContext },
+		);
 
 		let response;
 		try {
 			const result = await genaiClient.llmCallv2({
-				systemPrompt: NEWS_ANALYSIS_SYSTEM_PROMPT,
-				userPrompt,
+				systemPrompt: prompt.systemPrompt,
+				userPrompt: prompt.userPrompt,
 				opts: { model: GEMINI_MODEL_NAME, temperature: 0.3 }
 			});
 			if (tokenUsage && result.usage) {
@@ -186,8 +170,8 @@ End of instructions.`
 				console.warn('[Gemini] Primary model overloaded, attempting fallback model:', GEMINI_MODEL_NAME_FALLBACK);
 				try {
 					const fallbackResult = await genaiClient.llmCallv2({
-						systemPrompt: NEWS_ANALYSIS_SYSTEM_PROMPT,
-						userPrompt,
+						systemPrompt: prompt.systemPrompt,
+						userPrompt: prompt.userPrompt,
 						opts: { model: GEMINI_MODEL_NAME_FALLBACK, temperature: 0.3 }
 					});
 					if (tokenUsage && fallbackResult.usage) {
@@ -280,7 +264,7 @@ function parseNewsAnalysisResponse(response) {
 async function generateEnrichedAlert({ text, searchResults = [], searchResultText = '', options = {} }) {
 	const {
 		preserveLanguage = true,
-		systemPrompt = GEMINI_SYSTEM_PROMPT,
+		systemPrompt: systemPromptOverride,
 		tokenUsage,
 	} = options;
 
@@ -293,41 +277,23 @@ async function generateEnrichedAlert({ text, searchResults = [], searchResultTex
 		};
 	}
 
-	// Prepare prompt with language preservation if needed
-	const langDirective = preserveLanguage
-		? 'Respond in the same language as the Alert text.'
-		: '';
-
-	const contextPrompt = searchResults.length > 0
-		? `\n\nContext from verified sources:\n${searchResults
-			.map(result => `- ${result.title}\n  ${result.snippet}`)
-			.join('\n')}`
-		: '';
-
-	const contextSnippet = searchResultText
-		? `\n\nAdditional context for the sources:\n${searchResultText}`
-		: '';
-
-	const fullSystemPrompt = `${systemPrompt}\n\n${langDirective}`;
-	const context = `${text}${contextPrompt}${contextSnippet}`;
-	console.debug('[Gemini] Generating enriched alert with context:', context);
-	const userPrompt = `Analyze this alert and provide structured insights and sentiment based on the context.
-
-Alert: ${context}
-
-Instructions:
-- **Output:** Respond *only* with a single, valid JSON object.
-- **JSON schema:**
-{
-  "sentiment": "BULLISH" | "BEARISH" | "NEUTRAL",
-  "sentiment_score": number (0.0 to 1.0),
-  "insights": string[] (max 3 key points)
-}
-`;
+	const languageDirective = getLanguageDirective(preserveLanguage);
+	const contextPrompt = buildContextPrompt(searchResults);
+	const contextSnippet = buildContextSnippet(searchResultText);
+	const alertContext = `${text}${contextPrompt}${contextSnippet}`;
+	console.debug('[Gemini] Generating enriched alert with context:', alertContext);
+	const { systemPrompt, userPrompt } = await promptService.getChatPrompt(
+		PromptKeys.ALERT_ENRICHMENT,
+		{
+			alertContext,
+			languageDirective,
+		},
+		{ systemPromptOverride },
+	);
 
 	try {
 		const { text: responseText, usage, modelUsed } = await genaiClient.llmCallv2({
-			systemPrompt: fullSystemPrompt,
+			systemPrompt,
 			userPrompt,
 			context: { citations: searchResults },
 			opts: { temperature: 0.2 },
@@ -369,7 +335,7 @@ function parseEnrichedAlertResponse(response) {
 		return {
 			sentiment: parsed.sentiment,
 			sentiment_score: Math.max(0, Math.min(1, parsed.sentiment_score || 0.5)),
-			insights: Array.isArray(parsed.insights) ? parsed.insights.slice(0, 3) : [],
+			insights: Array.isArray(parsed.insights) ? parsed.insights : [],
 		};
 	} catch (error) {
 		console.warn(`[Gemini] Response parsing failed, using safe defaults: ${error.message}`);

--- a/src/services/grounding/grounding.js
+++ b/src/services/grounding/grounding.js
@@ -1,16 +1,16 @@
 const {
 	GROUNDING_MAX_SOURCES,
 	GROUNDING_TIMEOUT_MS,
-	SEARCH_QUERY_PROMPT,
 	GROUNDING_MAX_LENGTH,
 	GROUNDING_MODEL_NAME,
-	ALERT_ENRICHMENT_SYSTEM_PROMPT,
 	NEWS_ANALYSIS_SYSTEM_PROMPT,
-	GEMINI_SYSTEM_PROMPT,
 	GEMINI_MODEL_NAME,
 } = require('./config');
 const gemini = require('./gemini');
 const genaiClient = require('./genaiClient');
+const { getPromptService, PromptKeys } = require('../prompts');
+
+const promptService = getPromptService();
 
 /**
  * Derives a search query from alert text using an LLM
@@ -20,11 +20,14 @@ const genaiClient = require('./genaiClient');
  */
 async function deriveSearchQuery(alertText, opts = {}) {
 	try {
-		const prompt = `Alert: ${alertText}`;
-		console.debug('Deriving search query with prompt: ', prompt);
+		const { systemPrompt, userPrompt } = await promptService.getChatPrompt(
+			PromptKeys.SEARCH_QUERY_DERIVATION,
+			{ alertText },
+		);
+		console.debug('Deriving search query with prompt: ', userPrompt);
 		const response = await genaiClient.llmCallv2({
-			systemPrompt: SEARCH_QUERY_PROMPT,
-			userPrompt: prompt,
+			systemPrompt,
+			userPrompt,
 			opts: { temperature: opts.temperature },
 		});
 
@@ -58,19 +61,15 @@ async function groundAlert({ text, options = {} }) {
 		timeoutMs = GROUNDING_TIMEOUT_MS,
 		preserveLanguage = true,
 		maxLength = GROUNDING_MAX_LENGTH,
-		promptType = 'ALERT_ENRICHMENT', // Default to ALERT_ENRICHMENT for backward compatibility/current usage
+		// Default to ALERT_ENRICHMENT for backward compatibility/current usage
+		promptType = 'ALERT_ENRICHMENT',
 		tokenUsage,
 	} = options;
 
 	const startTime = Date.now();
-
-	// Select system prompt based on promptType
-	let systemPrompt = GEMINI_SYSTEM_PROMPT;
-	if (promptType === 'ALERT_ENRICHMENT') {
-		systemPrompt = ALERT_ENRICHMENT_SYSTEM_PROMPT;
-	} else if (promptType === 'NEWS_ANALYSIS') {
-		systemPrompt = NEWS_ANALYSIS_SYSTEM_PROMPT;
-	}
+	const systemPromptOverride = promptType === 'NEWS_ANALYSIS'
+		? NEWS_ANALYSIS_SYSTEM_PROMPT
+		: undefined;
 
 	/**
 	 * Create a timeout promise that rejects after a specified time
@@ -107,7 +106,7 @@ async function groundAlert({ text, options = {} }) {
 				text: text,
 				searchResults,
 				searchResultText,
-				options: { preserveLanguage, maxLength, systemPrompt, tokenUsage },
+				options: { preserveLanguage, maxLength, systemPrompt: systemPromptOverride, tokenUsage },
 			}),
 			timeoutPromise,
 		]).finally(cleanupTimeout);

--- a/src/services/inference/enrichmentService.js
+++ b/src/services/inference/enrichmentService.js
@@ -7,12 +7,29 @@
 
 const { getAzureAIClient } = require('./azureAiClient');
 const { sendWithRetry } = require('../../lib/retryHelper');
+const { getPromptService, PromptKeys } = require('../prompts');
 
-const ENRICHMENT_SYSTEM_PROMPT = `You are a financial market analyst specializing in risk assessment. 
-Given an analysis result from Gemini, assess the confidence level of the detected event.
-Respond with JSON: {"confidence": 0.0-1.0, "reasoning": "brief explanation"}
-Use conservative scoring: 0.7+ only for highly credible, well-sourced events.
-Penalize vague events, single sources, or uncorroborated claims.`;
+const promptService = getPromptService();
+
+function formatSourcesForPrompt(sources = []) {
+	if (!Array.isArray(sources) || sources.length === 0) {
+		return 'none';
+	}
+
+	return sources
+		.map(source => {
+			if (typeof source === 'string') {
+				return source;
+			}
+
+			if (source && typeof source === 'object') {
+				return source.title || source.url || source.sourceDomain || 'source';
+			}
+
+			return 'source';
+		})
+		.join(', ');
+}
 
 class EnrichmentService {
 	constructor() {
@@ -36,25 +53,26 @@ class EnrichmentService {
 	/**
    * Build enrichment prompt from analysis result
    * @param {Object} analysisData - Gemini analysis with confidence
-   * @returns {string} User message for LLM
+   * @returns {Promise<{systemPrompt: string, userPrompt: string}>} Prompt pair for LLM
    */
-	buildEnrichmentPrompt(analysisData) {
+	async buildEnrichmentPrompt(analysisData) {
 		const {
 			headline,
 			sentiment_score,
 			event_significance,
-			sources,
+			sources = [],
 			gemini_confidence,
+			confidence,
 		} = analysisData;
 
-		return `Assess the confidence of this financial event:
-Event: ${headline}
-Sentiment Score: ${sentiment_score}
-Event Significance: ${event_significance}
-Sources: ${sources.length} (${sources.join(', ')})
-Initial Confidence (Gemini): ${gemini_confidence}
-
-Respond with JSON: {"confidence": <0.0-1.0>, "reasoning": "<brief assessment>"}`;
+		return promptService.getChatPrompt(PromptKeys.CONFIDENCE_ENRICHMENT, {
+			headline,
+			sentimentScore: sentiment_score,
+			eventSignificance: event_significance,
+			sourcesCount: sources.length,
+			sourcesText: formatSourcesForPrompt(sources),
+			geminiConfidence: gemini_confidence ?? confidence ?? 0,
+		});
 	}
 
 	/**
@@ -75,8 +93,8 @@ Respond with JSON: {"confidence": <0.0-1.0>, "reasoning": "<brief assessment>"}`
 		// Call LLM enrichment with retry logic
 			const enrichmentResponse = await sendWithRetry(
 				async () => {
-					const userPrompt = this.buildEnrichmentPrompt(geminiAnalysis);
-					return await this.azureClient.chatCompletion(ENRICHMENT_SYSTEM_PROMPT, userPrompt);
+					const { systemPrompt, userPrompt } = await this.buildEnrichmentPrompt(geminiAnalysis);
+					return await this.azureClient.chatCompletion(systemPrompt, userPrompt);
 				},
 				3,
 				console,

--- a/src/services/prompts/PromptService.js
+++ b/src/services/prompts/PromptService.js
@@ -122,16 +122,30 @@ class PromptService {
 
 	async resolveRemotePrompt(definition, variables = {}, options = {}) {
 		let client;
+		const usingDefaultClientProvider = this.clientProvider === getLangfuseClient;
 
 		try {
 			client = await this.clientProvider();
 		} catch (error) {
-			const disabledReason = getLangfuseDisabledReason() || error.message;
+			const disabledReason = usingDefaultClientProvider
+				? getLangfuseDisabledReason() || error.message
+				: error.message;
 			this.warnOnce(
 				`langfuse-disabled:${disabledReason}`,
 				`[PromptService] Langfuse prompt management unavailable, using local fallbacks: ${disabledReason}`,
 			);
 			return null;
+		}
+
+		if (usingDefaultClientProvider) {
+			const disabledReason = getLangfuseDisabledReason();
+			if (disabledReason) {
+				this.warnOnce(
+					`langfuse-disabled:${disabledReason}`,
+					`[PromptService] Langfuse prompt management unavailable, using local fallbacks: ${disabledReason}`,
+				);
+				return null;
+			}
 		}
 
 		const label = options.label || getLangfusePromptLabel();
@@ -143,7 +157,7 @@ class PromptService {
 				label,
 				cacheTtlSeconds,
 			});
-			this.logger.debug(`[PromptService] Fetched Langfuse prompt "${definition.name}" successfully`);
+			this.logger.debug?.(`[PromptService] Fetched Langfuse prompt "${definition.name}" successfully`);
 
 			const compiledPrompt = prompt.compile(variables);
 			if (definition.type === 'chat') {

--- a/src/services/prompts/PromptService.js
+++ b/src/services/prompts/PromptService.js
@@ -1,0 +1,242 @@
+const {
+	isLangfusePromptManagementEnabled,
+	getLangfusePromptLabel,
+	getLangfusePromptCacheTtlSeconds,
+} = require('./config');
+const {
+	getLangfuseClient,
+	getLangfuseDisabledReason,
+} = require('./langfuseClient');
+const {
+	PromptKeys,
+	getPromptDefinition,
+} = require('./promptRegistry');
+
+function normalizeMessageContent(content) {
+	if (typeof content === 'string') {
+		return content;
+	}
+
+	if (Array.isArray(content)) {
+		return content
+			.map(part => normalizeMessageContent(part))
+			.filter(Boolean)
+			.join('');
+	}
+
+	if (content && typeof content === 'object') {
+		if (typeof content.text === 'string') {
+			return content.text;
+		}
+
+		if (typeof content.content === 'string') {
+			return content.content;
+		}
+	}
+
+	return '';
+}
+
+function normalizeChatMessages(messages = []) {
+	return messages
+		.map(message => ({
+			role: message.role,
+			content: normalizeMessageContent(message.content),
+		}))
+		.filter(message => Boolean(message.role) && Boolean(message.content));
+}
+
+function collapseUserPrompt(messages = []) {
+	return messages
+		.filter(message => message.role !== 'system')
+		.map(message => message.role === 'user' ? message.content : `[${message.role}] ${message.content}`)
+		.join('\n\n')
+		.trim();
+}
+
+async function fetchPromptFromClient(client, promptName, options) {
+	if (client?.prompt?.get) {
+		return client.prompt.get(promptName, options);
+	}
+
+	if (typeof client?.getPrompt === 'function') {
+		return client.getPrompt(promptName, undefined, options);
+	}
+
+	throw new Error('Langfuse client does not support prompt.get or getPrompt');
+}
+
+class PromptService {
+	constructor({ clientProvider = getLangfuseClient, logger = console } = {}) {
+		this.clientProvider = clientProvider;
+		this.logger = logger;
+		this.warningCache = new Set();
+	}
+
+	warnOnce(cacheKey, message) {
+		if (this.warningCache.has(cacheKey)) {
+			return;
+		}
+
+		this.warningCache.add(cacheKey);
+		this.logger.warn(message);
+	}
+
+	async resolvePrompt(promptKey, variables = {}, options = {}) {
+		const definition = getPromptDefinition(promptKey);
+
+		if (isLangfusePromptManagementEnabled()) {
+			const remotePrompt = await this.resolveRemotePrompt(definition, variables, options);
+			if (remotePrompt) {
+				return remotePrompt;
+			}
+		}
+
+		return this.resolveLocalPrompt(definition, variables, options);
+	}
+
+	async getChatPrompt(promptKey, variables = {}, options = {}) {
+		const prompt = await this.resolvePrompt(promptKey, variables, options);
+		if (prompt.type !== 'chat') {
+			throw new Error(`Prompt ${promptKey} is not a chat prompt`);
+		}
+
+		const systemPrompt = options.systemPromptOverride || prompt.systemPrompt;
+		const userPrompt = options.userPromptOverride || prompt.userPrompt;
+
+		return {
+			...prompt,
+			systemPrompt,
+			userPrompt,
+		};
+	}
+
+	async getTextPrompt(promptKey, variables = {}, options = {}) {
+		const prompt = await this.resolvePrompt(promptKey, variables, options);
+		if (prompt.type !== 'text') {
+			throw new Error(`Prompt ${promptKey} is not a text prompt`);
+		}
+
+		return prompt;
+	}
+
+	async resolveRemotePrompt(definition, variables = {}, options = {}) {
+		let client;
+
+		try {
+			client = await this.clientProvider();
+		} catch (error) {
+			const disabledReason = getLangfuseDisabledReason() || error.message;
+			this.warnOnce(
+				`langfuse-disabled:${disabledReason}`,
+				`[PromptService] Langfuse prompt management unavailable, using local fallbacks: ${disabledReason}`,
+			);
+			return null;
+		}
+
+		const label = options.label || getLangfusePromptLabel();
+		const cacheTtlSeconds = options.cacheTtlSeconds ?? getLangfusePromptCacheTtlSeconds();
+
+		try {
+			const prompt = await fetchPromptFromClient(client, definition.name, {
+				type: definition.type,
+				label,
+				cacheTtlSeconds,
+			});
+			this.logger.debug(`[PromptService] Fetched Langfuse prompt "${definition.name}" successfully`);
+
+			const compiledPrompt = prompt.compile(variables);
+			if (definition.type === 'chat') {
+				return this.normalizeChatPrompt(compiledPrompt, {
+					name: definition.name,
+					source: 'langfuse',
+					label,
+					version: prompt.version,
+				});
+			}
+
+			return {
+				type: 'text',
+				text: normalizeMessageContent(compiledPrompt),
+				name: definition.name,
+				source: 'langfuse',
+				label,
+				version: prompt.version,
+			};
+		} catch (error) {
+			this.warnOnce(
+				`langfuse-fetch:${definition.name}:${error.message}`,
+				`[PromptService] Failed to fetch Langfuse prompt "${definition.name}", using local fallback: ${error.message}`,
+			);
+			return null;
+		}
+	}
+
+	resolveLocalPrompt(definition, variables = {}, options = {}) {
+		const fallbackPrompt = definition.buildFallback(variables, options);
+		if (definition.type === 'chat') {
+			return this.normalizeChatPrompt(fallbackPrompt.messages, {
+				name: definition.name,
+				source: 'local',
+				label: null,
+				version: null,
+			});
+		}
+
+		return {
+			type: 'text',
+			text: fallbackPrompt.text,
+			name: definition.name,
+			source: 'local',
+			label: null,
+			version: null,
+		};
+	}
+
+	normalizeChatPrompt(messages, metadata) {
+		const normalizedMessages = normalizeChatMessages(messages);
+		if (!normalizedMessages.length) {
+			throw new Error(`Prompt "${metadata.name}" resolved to an empty chat prompt`);
+		}
+
+		const systemPrompt = normalizedMessages
+			.filter(message => message.role === 'system')
+			.map(message => message.content)
+			.join('\n\n')
+			.trim();
+
+		const userPrompt = collapseUserPrompt(normalizedMessages);
+		if (!userPrompt) {
+			throw new Error(`Prompt "${metadata.name}" resolved without user content`);
+		}
+
+		return {
+			type: 'chat',
+			messages: normalizedMessages,
+			systemPrompt,
+			userPrompt,
+			...metadata,
+		};
+	}
+}
+
+let promptServiceInstance = null;
+
+function getPromptService() {
+	if (!promptServiceInstance) {
+		promptServiceInstance = new PromptService();
+	}
+
+	return promptServiceInstance;
+}
+
+function resetPromptServiceForTests() {
+	promptServiceInstance = null;
+}
+
+module.exports = {
+	PromptKeys,
+	PromptService,
+	getPromptService,
+	resetPromptServiceForTests,
+};

--- a/src/services/prompts/config.js
+++ b/src/services/prompts/config.js
@@ -1,0 +1,31 @@
+function isProductionLikeEnvironment() {
+	return process.env.NODE_ENV === 'production' || process.env.RENDER === 'true';
+}
+
+function isLangfusePromptManagementEnabled() {
+	return process.env.ENABLE_LANGFUSE_PROMPTS === 'true';
+}
+
+function getLangfusePromptLabel() {
+	if (process.env.LANGFUSE_PROMPT_LABEL) {
+		return process.env.LANGFUSE_PROMPT_LABEL;
+	}
+
+	return isProductionLikeEnvironment() ? 'production' : 'latest';
+}
+
+function getLangfusePromptCacheTtlSeconds() {
+	if (process.env.LANGFUSE_PROMPT_CACHE_TTL_SECONDS !== undefined) {
+		const parsed = Number.parseInt(process.env.LANGFUSE_PROMPT_CACHE_TTL_SECONDS, 10);
+		return Number.isNaN(parsed) ? 0 : parsed;
+	}
+
+	return getLangfusePromptLabel() === 'latest' ? 0 : 60;
+}
+
+module.exports = {
+	isProductionLikeEnvironment,
+	isLangfusePromptManagementEnabled,
+	getLangfusePromptLabel,
+	getLangfusePromptCacheTtlSeconds,
+};

--- a/src/services/prompts/defaults/README.md
+++ b/src/services/prompts/defaults/README.md
@@ -1,0 +1,22 @@
+# Local default prompt files
+
+These files are the **version-controlled local fallbacks** used when Langfuse prompt management is disabled, unavailable, or missing a prompt.
+
+## Naming
+
+- `*.system.txt` → system message for chat prompts
+- `*.user.txt` → user message for chat prompts
+- `*.txt` → plain text prompt/query
+
+## Variables
+
+Templates support simple `{{variableName}}` placeholders.
+
+Examples:
+
+- `{{alertText}}`
+- `{{symbol}}`
+- `{{maxLength}}`
+- `{{languageDirective}}`
+
+Rendering is handled by `src/services/prompts/filePromptLoader.js`.

--- a/src/services/prompts/defaults/alert-enrichment.system.txt
+++ b/src/services/prompts/defaults/alert-enrichment.system.txt
@@ -1,0 +1,3 @@
+You are a financial market analyst. Your job is to analyze alerts and provide structured insights, sentiment, and technical levels.
+
+{{languageDirective}}

--- a/src/services/prompts/defaults/alert-enrichment.user.txt
+++ b/src/services/prompts/defaults/alert-enrichment.user.txt
@@ -1,0 +1,16 @@
+Analyze this alert and provide structured insights, sentiment, and technical levels based on the context.
+
+Alert: {{alertContext}}
+
+Instructions:
+- **Output:** Respond *only* with a single, valid JSON object.
+- **JSON schema:**
+{
+  "sentiment": "BULLISH" | "BEARISH" | "NEUTRAL",
+  "sentiment_score": number (0.0 to 1.0),
+  "insights": string[] (max 10 key points),
+  "technical_levels": {
+    "supports": string[],
+    "resistances": string[]
+  }
+}

--- a/src/services/prompts/defaults/confidence-enrichment.system.txt
+++ b/src/services/prompts/defaults/confidence-enrichment.system.txt
@@ -1,0 +1,5 @@
+You are a financial market analyst specializing in risk assessment.
+Given an analysis result from Gemini, assess the confidence level of the detected event.
+Respond with JSON: {"confidence": 0.0-1.0, "reasoning": "brief explanation"}
+Use conservative scoring: 0.7+ only for highly credible, well-sourced events.
+Penalize vague events, single sources, or uncorroborated claims.

--- a/src/services/prompts/defaults/confidence-enrichment.user.txt
+++ b/src/services/prompts/defaults/confidence-enrichment.user.txt
@@ -1,0 +1,8 @@
+Assess the confidence of this financial event:
+Event: {{headline}}
+Sentiment Score: {{sentimentScore}}
+Event Significance: {{eventSignificance}}
+Sources: {{sourcesCount}} ({{sourcesText}})
+Initial Confidence (Gemini): {{geminiConfidence}}
+
+Respond with JSON: {"confidence": <0.0-1.0>, "reasoning": "<brief assessment>"}

--- a/src/services/prompts/defaults/grounded-summary.system.txt
+++ b/src/services/prompts/defaults/grounded-summary.system.txt
@@ -1,0 +1,10 @@
+You are a helpful assistant that provides concise summaries of alerts with verified context.
+Focus on:
+1. Key facts and updates
+2. Market impact or implications
+3. Related context from reliable sources
+
+Keep summaries under {{maxLength}} characters.
+Preserve the original language of the alert if possible.
+
+{{languageDirective}}

--- a/src/services/prompts/defaults/grounded-summary.user.txt
+++ b/src/services/prompts/defaults/grounded-summary.user.txt
@@ -1,0 +1,3 @@
+Please analyze this alert and provide a concise summary (max {{maxLength}} chars) with citations based in the context:
+
+Alert: {{alertText}}{{contextPrompt}}{{contextSnippet}}

--- a/src/services/prompts/defaults/market-price-fetch.txt
+++ b/src/services/prompts/defaults/market-price-fetch.txt
@@ -1,0 +1,7 @@
+Get current price of {{symbol}} today in USD and respond with ONLY valid JSON. Example format (respond with similar structure but with actual numbers):
+{
+  "price": 150.25,
+  "change_24h": 2.5,
+  "context": "detailed context about price and market",
+  "sources": ["url1", "url2"]
+}

--- a/src/services/prompts/defaults/news-analysis-search-query.txt
+++ b/src/services/prompts/defaults/news-analysis-search-query.txt
@@ -1,0 +1,1 @@
+{{symbol}} news market sentiment events today

--- a/src/services/prompts/defaults/news-analysis.system.txt
+++ b/src/services/prompts/defaults/news-analysis.system.txt
@@ -1,0 +1,2 @@
+You are a financial market sentiment analyst specializing in crypto and stock news analysis.
+Analyze the provided news/context and detect market-moving events.

--- a/src/services/prompts/defaults/news-analysis.user.txt
+++ b/src/services/prompts/defaults/news-analysis.user.txt
@@ -1,0 +1,42 @@
+Analyze this news/market context for symbol {{symbol}}:
+
+{{enrichedContext}}
+
+Instructions (important):
+
+- **Task:** Read the provided news/context and detect any market-moving event related to the symbol.
+- **Output:** Respond *only* with a single, valid JSON object (no surrounding text, no markdown, no commentary).
+- **JSON schema:** Follow the example exactly. Use real values (numbers/strings) — do NOT include type annotations or ranges inside the JSON.
+
+Example JSON (respond with a similar structure using real values):
+{
+  "event_category": "price_surge",
+  "event_significance": 0.75,
+  "sentiment_score": 0.45,
+  "headline": "One-line event description",
+  "description": "Detailed explanation of the event with bulletpoints and bold text."
+}
+
+Field guidance:
+
+- **event_category** (string): one of **price_surge**, **price_decline**, **public_figure**, **regulatory**, **none**.
+- **event_significance** (number): 0.0 to 1.0 — how important the detected event is (use 0.0 for none, 1.0 for very significant).
+- **sentiment_score** (number): -1.0 to 1.0 — negative = bearish, positive = bullish.
+- **headline** (string): one concise line describing the event (max ~250 chars).
+- **description** (string): Detailed explanation with enrich text using hypen bulletpoints (not asterisks), nextline and bold text for readability (up to ~2000 chars).
+
+Event category hints:
+
+- **price_surge:** Bullish events (positive news, material price increases, upgrades, major buying pressure).
+- **price_decline:** Bearish events (negative news, material price drops, downgrades, selling pressure).
+- **public_figure:** Mentions/quotes from high-impact individuals that can move markets (e.g., Elon Musk).
+- **regulatory:** Official announcements, policy changes, fines, or legal actions.
+- **none:** No significant event detected.
+
+Conservatism and formatting rules:
+
+- Be conservative when assigning high scores — prefer 0.6+ only for well-sourced, high-credibility events.
+- Do not include any extra text before/after the JSON. If uncertain, return **event_category: "none"** with low significance.
+- Keep numeric values as plain numbers (no percent signs or units inside the JSON fields).
+
+End of instructions.

--- a/src/services/prompts/defaults/search-query-derivation.system.txt
+++ b/src/services/prompts/defaults/search-query-derivation.system.txt
@@ -1,0 +1,2 @@
+Extract key topics and entities from this alert to create a search query.
+Focus on recent developments, market conditions, or specific events mentioned.

--- a/src/services/prompts/defaults/search-query-derivation.user.txt
+++ b/src/services/prompts/defaults/search-query-derivation.user.txt
@@ -1,0 +1,1 @@
+Alert: {{alertText}}

--- a/src/services/prompts/filePromptLoader.js
+++ b/src/services/prompts/filePromptLoader.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_PROMPTS_DIR = path.join(__dirname, 'defaults');
+const promptFileCache = new Map();
+
+function readPromptFile(fileName) {
+	if (!promptFileCache.has(fileName)) {
+		const filePath = path.join(DEFAULT_PROMPTS_DIR, fileName);
+		const contents = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+		promptFileCache.set(fileName, contents);
+	}
+
+	return promptFileCache.get(fileName);
+}
+
+function renderPromptTemplate(template, variables = {}) {
+	return template
+		.replace(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g, (_, variableName) => {
+			const value = variables[variableName];
+			return value === undefined || value === null ? '' : String(value);
+		})
+		.replace(/[ \t]+\n/g, '\n')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim();
+}
+
+function getPromptFileTemplate(fileName, { envVar, variables = {} } = {}) {
+	const source = envVar && process.env[envVar]
+		? process.env[envVar]
+		: readPromptFile(fileName);
+
+	return renderPromptTemplate(source, variables);
+}
+
+function resetPromptFileCacheForTests() {
+	promptFileCache.clear();
+}
+
+module.exports = {
+	DEFAULT_PROMPTS_DIR,
+	readPromptFile,
+	renderPromptTemplate,
+	getPromptFileTemplate,
+	resetPromptFileCacheForTests,
+};

--- a/src/services/prompts/index.js
+++ b/src/services/prompts/index.js
@@ -1,0 +1,13 @@
+const {
+	PromptKeys,
+	PromptService,
+	getPromptService,
+	resetPromptServiceForTests,
+} = require('./PromptService');
+
+module.exports = {
+	PromptKeys,
+	PromptService,
+	getPromptService,
+	resetPromptServiceForTests,
+};

--- a/src/services/prompts/langfuseClient.js
+++ b/src/services/prompts/langfuseClient.js
@@ -1,0 +1,75 @@
+const DEFAULT_LANGFUSE_BASE_URL = 'https://cloud.langfuse.com';
+
+let clientPromise = null;
+
+function getLangfuseSettings() {
+	return {
+		enabled: process.env.ENABLE_LANGFUSE_PROMPTS === 'true',
+		publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+		secretKey: process.env.LANGFUSE_SECRET_KEY,
+		baseUrl: process.env.LANGFUSE_BASE_URL || DEFAULT_LANGFUSE_BASE_URL,
+	};
+}
+
+function isLangfuseConfigured() {
+	const settings = getLangfuseSettings();
+	return settings.enabled && Boolean(settings.publicKey) && Boolean(settings.secretKey);
+}
+
+function getLangfuseDisabledReason() {
+	const settings = getLangfuseSettings();
+
+	if (!settings.enabled) {
+		return 'Langfuse prompt management is disabled';
+	}
+
+	if (!settings.publicKey || !settings.secretKey) {
+		return 'LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY are required when ENABLE_LANGFUSE_PROMPTS is true';
+	}
+
+	return null;
+}
+
+async function loadLangfuseClientConstructor() {
+	const langfuseModule = await import('@langfuse/client');
+	return langfuseModule.LangfuseClient
+		|| langfuseModule.default?.LangfuseClient
+		|| langfuseModule.default;
+}
+
+async function getLangfuseClient() {
+	const disabledReason = getLangfuseDisabledReason();
+	if (disabledReason) {
+		throw new Error(disabledReason);
+	}
+
+	if (!clientPromise) {
+		clientPromise = loadLangfuseClientConstructor().then(LangfuseClient => {
+			if (!LangfuseClient) {
+				throw new Error('LangfuseClient constructor could not be resolved from @langfuse/client');
+			}
+
+			const settings = getLangfuseSettings();
+			return new LangfuseClient({
+				publicKey: settings.publicKey,
+				secretKey: settings.secretKey,
+				baseUrl: settings.baseUrl,
+			});
+		});
+	}
+
+	return clientPromise;
+}
+
+function resetLangfuseClientForTests() {
+	clientPromise = null;
+}
+
+module.exports = {
+	DEFAULT_LANGFUSE_BASE_URL,
+	getLangfuseClient,
+	getLangfuseSettings,
+	isLangfuseConfigured,
+	getLangfuseDisabledReason,
+	resetLangfuseClientForTests,
+};

--- a/src/services/prompts/localPromptTemplates.js
+++ b/src/services/prompts/localPromptTemplates.js
@@ -1,0 +1,125 @@
+const { getPromptFileTemplate } = require('./filePromptLoader');
+
+const LOCAL_PROMPT_FILES = Object.freeze({
+	SEARCH_QUERY_DERIVATION_SYSTEM: 'search-query-derivation.system.txt',
+	SEARCH_QUERY_DERIVATION_USER: 'search-query-derivation.user.txt',
+	GROUNDED_SUMMARY_SYSTEM: 'grounded-summary.system.txt',
+	GROUNDED_SUMMARY_USER: 'grounded-summary.user.txt',
+	ALERT_ENRICHMENT_SYSTEM: 'alert-enrichment.system.txt',
+	ALERT_ENRICHMENT_USER: 'alert-enrichment.user.txt',
+	NEWS_ANALYSIS_SYSTEM: 'news-analysis.system.txt',
+	NEWS_ANALYSIS_USER: 'news-analysis.user.txt',
+	NEWS_ANALYSIS_SEARCH_QUERY: 'news-analysis-search-query.txt',
+	CONFIDENCE_ENRICHMENT_SYSTEM: 'confidence-enrichment.system.txt',
+	CONFIDENCE_ENRICHMENT_USER: 'confidence-enrichment.user.txt',
+	MARKET_PRICE_FETCH: 'market-price-fetch.txt',
+});
+
+function getSearchQuerySystemPrompt() {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.SEARCH_QUERY_DERIVATION_SYSTEM, {
+		envVar: 'SEARCH_QUERY_PROMPT',
+	});
+}
+
+function getSearchQueryUserPrompt({ alertText }) {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.SEARCH_QUERY_DERIVATION_USER, {
+		variables: { alertText },
+	});
+}
+
+function getGroundedSummarySystemPrompt({ maxLength, languageDirective = '' } = {}) {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.GROUNDED_SUMMARY_SYSTEM, {
+		envVar: 'GEMINI_SYSTEM_PROMPT',
+		variables: { maxLength, languageDirective },
+	});
+}
+
+function getGroundedSummaryUserPrompt({ alertText, maxLength, contextPrompt = '', contextSnippet = '' }) {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.GROUNDED_SUMMARY_USER, {
+		variables: {
+			alertText,
+			maxLength,
+			contextPrompt,
+			contextSnippet,
+		},
+	});
+}
+
+function getAlertEnrichmentSystemPrompt({ languageDirective = '' } = {}) {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.ALERT_ENRICHMENT_SYSTEM, {
+		envVar: 'ALERT_ENRICHMENT_SYSTEM_PROMPT',
+		variables: { languageDirective },
+	});
+}
+
+function getAlertEnrichmentUserPrompt({ alertContext }) {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.ALERT_ENRICHMENT_USER, {
+		variables: { alertContext },
+	});
+}
+
+function getNewsAnalysisSystemPrompt() {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.NEWS_ANALYSIS_SYSTEM, {
+		envVar: 'NEWS_ANALYSIS_SYSTEM_PROMPT',
+	});
+}
+
+function getNewsAnalysisUserPrompt({ symbol, enrichedContext }) {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.NEWS_ANALYSIS_USER, {
+		variables: { symbol, enrichedContext },
+	});
+}
+
+function getNewsAnalysisSearchQueryPrompt({ symbol }) {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.NEWS_ANALYSIS_SEARCH_QUERY, {
+		variables: { symbol },
+	});
+}
+
+function getConfidenceEnrichmentSystemPrompt() {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.CONFIDENCE_ENRICHMENT_SYSTEM, {
+		envVar: 'CONFIDENCE_ENRICHMENT_SYSTEM_PROMPT',
+	});
+}
+
+function getConfidenceEnrichmentUserPrompt({
+	headline,
+	sentimentScore,
+	eventSignificance,
+	sourcesCount,
+	sourcesText,
+	geminiConfidence,
+}) {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.CONFIDENCE_ENRICHMENT_USER, {
+		variables: {
+			headline,
+			sentimentScore,
+			eventSignificance,
+			sourcesCount,
+			sourcesText,
+			geminiConfidence,
+		},
+	});
+}
+
+function getMarketPriceFetchPrompt({ symbol }) {
+	return getPromptFileTemplate(LOCAL_PROMPT_FILES.MARKET_PRICE_FETCH, {
+		variables: { symbol },
+	});
+}
+
+module.exports = {
+	LOCAL_PROMPT_FILES,
+	getSearchQuerySystemPrompt,
+	getSearchQueryUserPrompt,
+	getGroundedSummarySystemPrompt,
+	getGroundedSummaryUserPrompt,
+	getAlertEnrichmentSystemPrompt,
+	getAlertEnrichmentUserPrompt,
+	getNewsAnalysisSystemPrompt,
+	getNewsAnalysisUserPrompt,
+	getNewsAnalysisSearchQueryPrompt,
+	getConfidenceEnrichmentSystemPrompt,
+	getConfidenceEnrichmentUserPrompt,
+	getMarketPriceFetchPrompt,
+};

--- a/src/services/prompts/promptRegistry.js
+++ b/src/services/prompts/promptRegistry.js
@@ -1,0 +1,149 @@
+const {
+	GROUNDING_MAX_LENGTH,
+} = require('../grounding/config');
+const {
+	getSearchQuerySystemPrompt,
+	getSearchQueryUserPrompt,
+	getGroundedSummarySystemPrompt,
+	getGroundedSummaryUserPrompt,
+	getAlertEnrichmentSystemPrompt,
+	getAlertEnrichmentUserPrompt,
+	getNewsAnalysisSystemPrompt,
+	getNewsAnalysisUserPrompt,
+	getNewsAnalysisSearchQueryPrompt,
+	getConfidenceEnrichmentSystemPrompt,
+	getConfidenceEnrichmentUserPrompt,
+	getMarketPriceFetchPrompt,
+} = require('./localPromptTemplates');
+
+const PromptKeys = Object.freeze({
+	SEARCH_QUERY_DERIVATION: 'SEARCH_QUERY_DERIVATION',
+	GROUNDED_SUMMARY: 'GROUNDED_SUMMARY',
+	ALERT_ENRICHMENT: 'ALERT_ENRICHMENT',
+	NEWS_ANALYSIS: 'NEWS_ANALYSIS',
+	NEWS_ANALYSIS_SEARCH_QUERY: 'NEWS_ANALYSIS_SEARCH_QUERY',
+	CONFIDENCE_ENRICHMENT: 'CONFIDENCE_ENRICHMENT',
+	MARKET_PRICE_FETCH: 'MARKET_PRICE_FETCH',
+});
+
+const CONFIDENCE_ENRICHMENT_SYSTEM_PROMPT = getConfidenceEnrichmentSystemPrompt();
+
+const PROMPT_DEFINITIONS = {
+	[PromptKeys.SEARCH_QUERY_DERIVATION]: {
+		name: 'search-query-derivation',
+		type: 'chat',
+		buildFallback: ({ alertText }) => ({
+			type: 'chat',
+			messages: [
+				{ role: 'system', content: getSearchQuerySystemPrompt() },
+				{ role: 'user', content: getSearchQueryUserPrompt({ alertText }) },
+			],
+		}),
+	},
+	[PromptKeys.GROUNDED_SUMMARY]: {
+		name: 'grounded-summary',
+		type: 'chat',
+		buildFallback: ({ alertText, maxLength = GROUNDING_MAX_LENGTH, languageDirective = '', contextPrompt = '', contextSnippet = '' }) => ({
+			type: 'chat',
+			messages: [
+				{
+					role: 'system',
+					content: getGroundedSummarySystemPrompt({ maxLength, languageDirective }),
+				},
+				{
+					role: 'user',
+					content: getGroundedSummaryUserPrompt({
+						alertText,
+						maxLength,
+						contextPrompt,
+						contextSnippet,
+					}),
+				},
+			],
+		}),
+	},
+	[PromptKeys.ALERT_ENRICHMENT]: {
+		name: 'alert-enrichment',
+		type: 'chat',
+		buildFallback: ({ alertContext, languageDirective = '' }) => ({
+			type: 'chat',
+			messages: [
+				{
+					role: 'system',
+					content: getAlertEnrichmentSystemPrompt({ languageDirective }),
+				},
+				{
+					role: 'user',
+					content: getAlertEnrichmentUserPrompt({ alertContext }),
+				},
+			],
+		}),
+	},
+	[PromptKeys.NEWS_ANALYSIS]: {
+		name: 'news-analysis',
+		type: 'chat',
+		buildFallback: ({ symbol, enrichedContext }) => ({
+			type: 'chat',
+			messages: [
+				{ role: 'system', content: getNewsAnalysisSystemPrompt() },
+				{
+					role: 'user',
+					content: getNewsAnalysisUserPrompt({ symbol, enrichedContext }),
+				},
+			],
+		}),
+	},
+	[PromptKeys.NEWS_ANALYSIS_SEARCH_QUERY]: {
+		name: 'news-analysis-search-query',
+		type: 'text',
+		buildFallback: ({ symbol }) => ({
+			type: 'text',
+			text: getNewsAnalysisSearchQueryPrompt({ symbol }),
+		}),
+	},
+	[PromptKeys.CONFIDENCE_ENRICHMENT]: {
+		name: 'confidence-enrichment',
+		type: 'chat',
+		buildFallback: ({ headline, sentimentScore, eventSignificance, sourcesCount, sourcesText, geminiConfidence }) => ({
+			type: 'chat',
+			messages: [
+				{ role: 'system', content: getConfidenceEnrichmentSystemPrompt() },
+				{
+					role: 'user',
+					content: getConfidenceEnrichmentUserPrompt({
+						headline,
+						sentimentScore,
+						eventSignificance,
+						sourcesCount,
+						sourcesText,
+						geminiConfidence,
+					}),
+				},
+			],
+		}),
+	},
+	[PromptKeys.MARKET_PRICE_FETCH]: {
+		name: 'market-price-fetch',
+		type: 'text',
+		buildFallback: ({ symbol }) => ({
+			type: 'text',
+			text: getMarketPriceFetchPrompt({ symbol }),
+		}),
+	},
+};
+
+function getPromptDefinition(promptKey) {
+	const definition = PROMPT_DEFINITIONS[promptKey];
+	if (!definition) {
+		throw new Error(`Unknown prompt key: ${promptKey}`);
+	}
+
+	return definition;
+}
+
+module.exports = {
+	PromptKeys,
+	PROMPT_DEFINITIONS,
+	CONFIDENCE_ENRICHMENT_SYSTEM_PROMPT,
+	getPromptDefinition,
+};

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -12,6 +12,12 @@ process.env = {
 	SEARCH_MAX_RESULTS: '3',
 	GROUNDING_TIMEOUT_MS: '8000',
 	BOT_TOKEN: 'test-bot-token',
+	ENABLE_LANGFUSE_PROMPTS: 'false',
+	LANGFUSE_PUBLIC_KEY: '',
+	LANGFUSE_SECRET_KEY: '',
+	LANGFUSE_BASE_URL: 'https://cloud.langfuse.com',
+	LANGFUSE_PROMPT_LABEL: 'latest',
+	LANGFUSE_PROMPT_CACHE_TTL_SECONDS: '0',
 	// Sentry disabled by default in tests
 	ENABLE_SENTRY: 'false',
 	SENTRY_DSN: undefined,

--- a/tests/unit/enrichment-service.test.js
+++ b/tests/unit/enrichment-service.test.js
@@ -3,6 +3,17 @@
  * Tests: Conservative confidence selection, error handling, fallback logic
  */
 
+const mockPromptService = {
+	getChatPrompt: jest.fn(),
+};
+
+jest.mock('../../src/services/prompts', () => ({
+	getPromptService: jest.fn(() => mockPromptService),
+	PromptKeys: {
+		CONFIDENCE_ENRICHMENT: 'CONFIDENCE_ENRICHMENT',
+	},
+}));
+
 const { getEnrichmentService, EnrichmentService } = require('../../src/services/inference/enrichmentService');
 
 jest.mock('../../src/services/inference/azureAiClient');
@@ -20,6 +31,10 @@ describe('EnrichmentService (Phase 8 - US6)', () => {
 			ENABLE_LLM_ALERT_ENRICHMENT: 'false', // Disabled by default
 			AZURE_LLM_MODEL: 'gpt-4',
 		};
+		mockPromptService.getChatPrompt.mockResolvedValue({
+			systemPrompt: 'Risk assessment system prompt',
+			userPrompt: 'Risk assessment user prompt',
+		});
 	});
 
 	afterEach(() => {
@@ -56,7 +71,7 @@ describe('EnrichmentService (Phase 8 - US6)', () => {
 	});
 
 	describe('buildEnrichmentPrompt', () => {
-		it('should build prompt from analysis data', () => {
+		it('should build prompt from analysis data', async () => {
 			azureAiClient.getAzureAIClient.mockReturnValue({
 				validate: jest.fn().mockReturnValue(true),
 			});
@@ -70,16 +85,24 @@ describe('EnrichmentService (Phase 8 - US6)', () => {
 				gemini_confidence: 0.84,
 			};
 
-			const prompt = service.buildEnrichmentPrompt(analysisData);
+			const prompt = await service.buildEnrichmentPrompt(analysisData);
 
-			expect(prompt).toContain('Bitcoin surges on positive news');
-			expect(prompt).toContain('0.9'); // sentiment_score
-			expect(prompt).toContain('0.8'); // event_significance
-			expect(prompt).toContain('2'); // sources count
-			expect(prompt).toContain('0.84'); // gemini_confidence
+			expect(prompt.systemPrompt).toBe('Risk assessment system prompt');
+			expect(prompt.userPrompt).toBe('Risk assessment user prompt');
+			expect(mockPromptService.getChatPrompt).toHaveBeenCalledWith(
+				'CONFIDENCE_ENRICHMENT',
+				expect.objectContaining({
+					headline: 'Bitcoin surges on positive news',
+					sentimentScore: 0.9,
+					eventSignificance: 0.8,
+					sourcesCount: 2,
+					sourcesText: 'https://example.com/1, https://example.com/2',
+					geminiConfidence: 0.84,
+				}),
+			);
 		});
 
-		it('should include all required fields in prompt', () => {
+		it('should include all required fields in prompt variables', async () => {
 			azureAiClient.getAzureAIClient.mockReturnValue({
 				validate: jest.fn().mockReturnValue(true),
 			});
@@ -93,14 +116,19 @@ describe('EnrichmentService (Phase 8 - US6)', () => {
 				gemini_confidence: 0.75,
 			};
 
-			const prompt = service.buildEnrichmentPrompt(analysisData);
+			await service.buildEnrichmentPrompt(analysisData);
 
-			expect(prompt).toContain('Assess the confidence');
-			expect(prompt).toContain('Event:');
-			expect(prompt).toContain('Sentiment Score:');
-			expect(prompt).toContain('Event Significance:');
-			expect(prompt).toContain('Sources:');
-			expect(prompt).toContain('Initial Confidence (Gemini):');
+			expect(mockPromptService.getChatPrompt).toHaveBeenCalledWith(
+				'CONFIDENCE_ENRICHMENT',
+				expect.objectContaining({
+					headline: 'Market event',
+					sentimentScore: 0.5,
+					eventSignificance: 0.6,
+					sourcesCount: 1,
+					sourcesText: 'https://source1.com',
+					geminiConfidence: 0.75,
+				}),
+			);
 		});
 	});
 
@@ -136,6 +164,39 @@ describe('EnrichmentService (Phase 8 - US6)', () => {
 			// Conservative: min(0.9, 0.7) = 0.7
 			expect(result.enriched_confidence).toBe(0.7);
 			expect(result.original_confidence).toBe(0.9);
+		});
+
+		it('should send resolved prompt pair to the Azure client', async () => {
+			process.env.ENABLE_LLM_ALERT_ENRICHMENT = 'true';
+			const service = new EnrichmentService();
+
+			const mockAzureClient = azureAiClient.getAzureAIClient();
+			mockAzureClient.chatCompletion.mockResolvedValue('{"confidence": 0.7, "reasoning": "Well sourced"}');
+			mockAzureClient.parseJsonResponse.mockReturnValue({ confidence: 0.7, reasoning: 'Well sourced' });
+
+			retryHelper.sendWithRetry.mockImplementation(async (sendFn) => sendFn());
+
+			await service.enrichAlert({
+				confidence: 0.9,
+				headline: 'Prompt resolution event',
+				sentiment_score: 0.8,
+				event_significance: 0.75,
+				sources: [{ title: 'Reuters', url: 'https://reuters.com/test' }],
+			});
+
+			expect(mockPromptService.getChatPrompt).toHaveBeenCalledWith(
+				'CONFIDENCE_ENRICHMENT',
+				expect.objectContaining({
+					headline: 'Prompt resolution event',
+					sourcesCount: 1,
+					sourcesText: 'Reuters',
+					geminiConfidence: 0.9,
+				}),
+			);
+			expect(mockAzureClient.chatCompletion).toHaveBeenCalledWith(
+				'Risk assessment system prompt',
+				'Risk assessment user prompt',
+			);
 		});
 
 		it('should use Gemini confidence when LLM is lower (conservative selection)', async () => {

--- a/tests/unit/grounding.test.js
+++ b/tests/unit/grounding.test.js
@@ -96,7 +96,7 @@ describe('Grounding Service', () => {
 			})).rejects.toThrow('Grounding failed: API error');
 		});
 
-		it('should use ALERT_ENRICHMENT prompt by default', async () => {
+		it('should use centralized alert prompt defaults by default', async () => {
 			genaiClient.search.mockResolvedValueOnce({ results: [], totalResults: 0 });
 			generateEnrichedAlert.mockResolvedValueOnce({
 				sentiment: 'NEUTRAL',
@@ -107,11 +107,8 @@ describe('Grounding Service', () => {
 
 			await groundAlert({ text: 'Test alert text' });
 
-			expect(generateEnrichedAlert).toHaveBeenCalledWith(expect.objectContaining({
-				options: expect.objectContaining({
-					systemPrompt: expect.stringContaining('structured insights'),
-				}),
-			}));
+			const call = generateEnrichedAlert.mock.calls[0][0];
+			expect(call.options.systemPrompt).toBeUndefined();
 		});
 
 		it('should use NEWS_ANALYSIS prompt when requested', async () => {

--- a/tests/unit/prompt-service.test.js
+++ b/tests/unit/prompt-service.test.js
@@ -1,0 +1,144 @@
+/* global describe, it, expect, beforeEach, afterEach, jest */
+
+const { PromptService, PromptKeys } = require('../../src/services/prompts');
+
+describe('PromptService', () => {
+	const originalEnv = process.env;
+	let logger;
+
+	beforeEach(() => {
+		process.env = {
+			...originalEnv,
+			ENABLE_LANGFUSE_PROMPTS: 'false',
+			LANGFUSE_PUBLIC_KEY: '',
+			LANGFUSE_SECRET_KEY: '',
+			LANGFUSE_PROMPT_LABEL: 'latest',
+			LANGFUSE_PROMPT_CACHE_TTL_SECONDS: '0',
+		};
+		logger = {
+			warn: jest.fn(),
+		};
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	it('should return local fallback chat prompt when Langfuse is disabled', async () => {
+		const service = new PromptService({ logger });
+
+		const prompt = await service.getChatPrompt(PromptKeys.SEARCH_QUERY_DERIVATION, {
+			alertText: 'BTCUSDT breaks resistance',
+		});
+
+		expect(prompt.source).toBe('local');
+		expect(prompt.systemPrompt).toContain('Extract key topics and entities');
+		expect(prompt.userPrompt).toContain('BTCUSDT breaks resistance');
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it('should fetch and compile remote Langfuse chat prompts', async () => {
+		process.env.ENABLE_LANGFUSE_PROMPTS = 'true';
+
+		const remotePrompt = {
+			version: 7,
+			compile: jest.fn().mockReturnValue([
+				{ role: 'system', content: 'Remote system prompt' },
+				{ role: 'user', content: 'Remote user prompt' },
+			]),
+		};
+		const client = {
+			prompt: {
+				get: jest.fn().mockResolvedValue(remotePrompt),
+			},
+		};
+		const service = new PromptService({
+			logger,
+			clientProvider: jest.fn().mockResolvedValue(client),
+		});
+
+		const prompt = await service.getChatPrompt(
+			PromptKeys.ALERT_ENRICHMENT,
+			{ alertContext: 'Bitcoin alert context', languageDirective: 'Respond in Spanish.' },
+			{ label: 'staging', cacheTtlSeconds: 300 },
+		);
+
+		expect(client.prompt.get).toHaveBeenCalledWith('alert-enrichment', {
+			type: 'chat',
+			label: 'staging',
+			cacheTtlSeconds: 300,
+		});
+		expect(remotePrompt.compile).toHaveBeenCalledWith({
+			alertContext: 'Bitcoin alert context',
+			languageDirective: 'Respond in Spanish.',
+		});
+		expect(prompt.source).toBe('langfuse');
+		expect(prompt.version).toBe(7);
+		expect(prompt.systemPrompt).toBe('Remote system prompt');
+		expect(prompt.userPrompt).toBe('Remote user prompt');
+	});
+
+	it('should fall back to local prompts when Langfuse fetch fails', async () => {
+		process.env.ENABLE_LANGFUSE_PROMPTS = 'true';
+
+		const service = new PromptService({
+			logger,
+			clientProvider: jest.fn().mockRejectedValue(new Error('Missing Langfuse credentials')),
+		});
+
+		const prompt = await service.getChatPrompt(PromptKeys.GROUNDED_SUMMARY, {
+			alertText: 'Fallback alert',
+			maxLength: 250,
+			languageDirective: '',
+			contextPrompt: '',
+			contextSnippet: '',
+		});
+
+		expect(prompt.source).toBe('local');
+		expect(prompt.userPrompt).toContain('Fallback alert');
+		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('using local fallbacks'));
+	});
+
+	it('should fetch remote text prompts for non-chat use cases', async () => {
+		process.env.ENABLE_LANGFUSE_PROMPTS = 'true';
+
+		const remotePrompt = {
+			version: 3,
+			compile: jest.fn().mockReturnValue('Remote price query for BTCUSDT'),
+		};
+		const client = {
+			prompt: {
+				get: jest.fn().mockResolvedValue(remotePrompt),
+			},
+		};
+		const service = new PromptService({
+			logger,
+			clientProvider: jest.fn().mockResolvedValue(client),
+		});
+
+		const prompt = await service.getTextPrompt(PromptKeys.MARKET_PRICE_FETCH, { symbol: 'BTCUSDT' });
+
+		expect(prompt.type).toBe('text');
+		expect(prompt.text).toBe('Remote price query for BTCUSDT');
+		expect(prompt.source).toBe('langfuse');
+	});
+
+	it('should allow overriding the resolved system prompt', async () => {
+		const service = new PromptService({ logger });
+
+		const prompt = await service.getChatPrompt(
+			PromptKeys.GROUNDED_SUMMARY,
+			{
+				alertText: 'Custom system prompt alert',
+				maxLength: 120,
+				languageDirective: '',
+				contextPrompt: '',
+				contextSnippet: '',
+			},
+			{ systemPromptOverride: 'My custom system prompt' },
+		);
+
+		expect(prompt.systemPrompt).toBe('My custom system prompt');
+		expect(prompt.userPrompt).toContain('Custom system prompt alert');
+	});
+});


### PR DESCRIPTION
## Summary

Centralize runtime LLM prompt management behind Langfuse while preserving local fail-open fallbacks. The default prompts are now stored as readable text templates under `src/services/prompts/defaults/`, making them easier to edit and review.

## Key Changes

### 🧩 Central prompt management

- Added `PromptService` and a small file-backed prompt loader under `src/services/prompts/`.
- Registered stable prompt keys and Langfuse prompt names in `promptRegistry.js`.
- Kept the existing `systemPrompt` / `userPrompt` contract intact for Gemini, Azure, and OpenRouter.

### 📄 File-backed default prompts

- Moved all local fallback prompt text into version-controlled `.txt` files.
- Added a lightweight placeholder renderer for templates like `{{symbol}}`, `{{alertText}}`, and `{{maxLength}}`.
- Preserved env overrides where the original implementation already supported them.

### 🔁 Runtime integration

- Updated grounding, alert enrichment, news analysis, and price-query flows to resolve prompts through the centralized service.
- Preserved fail-open behavior when Langfuse is disabled, misconfigured, or unavailable.

### 🧪 Test coverage

- Added unit coverage for prompt resolution, remote fetch, label selection, and fallback behavior.
- Updated affected grounding and enrichment tests to match the centralized prompt flow.

## Technical Implementation

### Architecture changes

#### `src/services/prompts/`

- `PromptService.js` resolves prompts from Langfuse or local templates.
- `filePromptLoader.js` reads prompt templates from disk and renders placeholders.
- `localPromptTemplates.js` maps each logical prompt to its fallback file.
- `defaults/` contains the readable prompt templates used as local fallbacks.

### Dependencies Added

- `@langfuse/client`: Langfuse prompt management SDK.

### File Structure Additions

```text
src/services/prompts/
├── PromptService.js
├── config.js
├── filePromptLoader.js
├── index.js
├── langfuseClient.js
├── localPromptTemplates.js
└── defaults/
    ├── README.md
    ├── alert-enrichment.system.txt
    ├── alert-enrichment.user.txt
    ├── confidence-enrichment.system.txt
    ├── confidence-enrichment.user.txt
    ├── grounded-summary.system.txt
    ├── grounded-summary.user.txt
    ├── market-price-fetch.txt
    ├── news-analysis-search-query.txt
    ├── news-analysis.system.txt
    ├── news-analysis.user.txt
    ├── search-query-derivation.system.txt
    └── search-query-derivation.user.txt
```

## Testing

### Pre-merge Verification

- [x] Run focused prompt-related unit tests
- [x] Run focused grounding and enrichment tests
- [x] Run full repository test suite
- [ ] Verify deployed Langfuse prompt labels in production-like environment

### Review Checklist

- [x] Code quality meets project standards
- [x] All tests pass and coverage is maintained
- [x] Documentation is complete and accurate
- [x] Breaking change assessment completed

## References

- Langfuse prompt management
- Central prompt service under `src/services/prompts/`
- Local fallback prompt templates under `src/services/prompts/defaults/`
