### PR TITLE
feat: Add Sentry traces and span instrumentation across the bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,6 +192,8 @@ ENABLE_SENTRY=false # Enable Sentry error reporting (`true` or `false`, default:
 SENTRY_DSN=your_sentry_dsn_here # Sentry Data Source Name (DSN) from your Sentry project settings
 SENTRY_SEND_ALERT_CONTENT=true # Include alert text in error events (`true` or `false`, default: `true`)
 SENTRY_SAMPLE_RATE_ERRORS=1.0 # Error sample rate from 0.0 to 1.0 (default: `1.0` = 100% of errors)
+SENTRY_TRACES_SAMPLE_RATE=0.1 # Trace sample rate from 0.0 to 1.0 (leave empty/unset to disable tracing entirely)
+SENTRY_CONSOLE_LOG_LEVELS=warn,error # Comma-separated console levels captured as Sentry Logs
 SENTRY_ENVIRONMENT=development # Explicit environment tag (`production`, `preview`, `development`). Auto-derived if not set
 SENTRY_RELEASE=local # Explicit release tag (e.g., `v1.2.3`). Auto-derived from git commit if not set
 # ============================================================================

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 - `SENTRY_RELEASE` - Explicit release tag (e.g., `v1.2.3`). Auto-derived from git commit if not set
 - `SENTRY_SEND_ALERT_CONTENT` - Include alert text in error events (`true` or `false`, default: `true`)
 - `SENTRY_SAMPLE_RATE_ERRORS` - Error sample rate from 0.0 to 1.0 (default: `1.0` = 100%)
+- `SENTRY_TRACES_SAMPLE_RATE` - Trace sample rate from 0.0 to 1.0 (leave unset to disable tracing and custom spans)
 - `SENTRY_CONSOLE_LOG_LEVELS` - Comma-separated console levels sent as Sentry Logs (default: `warn,error`; allowed: `debug`, `info`, `warn`, `error`, `log`, `assert`, `trace`)
 - Sentry Logs are enabled automatically when `ENABLE_SENTRY=true`; configured console levels are sent as Sentry Logs.
 
@@ -632,6 +633,7 @@ When enabled, it also forwards configured console levels to Sentry Logs using th
 - **Privacy Controls**: Optional exclusion of alert content from error events
 - **Structured Console Logs**: All `console.*` output is emitted as one-line JSON with `timestamp`, `level`, `message`, `service`, `environment`, and optional `attributes`, `parameters`, and `error`
 - **Console Log Capture**: Configured console levels are captured as searchable Sentry Logs
+- **Optional Tracing/Spans**: Enable transaction traces plus custom spans for alert processing, news analysis, and multi-channel delivery
 - **Graceful Degradation**: Works without affecting existing fallback mechanisms
 
 ### Configuration
@@ -652,6 +654,9 @@ SENTRY_SEND_ALERT_CONTENT=false
 
 # Optional: Error sampling (default: 1.0 = 100%)
 SENTRY_SAMPLE_RATE_ERRORS=1.0
+
+# Optional: Trace sampling (leave unset to disable tracing)
+SENTRY_TRACES_SAMPLE_RATE=0.1
 
 # Optional: Console log levels captured as Sentry Logs (default: warn,error)
 SENTRY_CONSOLE_LOG_LEVELS=warn,error

--- a/agents.md
+++ b/agents.md
@@ -18,7 +18,7 @@ Key files / entry points
 Environment and runtime behavior (discoverable)
 - NODE version: `20.x` (see `package.json` engines).
 - Required env vars: `BOT_TOKEN` (throws if missing; even when Telegram bot is disabled).
-- Optional but relevant (non-exhaustive; see feature sections below for full config): `ENABLE_TELEGRAM_BOT`, `PORT`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID`, `ENABLE_WHATSAPP_ALERTS`, `ENABLE_GEMINI_GROUNDING`, `GEMINI_API_KEY`, `ENABLE_LANGFUSE_PROMPTS`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_PROMPT_LABEL`, `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`, `BRAVE_SEARCH_API_KEY`, `BRAVE_SEARCH_ENDPOINT`, `FORCE_BRAVE_SEARCH`, `MODEL_PROVIDER`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `ENABLE_NEWS_MONITOR`, `ENABLE_SENTRY`, `SENTRY_DSN`, `SENTRY_CONSOLE_LOG_LEVELS`, `LOG_LEVEL`, `SERVICE_NAME`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `RENDER`, `IS_PULL_REQUEST`, `RENDER_GIT_COMMIT`, `RENDER_GIT_REPO_SLUG`.
+- Optional but relevant (non-exhaustive; see feature sections below for full config): `ENABLE_TELEGRAM_BOT`, `PORT`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID`, `ENABLE_WHATSAPP_ALERTS`, `ENABLE_GEMINI_GROUNDING`, `GEMINI_API_KEY`, `ENABLE_LANGFUSE_PROMPTS`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_PROMPT_LABEL`, `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`, `BRAVE_SEARCH_API_KEY`, `BRAVE_SEARCH_ENDPOINT`, `FORCE_BRAVE_SEARCH`, `MODEL_PROVIDER`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `ENABLE_NEWS_MONITOR`, `ENABLE_SENTRY`, `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_CONSOLE_LOG_LEVELS`, `LOG_LEVEL`, `SERVICE_NAME`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `RENDER`, `IS_PULL_REQUEST`, `RENDER_GIT_COMMIT`, `RENDER_GIT_REPO_SLUG`.
 - Bot startup is gated: bot is launched only when `ENABLE_TELEGRAM_BOT === 'true'` and not a preview environment (`RENDER==='true' && IS_PULL_REQUEST==='true'` disables it).
 - Routes under `/api` (e.g. `/api/webhook/alert`) are mounted regardless of bot launch; individual features and notification channels are gated via env flags and per-channel validation.
 
@@ -578,7 +578,7 @@ ENABLE_SENTRY (005)
 **To extend**:
 1. **Discord integration**: Add in `src/services/notification/DiscordService.js`
 2. **Error aggregation**: Track error rates in memory for metrics
-3. **Sentry reporting (005-sentry-runtime-errors)**: Use a thin monitoring service (`src/services/monitoring/SentryService.js`) that wraps `@sentry/node` for runtime errors and Sentry Logs capture of configured console levels. Gated by `ENABLE_SENTRY` and `SENTRY_DSN`; MUST NOT change HTTP responses or notification fallbacks and SHOULD be stubbed/mocked in tests (no real Sentry traffic by default).
+3. **Sentry reporting (005-sentry-runtime-errors)**: Use a thin monitoring service (`src/services/monitoring/SentryService.js`) that wraps `@sentry/node` for runtime errors, optional tracing/spans, and Sentry Logs capture of configured console levels. Gated by `ENABLE_SENTRY` and `SENTRY_DSN`; MUST NOT change HTTP responses or notification fallbacks and SHOULD be stubbed/mocked in tests (no real Sentry traffic by default).
 4. **Telegram admin alerts**: Send critical errors to admin chat if configured
 
 ## Runtime Error Monitoring with Sentry (005-sentry-runtime-errors)
@@ -609,6 +609,7 @@ This feature introduces backend runtime error monitoring using Sentry's Node SDK
 - `SENTRY_DSN` (server-side DSN from Sentry project; required when `ENABLE_SENTRY==='true'` in environments where we want events)
 - `SENTRY_SEND_ALERT_CONTENT` (default: true; controls whether alert/news text is included in event payloads)
 - `SENTRY_SAMPLE_RATE_ERRORS` (default: 1.0; error sampling rate 0.0-1.0)
+- `SENTRY_TRACES_SAMPLE_RATE` (optional; trace sampling rate 0.0-1.0. Leave unset to disable tracing/spans entirely)
 - `SENTRY_CONSOLE_LOG_LEVELS` (default: `warn,error`; comma-separated levels captured as Sentry Logs; allowed values: `debug`, `info`, `warn`, `error`, `log`, `assert`, `trace`)
 - Optional overrides (otherwise derived from existing deployment vars):
   - `SENTRY_ENVIRONMENT` (e.g., `production`, `preview`, `development`)

--- a/src/controllers/commands.js
+++ b/src/controllers/commands.js
@@ -17,7 +17,7 @@ const getPrice = async (context) => {
 	});
 
 	try {
-		const result = await sentryService.withActiveSpan(commandSpan, () => fetchSymbolPrice(context));
+		const result = await fetchSymbolPrice(context, { parentSpan: commandSpan });
 		await context.reply(`Precio de ${result.symbol} es ${result.price}`);
 	} catch (error) {
 		console.error(error);

--- a/src/controllers/commands.js
+++ b/src/controllers/commands.js
@@ -1,46 +1,81 @@
 const { fetchSymbolPrice } = require('./commands/handlers/core/fetchPriceCryptoSymbol');
 const sentryService = require('../services/monitoring/SentryService');
 
-const getPrice = (context) => {
-	fetchSymbolPrice(context).then((result) => {
-		context.reply(`Precio de ${result.symbol} es ${result.price}`);
-	}).catch((error) => {
-		console.error(error);
-		// Capture Telegram command errors to Sentry (T015)
-		sentryService.captureRuntimeError({
-			channel: 'telegram',
-			error,
-			extra: {
-				command: 'getPrice',
-				chatId: context.update && context.update.message && context.update.message.chat && context.update.message.chat.id,
+const getPrice = async (context) => {
+	const chatId = context.update && context.update.message && context.update.message.chat && context.update.message.chat.id;
+	const messageSplited = context.message.text.split(' ');
+	const symbol = messageSplited[1] || '';
+
+	return sentryService.withSpan(
+		{
+			name: 'telegram.command.precio',
+			op: 'bot.command',
+			forceTransaction: true,
+			attributes: {
+				'telegram.command': '/precio',
+				'telegram.chat_id': chatId ? String(chatId) : 'unknown',
+				'crypto.symbol': symbol || 'missing',
 			},
-		});
-	});
+		},
+		async () => {
+			try {
+				const result = await fetchSymbolPrice(context);
+				await context.reply(`Precio de ${result.symbol} es ${result.price}`);
+			} catch (error) {
+				console.error(error);
+				// Capture Telegram command errors to Sentry (T015)
+				sentryService.captureRuntimeError({
+					channel: 'telegram',
+					error,
+					extra: {
+						command: 'getPrice',
+						chatId,
+						symbol,
+					},
+				});
+			}
+		},
+	);
 };
 
 const cryptoBotCmd = (context) => {
-	try {
-		const messageSplited = context.message.text.split(' ');
-		const cmd = messageSplited[1];
-		switch (cmd) {
-		case 'id':
-			context.reply(`Chat Id: ${context.update.message.chat.id}`);
-			break;
-		default:
-			// Nothing
-		}
-	} catch (error) {
-		console.error(error);
-		// Capture Telegram command errors to Sentry (T015)
-		sentryService.captureRuntimeError({
-			channel: 'telegram',
-			error,
-			extra: {
-				command: 'cryptoBotCmd',
-				chatId: context.update && context.update.message && context.update.message.chat && context.update.message.chat.id,
+	const chatId = context.update && context.update.message && context.update.message.chat && context.update.message.chat.id;
+
+	return sentryService.withSpan(
+		{
+			name: 'telegram.command.cryptobot',
+			op: 'bot.command',
+			forceTransaction: true,
+			attributes: {
+				'telegram.command': '/cryptobot',
+				'telegram.chat_id': chatId ? String(chatId) : 'unknown',
 			},
-		});
-	}
+		},
+		() => {
+			try {
+				const messageSplited = context.message.text.split(' ');
+				const cmd = messageSplited[1];
+				switch (cmd) {
+				case 'id':
+					context.reply(`Chat Id: ${chatId}`);
+					break;
+				default:
+					// Nothing
+				}
+			} catch (error) {
+				console.error(error);
+				// Capture Telegram command errors to Sentry (T015)
+				sentryService.captureRuntimeError({
+					channel: 'telegram',
+					error,
+					extra: {
+						command: 'cryptoBotCmd',
+						chatId,
+					},
+				});
+			}
+		},
+	);
 };
 
 module.exports = { getPrice, cryptoBotCmd };

--- a/src/controllers/commands.js
+++ b/src/controllers/commands.js
@@ -6,76 +6,61 @@ const getPrice = async (context) => {
 	const messageSplited = context.message.text.split(' ');
 	const symbol = messageSplited[1] || '';
 
-	return sentryService.withSpan(
-		{
-			name: 'telegram.command.precio',
-			op: 'bot.command',
-			forceTransaction: true,
-			attributes: {
-				'telegram.command': '/precio',
-				'telegram.chat_id': chatId ? String(chatId) : 'unknown',
-				'crypto.symbol': symbol || 'missing',
+	try {
+		const result = await sentryService.withSpan(
+			{
+				name: 'telegram.command.precio',
+				op: 'bot.command',
+				forceTransaction: true,
+				attributes: {
+					'telegram.command': '/precio',
+					'telegram.chat_id': chatId ? String(chatId) : 'unknown',
+					'crypto.symbol': symbol || 'missing',
+				},
 			},
-		},
-		async () => {
-			try {
-				const result = await fetchSymbolPrice(context);
-				await context.reply(`Precio de ${result.symbol} es ${result.price}`);
-			} catch (error) {
-				console.error(error);
-				// Capture Telegram command errors to Sentry (T015)
-				sentryService.captureRuntimeError({
-					channel: 'telegram',
-					error,
-					extra: {
-						command: 'getPrice',
-						chatId,
-						symbol,
-					},
-				});
-			}
-		},
-	);
+			() => fetchSymbolPrice(context),
+		);
+		await context.reply(`Precio de ${result.symbol} es ${result.price}`);
+	} catch (error) {
+		console.error(error);
+		// Capture Telegram command errors to Sentry (T015)
+		sentryService.captureRuntimeError({
+			channel: 'telegram',
+			error,
+			extra: {
+				command: 'getPrice',
+				chatId,
+				symbol,
+			},
+		});
+	}
 };
 
 const cryptoBotCmd = (context) => {
 	const chatId = context.update && context.update.message && context.update.message.chat && context.update.message.chat.id;
 
-	return sentryService.withSpan(
-		{
-			name: 'telegram.command.cryptobot',
-			op: 'bot.command',
-			forceTransaction: true,
-			attributes: {
-				'telegram.command': '/cryptobot',
-				'telegram.chat_id': chatId ? String(chatId) : 'unknown',
+	try {
+		const messageSplited = context.message.text.split(' ');
+		const cmd = messageSplited[1];
+		switch (cmd) {
+		case 'id':
+			context.reply(`Chat Id: ${chatId}`);
+			break;
+		default:
+			// Nothing
+		}
+	} catch (error) {
+		console.error(error);
+		// Capture Telegram command errors to Sentry (T015)
+		sentryService.captureRuntimeError({
+			channel: 'telegram',
+			error,
+			extra: {
+				command: 'cryptoBotCmd',
+				chatId,
 			},
-		},
-		() => {
-			try {
-				const messageSplited = context.message.text.split(' ');
-				const cmd = messageSplited[1];
-				switch (cmd) {
-				case 'id':
-					context.reply(`Chat Id: ${chatId}`);
-					break;
-				default:
-					// Nothing
-				}
-			} catch (error) {
-				console.error(error);
-				// Capture Telegram command errors to Sentry (T015)
-				sentryService.captureRuntimeError({
-					channel: 'telegram',
-					error,
-					extra: {
-						command: 'cryptoBotCmd',
-						chatId,
-					},
-				});
-			}
-		},
-	);
+		});
+	}
 };
 
 module.exports = { getPrice, cryptoBotCmd };

--- a/src/controllers/commands.js
+++ b/src/controllers/commands.js
@@ -5,21 +5,19 @@ const getPrice = async (context) => {
 	const chatId = context.update && context.update.message && context.update.message.chat && context.update.message.chat.id;
 	const messageSplited = context.message.text.split(' ');
 	const symbol = messageSplited[1] || '';
+	const commandSpan = sentryService.startInactiveSpan({
+		name: 'telegram.command.precio',
+		op: 'bot.command',
+		forceTransaction: true,
+		attributes: {
+			'telegram.command': '/precio',
+			'telegram.chat_id': chatId ? String(chatId) : 'unknown',
+			'crypto.symbol': symbol || 'missing',
+		},
+	});
 
 	try {
-		const result = await sentryService.withSpan(
-			{
-				name: 'telegram.command.precio',
-				op: 'bot.command',
-				forceTransaction: true,
-				attributes: {
-					'telegram.command': '/precio',
-					'telegram.chat_id': chatId ? String(chatId) : 'unknown',
-					'crypto.symbol': symbol || 'missing',
-				},
-			},
-			() => fetchSymbolPrice(context),
-		);
+		const result = await sentryService.withActiveSpan(commandSpan, () => fetchSymbolPrice(context));
 		await context.reply(`Precio de ${result.symbol} es ${result.price}`);
 	} catch (error) {
 		console.error(error);
@@ -33,11 +31,22 @@ const getPrice = async (context) => {
 				symbol,
 			},
 		});
+	} finally {
+		sentryService.endSpan(commandSpan);
 	}
 };
 
 const cryptoBotCmd = (context) => {
 	const chatId = context.update && context.update.message && context.update.message.chat && context.update.message.chat.id;
+	const commandSpan = sentryService.startInactiveSpan({
+		name: 'telegram.command.cryptobot',
+		op: 'bot.command',
+		forceTransaction: true,
+		attributes: {
+			'telegram.command': '/cryptobot',
+			'telegram.chat_id': chatId ? String(chatId) : 'unknown',
+		},
+	});
 
 	try {
 		const messageSplited = context.message.text.split(' ');
@@ -60,6 +69,8 @@ const cryptoBotCmd = (context) => {
 				chatId,
 			},
 		});
+	} finally {
+		sentryService.endSpan(commandSpan);
 	}
 };
 

--- a/src/controllers/commands/handlers/core/fetchPriceCryptoSymbol.js
+++ b/src/controllers/commands/handlers/core/fetchPriceCryptoSymbol.js
@@ -7,14 +7,16 @@ const client = new MainClient({
 	beautifyResponses: true,
 });
 
-const fetchSymbolPrice = async (context) => {
+const fetchSymbolPrice = async (context, options = {}) => {
 	// Check for parameters;
 	const messageSplited = context.message.text.split(' ');
 	const symbol = messageSplited[1];
+	const { parentSpan } = options;
 	const priceFetchSpan = sentryService.startInactiveSpan({
 		name: 'binance.get_avg_price',
 		op: 'http.client',
 		onlyIfParent: true,
+		parentSpan,
 		attributes: {
 			'provider.name': 'binance',
 			'provider.operation': 'getAvgPrice',
@@ -23,7 +25,7 @@ const fetchSymbolPrice = async (context) => {
 	});
 	try {
 		let price;
-		const data = await sentryService.withActiveSpan(priceFetchSpan, () => client.getAvgPrice({ symbol: symbol }));
+		const data = await client.getAvgPrice({ symbol: symbol });
 		// The prices have been successfully retrieved
 		// So build the response object to trigger the success intent
 		if (data.price >= 1) {

--- a/src/controllers/commands/handlers/core/fetchPriceCryptoSymbol.js
+++ b/src/controllers/commands/handlers/core/fetchPriceCryptoSymbol.js
@@ -11,21 +11,19 @@ const fetchSymbolPrice = async (context) => {
 	// Check for parameters;
 	const messageSplited = context.message.text.split(' ');
 	const symbol = messageSplited[1];
+	const priceFetchSpan = sentryService.startInactiveSpan({
+		name: 'binance.get_avg_price',
+		op: 'http.client',
+		onlyIfParent: true,
+		attributes: {
+			'provider.name': 'binance',
+			'provider.operation': 'getAvgPrice',
+			'crypto.symbol': symbol || 'missing',
+		},
+	});
 	try {
 		let price;
-		const data = await sentryService.withSpan(
-			{
-				name: 'binance.get_avg_price',
-				op: 'http.client',
-				onlyIfParent: true,
-				attributes: {
-					'provider.name': 'binance',
-					'provider.operation': 'getAvgPrice',
-					'crypto.symbol': symbol || 'missing',
-				},
-			},
-			() => client.getAvgPrice({ symbol: symbol }),
-		);
+		const data = await sentryService.withActiveSpan(priceFetchSpan, () => client.getAvgPrice({ symbol: symbol }));
 		// The prices have been successfully retrieved
 		// So build the response object to trigger the success intent
 		if (data.price >= 1) {
@@ -45,6 +43,8 @@ const fetchSymbolPrice = async (context) => {
 		console.error('Error fetching symbol price:', e);
 		// Reject the Promise to say that an error occurred while the handler was performing the action
 		return Promise.reject(e);
+	} finally {
+		sentryService.endSpan(priceFetchSpan);
 	}
 };
 

--- a/src/controllers/commands/handlers/core/fetchPriceCryptoSymbol.js
+++ b/src/controllers/commands/handlers/core/fetchPriceCryptoSymbol.js
@@ -1,5 +1,6 @@
 const { round10 } = require('../../../helpers');
 const { MainClient } = require('binance');
+const sentryService = require('../../../../services/monitoring/SentryService');
 
 const client = new MainClient({
 	// Optional (default: false) - when true, response strings are parsed to floats (only for known keys).
@@ -12,7 +13,19 @@ const fetchSymbolPrice = async (context) => {
 	const symbol = messageSplited[1];
 	try {
 		let price;
-		const data = await client.getAvgPrice({ symbol: symbol });
+		const data = await sentryService.withSpan(
+			{
+				name: 'binance.get_avg_price',
+				op: 'http.client',
+				onlyIfParent: true,
+				attributes: {
+					'provider.name': 'binance',
+					'provider.operation': 'getAvgPrice',
+					'crypto.symbol': symbol || 'missing',
+				},
+			},
+			() => client.getAvgPrice({ symbol: symbol }),
+		);
 		// The prices have been successfully retrieved
 		// So build the response object to trigger the success intent
 		if (data.price >= 1) {
@@ -36,4 +49,3 @@ const fetchSymbolPrice = async (context) => {
 };
 
 module.exports = { fetchSymbolPrice };
-

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -57,20 +57,22 @@ async function processEnrichment(alert, options) {
 	let enriched = false;
 
 	if (isGeminiEnabled || isTradingViewMcpEnabled) {
+		const enrichmentSpan = sentryService.startInactiveSpan({
+			name: 'alerts.enrichment',
+`			op: 'alert.enrich',
+			onlyIfParent: true,
+			attributes: {
+				'alert.length': alert.text.length,
+				'alert.use_tradingview_data': useTradingViewData,
+				'feature.gemini_grounding': isGeminiEnabled,
+				'feature.tradingview_mcp_enrichment': isTradingViewMcpEnabled,
+			},
+		});
+
 		try {
 			console.debug('Starting alert enrichment process');
-			const enrichedAlert = await sentryService.withSpan(
-				{
-					name: 'alerts.enrichment',
-					op: 'alert.enrich',
-					onlyIfParent: true,
-					attributes: {
-						'alert.length': alert.text.length,
-						'alert.use_tradingview_data': useTradingViewData,
-						'feature.gemini_grounding': isGeminiEnabled,
-						'feature.tradingview_mcp_enrichment': isTradingViewMcpEnabled,
-					},
-				},
+			const enrichedAlert = await sentryService.withActiveSpan(
+				enrichmentSpan,
 				() => enrichAlert({ text: alert.text }, { tokenUsage, useTradingViewData }),
 			);
 			if (enrichedAlert && typeof enrichedAlert === 'object') {
@@ -83,6 +85,8 @@ async function processEnrichment(alert, options) {
 			}
 		} catch (error) {
 			console.warn('[Alert] Enrichment failed, using original text:', error.message);
+		} finally {
+			sentryService.endSpan(enrichmentSpan);
 		}
 	}
 

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -59,7 +59,20 @@ async function processEnrichment(alert, options) {
 	if (isGeminiEnabled || isTradingViewMcpEnabled) {
 		try {
 			console.debug('Starting alert enrichment process');
-			const enrichedAlert = await enrichAlert({ text: alert.text }, { tokenUsage, useTradingViewData });
+			const enrichedAlert = await sentryService.withSpan(
+				{
+					name: 'alerts.enrichment',
+					op: 'alert.enrich',
+					onlyIfParent: true,
+					attributes: {
+						'alert.length': alert.text.length,
+						'alert.use_tradingview_data': useTradingViewData,
+						'feature.gemini_grounding': isGeminiEnabled,
+						'feature.tradingview_mcp_enrichment': isTradingViewMcpEnabled,
+					},
+				},
+				() => enrichAlert({ text: alert.text }, { tokenUsage, useTradingViewData }),
+			);
 			if (enrichedAlert && typeof enrichedAlert === 'object') {
 				enrichedAlert.tokenUsage = tokenUsage.toJSON();
 				enriched = true;
@@ -84,50 +97,77 @@ function postAlert(bot) {
 		let alertText = '';
 		let alert = null;
 
-		try {
-			if (typeof body === 'object' && 'text' in body) {
-				alertText = body.text;
-			} else {
-				alertText = body;
-			}
-
-			const { text } = validateAlert(alertText);
-			alert = { text };
-
-			const tokenUsage = new TokenUsageTracker();
-			const enriched = await processEnrichment(alert, { tokenUsage, useTradingViewData });
-
-			// Send to all enabled notification channels
-			const results = await notificationManager.sendToAll(alert);
-
-			// Return 200 OK regardless of delivery success (fail-open pattern)
-			const tokenUsageJSON = tokenUsage.toJSON();
-			tokenUsageJSON.formattedSummary = tokenUsage.formatSummary();
-			res.json({ success: true, results, enriched, tokenUsage: tokenUsageJSON });
-		} catch (error) {
-			console.error('[Alert] Request failed:', error.message);
-
-			// Capture runtime error to Sentry (T012)
-			sentryService.captureRuntimeError({
-				channel: 'http-alert',
-				error,
-				http: {
-					endpoint: '/api/webhook/alert',
-					method: 'POST',
-					statusCode: (error.response && error.response.error_code) || 500,
+		return sentryService.withSpan(
+			{
+				name: 'alerts.webhook.process',
+				op: 'http.server.handler',
+				onlyIfParent: true,
+				attributes: {
+					'http.route': '/api/webhook/alert',
+					'http.method': 'POST',
+					'alert.use_tradingview_data': useTradingViewData,
 				},
-				alert: {
-					textLength: alertText ? alertText.length : 0,
-					hasEnrichment: !!(alert && alert.enriched),
-					enrichedSource: alert && alert.enriched && alert.enriched.extraText && alert.enriched.extraText.includes('tradingview-mcp') ? 'tradingview-mcp' : (alert && alert.enriched ? 'gemini-grounding' : undefined),
-					truncated: false,
-				},
-			});
+			},
+			async () => {
+				try {
+					if (typeof body === 'object' && 'text' in body) {
+						alertText = body.text;
+					} else {
+						alertText = body;
+					}
 
-			const status = (error.response && error.response.error_code) || 500;
-			const errorResponse = error.response || { error: 'Internal server error', details: error.message };
-			res.status(status).send(errorResponse);
-		}
+					const { text } = validateAlert(alertText);
+					alert = { text };
+
+					const tokenUsage = new TokenUsageTracker();
+					const enriched = await processEnrichment(alert, { tokenUsage, useTradingViewData });
+
+					// Send to all enabled notification channels
+					const enabledChannels = notificationManager ? notificationManager.getEnabledChannels() : [];
+					const results = await sentryService.withSpan(
+						{
+							name: 'alerts.notifications.dispatch',
+							op: 'notification.dispatch',
+							onlyIfParent: true,
+							attributes: {
+								'notification.enabled_channels_count': enabledChannels.length,
+								'notification.enabled_channels': enabledChannels.join(',') || 'none',
+								'alert.enriched': enriched,
+							},
+						},
+						() => notificationManager.sendToAll(alert),
+					);
+
+					// Return 200 OK regardless of delivery success (fail-open pattern)
+					const tokenUsageJSON = tokenUsage.toJSON();
+					tokenUsageJSON.formattedSummary = tokenUsage.formatSummary();
+					res.json({ success: true, results, enriched, tokenUsage: tokenUsageJSON });
+				} catch (error) {
+					console.error('[Alert] Request failed:', error.message);
+
+					// Capture runtime error to Sentry (T012)
+					sentryService.captureRuntimeError({
+						channel: 'http-alert',
+						error,
+						http: {
+							endpoint: '/api/webhook/alert',
+							method: 'POST',
+							statusCode: (error.response && error.response.error_code) || 500,
+						},
+						alert: {
+							textLength: alertText ? alertText.length : 0,
+							hasEnrichment: !!(alert && alert.enriched),
+							enrichedSource: alert && alert.enriched && alert.enriched.extraText && alert.enriched.extraText.includes('tradingview-mcp') ? 'tradingview-mcp' : (alert && alert.enriched ? 'gemini-grounding' : undefined),
+							truncated: false,
+						},
+					});
+
+					const status = (error.response && error.response.error_code) || 500;
+					const errorResponse = error.response || { error: 'Internal server error', details: error.message };
+					res.status(status).send(errorResponse);
+				}
+			},
+		);
 	};
 }
 

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -97,77 +97,50 @@ function postAlert(bot) {
 		let alertText = '';
 		let alert = null;
 
-		return sentryService.withSpan(
-			{
-				name: 'alerts.webhook.process',
-				op: 'http.server.handler',
-				onlyIfParent: true,
-				attributes: {
-					'http.route': '/api/webhook/alert',
-					'http.method': 'POST',
-					'alert.use_tradingview_data': useTradingViewData,
+		try {
+			if (typeof body === 'object' && 'text' in body) {
+				alertText = body.text;
+			} else {
+				alertText = body;
+			}
+
+			const { text } = validateAlert(alertText);
+			alert = { text };
+
+			const tokenUsage = new TokenUsageTracker();
+			const enriched = await processEnrichment(alert, { tokenUsage, useTradingViewData });
+
+			// NotificationManager owns the custom dispatch spans.
+			const results = await notificationManager.sendToAll(alert);
+
+			// Return 200 OK regardless of delivery success (fail-open pattern)
+			const tokenUsageJSON = tokenUsage.toJSON();
+			tokenUsageJSON.formattedSummary = tokenUsage.formatSummary();
+			res.json({ success: true, results, enriched, tokenUsage: tokenUsageJSON });
+		} catch (error) {
+			console.error('[Alert] Request failed:', error.message);
+
+			// Capture runtime error to Sentry (T012)
+			sentryService.captureRuntimeError({
+				channel: 'http-alert',
+				error,
+				http: {
+					endpoint: '/api/webhook/alert',
+					method: 'POST',
+					statusCode: (error.response && error.response.error_code) || 500,
 				},
-			},
-			async () => {
-				try {
-					if (typeof body === 'object' && 'text' in body) {
-						alertText = body.text;
-					} else {
-						alertText = body;
-					}
+				alert: {
+					textLength: alertText ? alertText.length : 0,
+					hasEnrichment: !!(alert && alert.enriched),
+					enrichedSource: alert && alert.enriched && alert.enriched.extraText && alert.enriched.extraText.includes('tradingview-mcp') ? 'tradingview-mcp' : (alert && alert.enriched ? 'gemini-grounding' : undefined),
+					truncated: false,
+				},
+			});
 
-					const { text } = validateAlert(alertText);
-					alert = { text };
-
-					const tokenUsage = new TokenUsageTracker();
-					const enriched = await processEnrichment(alert, { tokenUsage, useTradingViewData });
-
-					// Send to all enabled notification channels
-					const enabledChannels = notificationManager ? notificationManager.getEnabledChannels() : [];
-					const results = await sentryService.withSpan(
-						{
-							name: 'alerts.notifications.dispatch',
-							op: 'notification.dispatch',
-							onlyIfParent: true,
-							attributes: {
-								'notification.enabled_channels_count': enabledChannels.length,
-								'notification.enabled_channels': enabledChannels.join(',') || 'none',
-								'alert.enriched': enriched,
-							},
-						},
-						() => notificationManager.sendToAll(alert),
-					);
-
-					// Return 200 OK regardless of delivery success (fail-open pattern)
-					const tokenUsageJSON = tokenUsage.toJSON();
-					tokenUsageJSON.formattedSummary = tokenUsage.formatSummary();
-					res.json({ success: true, results, enriched, tokenUsage: tokenUsageJSON });
-				} catch (error) {
-					console.error('[Alert] Request failed:', error.message);
-
-					// Capture runtime error to Sentry (T012)
-					sentryService.captureRuntimeError({
-						channel: 'http-alert',
-						error,
-						http: {
-							endpoint: '/api/webhook/alert',
-							method: 'POST',
-							statusCode: (error.response && error.response.error_code) || 500,
-						},
-						alert: {
-							textLength: alertText ? alertText.length : 0,
-							hasEnrichment: !!(alert && alert.enriched),
-							enrichedSource: alert && alert.enriched && alert.enriched.extraText && alert.enriched.extraText.includes('tradingview-mcp') ? 'tradingview-mcp' : (alert && alert.enriched ? 'gemini-grounding' : undefined),
-							truncated: false,
-						},
-					});
-
-					const status = (error.response && error.response.error_code) || 500;
-					const errorResponse = error.response || { error: 'Internal server error', details: error.message };
-					res.status(status).send(errorResponse);
-				}
-			},
-		);
+			const status = (error.response && error.response.error_code) || 500;
+			const errorResponse = error.response || { error: 'Internal server error', details: error.message };
+			res.status(status).send(errorResponse);
+		}
 	};
 }
 

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -50,7 +50,7 @@ function getNotificationManager() {
 }
 
 async function processEnrichment(alert, options) {
-	const { tokenUsage, useTradingViewData } = options;
+	const { tokenUsage, useTradingViewData, parentSpan } = options;
 	const isGeminiEnabled = process.env.ENABLE_GEMINI_GROUNDING === 'true';
 	const isTradingViewMcpEnabled = process.env.ENABLE_TRADINGVIEW_MCP_ENRICHMENT === 'true' && useTradingViewData;
 
@@ -59,8 +59,9 @@ async function processEnrichment(alert, options) {
 	if (isGeminiEnabled || isTradingViewMcpEnabled) {
 		const enrichmentSpan = sentryService.startInactiveSpan({
 			name: 'alerts.enrichment',
-`			op: 'alert.enrich',
+			op: 'alert.enrich',
 			onlyIfParent: true,
+			parentSpan,
 			attributes: {
 				'alert.length': alert.text.length,
 				'alert.use_tradingview_data': useTradingViewData,
@@ -71,10 +72,7 @@ async function processEnrichment(alert, options) {
 
 		try {
 			console.debug('Starting alert enrichment process');
-			const enrichedAlert = await sentryService.withActiveSpan(
-				enrichmentSpan,
-				() => enrichAlert({ text: alert.text }, { tokenUsage, useTradingViewData }),
-			);
+			const enrichedAlert = await enrichAlert({ text: alert.text }, { tokenUsage, useTradingViewData });
 			if (enrichedAlert && typeof enrichedAlert === 'object') {
 				enrichedAlert.tokenUsage = tokenUsage.toJSON();
 				enriched = true;
@@ -102,6 +100,8 @@ function postAlert(bot) {
 		let alert = null;
 
 		try {
+			const requestSpan = sentryService.getActiveSpan();
+
 			if (typeof body === 'object' && 'text' in body) {
 				alertText = body.text;
 			} else {
@@ -112,10 +112,10 @@ function postAlert(bot) {
 			alert = { text };
 
 			const tokenUsage = new TokenUsageTracker();
-			const enriched = await processEnrichment(alert, { tokenUsage, useTradingViewData });
+			const enriched = await processEnrichment(alert, { tokenUsage, useTradingViewData, parentSpan: requestSpan });
 
 			// NotificationManager owns the custom dispatch spans.
-			const results = await notificationManager.sendToAll(alert);
+			const results = await notificationManager.sendToAll(alert, { parentSpan: requestSpan });
 
 			// Return 200 OK regardless of delivery success (fail-open pattern)
 			const tokenUsageJSON = tokenUsage.toJSON();

--- a/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
@@ -40,6 +40,8 @@ class NewsMonitorHandler {
 		const tokenUsage = new TokenUsageTracker();
 
 		try {
+			const requestSpan = sentryService.getActiveSpan();
+
 			// Inject notification manager into analyzer (set once before analysis)
 			const notificationManager = getNotificationManager();
 			if (notificationManager) {
@@ -85,6 +87,7 @@ class NewsMonitorHandler {
 				name: 'news_monitor.analyze_symbols',
 				op: 'news.analysis',
 				onlyIfParent: true,
+				parentSpan: requestSpan,
 				attributes: {
 					'news.symbol_count': symbolsToAnalyze.length,
 					'news.request_id': requestId,
@@ -93,10 +96,7 @@ class NewsMonitorHandler {
 
 			let results;
 			try {
-				results = await sentryService.withActiveSpan(
-					analysisSpan,
-					() => this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage),
-				);
+				results = await this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage);
 			} finally {
 				sentryService.endSpan(analysisSpan);
 			}

--- a/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
@@ -81,18 +81,25 @@ class NewsMonitorHandler {
 				});
 			}
 
-			const results = await sentryService.withSpan(
-				{
-					name: 'news_monitor.analyze_symbols',
-					op: 'news.analysis',
-					onlyIfParent: true,
-					attributes: {
-						'news.symbol_count': symbolsToAnalyze.length,
-						'news.request_id': requestId,
-					},
+			const analysisSpan = sentryService.startInactiveSpan({
+				name: 'news_monitor.analyze_symbols',
+				op: 'news.analysis',
+				onlyIfParent: true,
+				attributes: {
+					'news.symbol_count': symbolsToAnalyze.length,
+					'news.request_id': requestId,
 				},
-				() => this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage),
-			);
+			});
+
+			let results;
+			try {
+				results = await sentryService.withActiveSpan(
+					analysisSpan,
+					() => this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage),
+				);
+			} finally {
+				sentryService.endSpan(analysisSpan);
+			}
 
 			const summary = this.generateSummary(results);
 			const response = {

--- a/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
@@ -39,101 +39,125 @@ class NewsMonitorHandler {
 		const startTime = Date.now();
 		const tokenUsage = new TokenUsageTracker();
 
-		try {
-			// Inject notification manager into analyzer (set once before analysis)
-			const notificationManager = getNotificationManager();
-			if (notificationManager) {
-				setNotificationManager(notificationManager);
-			}
-
-			// Check feature flag
-			if (process.env.ENABLE_NEWS_MONITOR !== 'true') {
-				return res.status(403).json({
-					error: 'News monitor feature is disabled. Set ENABLE_NEWS_MONITOR=true to enable.',
-					code: 'FEATURE_DISABLED',
-					requestId,
-				});
-			}
-
-			// Parse request
-			const { crypto, stocks } = this.parseRequest(req);
-			const allSymbols = [...(crypto || []), ...(stocks || [])];
-			const validationError = this.validateRequest(allSymbols);
-			if (validationError) {
-				return res.status(400).json({
-					error: validationError,
-					code: 'INVALID_REQUEST',
-					requestId,
-				});
-			}
-
-			// Get default symbols if not provided
-			const symbolsToAnalyze = allSymbols.length > 0
-				? allSymbols
-				: this.getDefaultSymbols();
-
-			console.info('[NewsMonitor] Analyzing symbols:', symbolsToAnalyze);
-			if (symbolsToAnalyze.length === 0) {
-				return res.status(400).json({
-					error: 'No symbols to analyze. Provide crypto/stocks or set env defaults.',
-					code: 'NO_SYMBOLS',
-					requestId,
-				});
-			}
-
-			// Run analysis
-			const results = await this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage);
-
-			// Generate summary
-			const summary = this.generateSummary(results);
-
-			// Build response
-			const response = {
-				success: summary.analyzed > 0 || summary.cached > 0,
-				partial_success: summary.timeout > 0 || summary.error > 0,
-				results,
-				summary,
-				totalDurationMs: Date.now() - startTime,
-				requestId,
-				tokenUsage: tokenUsage.toJSON(),
-			};
-
-			// Remove partial_success if all succeeded
-			if (!response.partial_success) {
-				delete response.partial_success;
-			}
-
-			console.info('[NewsMonitor] Request complete', {
-				requestId,
-				totalMs: response.totalDurationMs,
-				summary,
-			});
-
-			return res.status(200).json(response);
-		} catch (error) {
-			console.error('[NewsMonitor] Unexpected error:', error);
-
-			// Capture runtime error to Sentry (T013) - only for 500 errors
-			sentryService.captureRuntimeError({
-				channel: 'news-monitor',
-				error,
-				http: {
-					endpoint: '/api/news-monitor',
-					method: req.method,
-					statusCode: 500,
-					requestId,
-					featureFlagState: {
-						ENABLE_NEWS_MONITOR: process.env.ENABLE_NEWS_MONITOR === 'true',
-					},
+		return sentryService.withSpan(
+			{
+				name: 'news_monitor.webhook.process',
+				op: 'http.server.handler',
+				onlyIfParent: true,
+				attributes: {
+					'http.route': '/api/news-monitor',
+					'http.method': req.method,
 				},
-			});
+			},
+			async () => {
+				try {
+					// Inject notification manager into analyzer (set once before analysis)
+					const notificationManager = getNotificationManager();
+					if (notificationManager) {
+						setNotificationManager(notificationManager);
+					}
 
-			return res.status(500).json({
-				error: 'Internal server error. Please try again later.',
-				code: 'INTERNAL_ERROR',
-				requestId,
-			});
-		}
+					// Check feature flag
+					if (process.env.ENABLE_NEWS_MONITOR !== 'true') {
+						return res.status(403).json({
+							error: 'News monitor feature is disabled. Set ENABLE_NEWS_MONITOR=true to enable.',
+							code: 'FEATURE_DISABLED',
+							requestId,
+						});
+					}
+
+					// Parse request
+					const { crypto, stocks } = this.parseRequest(req);
+					const allSymbols = [...(crypto || []), ...(stocks || [])];
+					const validationError = this.validateRequest(allSymbols);
+					if (validationError) {
+						return res.status(400).json({
+							error: validationError,
+							code: 'INVALID_REQUEST',
+							requestId,
+						});
+					}
+
+					// Get default symbols if not provided
+					const symbolsToAnalyze = allSymbols.length > 0
+						? allSymbols
+						: this.getDefaultSymbols();
+
+					console.info('[NewsMonitor] Analyzing symbols:', symbolsToAnalyze);
+					if (symbolsToAnalyze.length === 0) {
+						return res.status(400).json({
+							error: 'No symbols to analyze. Provide crypto/stocks or set env defaults.',
+							code: 'NO_SYMBOLS',
+							requestId,
+						});
+					}
+
+					// Run analysis
+					const results = await sentryService.withSpan(
+						{
+							name: 'news_monitor.analyze_symbols',
+							op: 'news.analysis',
+							onlyIfParent: true,
+							attributes: {
+								'news.symbol_count': symbolsToAnalyze.length,
+								'news.request_id': requestId,
+							},
+						},
+						() => this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage),
+					);
+
+					// Generate summary
+					const summary = this.generateSummary(results);
+
+					// Build response
+					const response = {
+						success: summary.analyzed > 0 || summary.cached > 0,
+						partial_success: summary.timeout > 0 || summary.error > 0,
+						results,
+						summary,
+						totalDurationMs: Date.now() - startTime,
+						requestId,
+						tokenUsage: tokenUsage.toJSON(),
+					};
+
+					// Remove partial_success if all succeeded
+					if (!response.partial_success) {
+						delete response.partial_success;
+					}
+
+					console.info('[NewsMonitor] Request complete', {
+						requestId,
+						totalMs: response.totalDurationMs,
+						summary,
+					});
+
+					return res.status(200).json(response);
+				} catch (error) {
+					console.error('[NewsMonitor] Unexpected error:', error);
+
+					// Capture runtime error to Sentry (T013) - only for 500 errors
+					sentryService.captureRuntimeError({
+						channel: 'news-monitor',
+						error,
+						http: {
+							endpoint: '/api/news-monitor',
+							method: req.method,
+							statusCode: 500,
+							requestId,
+							featureFlagState: {
+								ENABLE_NEWS_MONITOR: process.env.ENABLE_NEWS_MONITOR === 'true',
+							},
+						},
+					});
+
+					return res.status(500).json({
+						error: 'Internal server error. Please try again later.',
+						code: 'INTERNAL_ERROR',
+						requestId,
+					});
+				}
+			},
+		);
 	}
 
 	/**

--- a/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
@@ -39,125 +39,107 @@ class NewsMonitorHandler {
 		const startTime = Date.now();
 		const tokenUsage = new TokenUsageTracker();
 
-		return sentryService.withSpan(
-			{
-				name: 'news_monitor.webhook.process',
-				op: 'http.server.handler',
-				onlyIfParent: true,
-				attributes: {
-					'http.route': '/api/news-monitor',
-					'http.method': req.method,
+		try {
+			// Inject notification manager into analyzer (set once before analysis)
+			const notificationManager = getNotificationManager();
+			if (notificationManager) {
+				setNotificationManager(notificationManager);
+			}
+
+			// Check feature flag
+			if (process.env.ENABLE_NEWS_MONITOR !== 'true') {
+				return res.status(403).json({
+					error: 'News monitor feature is disabled. Set ENABLE_NEWS_MONITOR=true to enable.',
+					code: 'FEATURE_DISABLED',
+					requestId,
+				});
+			}
+
+			// Parse request
+			const { crypto, stocks } = this.parseRequest(req);
+			const allSymbols = [...(crypto || []), ...(stocks || [])];
+			const validationError = this.validateRequest(allSymbols);
+			if (validationError) {
+				return res.status(400).json({
+					error: validationError,
+					code: 'INVALID_REQUEST',
+					requestId,
+				});
+			}
+
+			// Get default symbols if not provided
+			const symbolsToAnalyze = allSymbols.length > 0
+				? allSymbols
+				: this.getDefaultSymbols();
+
+			console.info('[NewsMonitor] Analyzing symbols:', symbolsToAnalyze);
+			if (symbolsToAnalyze.length === 0) {
+				return res.status(400).json({
+					error: 'No symbols to analyze. Provide crypto/stocks or set env defaults.',
+					code: 'NO_SYMBOLS',
+					requestId,
+				});
+			}
+
+			const results = await sentryService.withSpan(
+				{
+					name: 'news_monitor.analyze_symbols',
+					op: 'news.analysis',
+					onlyIfParent: true,
+					attributes: {
+						'news.symbol_count': symbolsToAnalyze.length,
+						'news.request_id': requestId,
+					},
 				},
-			},
-			async () => {
-				try {
-					// Inject notification manager into analyzer (set once before analysis)
-					const notificationManager = getNotificationManager();
-					if (notificationManager) {
-						setNotificationManager(notificationManager);
-					}
+				() => this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage),
+			);
 
-					// Check feature flag
-					if (process.env.ENABLE_NEWS_MONITOR !== 'true') {
-						return res.status(403).json({
-							error: 'News monitor feature is disabled. Set ENABLE_NEWS_MONITOR=true to enable.',
-							code: 'FEATURE_DISABLED',
-							requestId,
-						});
-					}
+			const summary = this.generateSummary(results);
+			const response = {
+				success: summary.analyzed > 0 || summary.cached > 0,
+				partial_success: summary.timeout > 0 || summary.error > 0,
+				results,
+				summary,
+				totalDurationMs: Date.now() - startTime,
+				requestId,
+				tokenUsage: tokenUsage.toJSON(),
+			};
 
-					// Parse request
-					const { crypto, stocks } = this.parseRequest(req);
-					const allSymbols = [...(crypto || []), ...(stocks || [])];
-					const validationError = this.validateRequest(allSymbols);
-					if (validationError) {
-						return res.status(400).json({
-							error: validationError,
-							code: 'INVALID_REQUEST',
-							requestId,
-						});
-					}
+			if (!response.partial_success) {
+				delete response.partial_success;
+			}
 
-					// Get default symbols if not provided
-					const symbolsToAnalyze = allSymbols.length > 0
-						? allSymbols
-						: this.getDefaultSymbols();
+			console.info('[NewsMonitor] Request complete', {
+				requestId,
+				totalMs: response.totalDurationMs,
+				summary,
+			});
 
-					console.info('[NewsMonitor] Analyzing symbols:', symbolsToAnalyze);
-					if (symbolsToAnalyze.length === 0) {
-						return res.status(400).json({
-							error: 'No symbols to analyze. Provide crypto/stocks or set env defaults.',
-							code: 'NO_SYMBOLS',
-							requestId,
-						});
-					}
+			return res.status(200).json(response);
+		} catch (error) {
+			console.error('[NewsMonitor] Unexpected error:', error);
 
-					// Run analysis
-					const results = await sentryService.withSpan(
-						{
-							name: 'news_monitor.analyze_symbols',
-							op: 'news.analysis',
-							onlyIfParent: true,
-							attributes: {
-								'news.symbol_count': symbolsToAnalyze.length,
-								'news.request_id': requestId,
-							},
-						},
-						() => this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage),
-					);
+			// Capture runtime error to Sentry (T013) - only for 500 errors
+			sentryService.captureRuntimeError({
+				channel: 'news-monitor',
+				error,
+				http: {
+					endpoint: '/api/news-monitor',
+					method: req.method,
+					statusCode: 500,
+					requestId,
+					featureFlagState: {
+						ENABLE_NEWS_MONITOR: process.env.ENABLE_NEWS_MONITOR === 'true',
+					},
+				},
+			});
 
-					// Generate summary
-					const summary = this.generateSummary(results);
-
-					// Build response
-					const response = {
-						success: summary.analyzed > 0 || summary.cached > 0,
-						partial_success: summary.timeout > 0 || summary.error > 0,
-						results,
-						summary,
-						totalDurationMs: Date.now() - startTime,
-						requestId,
-						tokenUsage: tokenUsage.toJSON(),
-					};
-
-					// Remove partial_success if all succeeded
-					if (!response.partial_success) {
-						delete response.partial_success;
-					}
-
-					console.info('[NewsMonitor] Request complete', {
-						requestId,
-						totalMs: response.totalDurationMs,
-						summary,
-					});
-
-					return res.status(200).json(response);
-				} catch (error) {
-					console.error('[NewsMonitor] Unexpected error:', error);
-
-					// Capture runtime error to Sentry (T013) - only for 500 errors
-					sentryService.captureRuntimeError({
-						channel: 'news-monitor',
-						error,
-						http: {
-							endpoint: '/api/news-monitor',
-							method: req.method,
-							statusCode: 500,
-							requestId,
-							featureFlagState: {
-								ENABLE_NEWS_MONITOR: process.env.ENABLE_NEWS_MONITOR === 'true',
-							},
-						},
-					});
-
-					return res.status(500).json({
-						error: 'Internal server error. Please try again later.',
-						code: 'INTERNAL_ERROR',
-						requestId,
-					});
-				}
-			},
-		);
+			return res.status(500).json({
+				error: 'Internal server error. Please try again later.',
+				code: 'INTERNAL_ERROR',
+				requestId,
+			});
+		}
 	}
 
 	/**

--- a/src/services/monitoring/SentryService.js
+++ b/src/services/monitoring/SentryService.js
@@ -80,6 +80,7 @@ const Sentry = require('@sentry/node');
  * @property {string} [release]
  * @property {boolean} sendAlertContent - Whether to include full alert/news text in events
  * @property {number} sampleRateErrors - Error sample rate (0.0-1.0)
+ * @property {number|undefined} tracesSampleRate - Trace sample rate (0.0-1.0), undefined disables tracing
  * @property {string[]} consoleLogLevels - Console levels captured as Sentry Logs
  */
 
@@ -204,12 +205,49 @@ class SentryService {
 	}
 
 	/**
+	 * Parse a mandatory sample rate value with fallback
+	 * @param {string|undefined} value
+	 * @param {number|undefined} fallback
+	 * @returns {number|undefined}
+	 */
+	_parseSampleRate(value, fallback) {
+		const parsed = Number.parseFloat(value);
+		if (!Number.isFinite(parsed)) {
+			return fallback;
+		}
+
+		if (parsed < 0) {
+			return 0;
+		}
+
+		if (parsed > 1) {
+			return 1;
+		}
+
+		return parsed;
+	}
+
+	/**
+	 * Parse an optional sample rate value
+	 * @param {string|undefined} value
+	 * @returns {number|undefined}
+	 */
+	_parseOptionalSampleRate(value) {
+		if (value === undefined || value === null || String(value).trim() === '') {
+			return undefined;
+		}
+
+		return this._parseSampleRate(value, undefined);
+	}
+
+	/**
 	 * Build monitoring configuration from environment variables
 	 * @returns {MonitoringConfiguration}
 	 */
 	_buildConfiguration() {
 		const dsn = process.env.SENTRY_DSN || undefined;
 		const enabled = process.env.ENABLE_SENTRY === 'true' && !!dsn;
+		const tracesSampleRate = this._parseOptionalSampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE);
 
 		// Default sendAlertContent to true
 		return {
@@ -218,7 +256,8 @@ class SentryService {
 			environment: this._deriveEnvironment(),
 			release: this._deriveRelease(),
 			sendAlertContent: process.env.SENTRY_SEND_ALERT_CONTENT !== 'false',
-			sampleRateErrors: parseFloat(process.env.SENTRY_SAMPLE_RATE_ERRORS) || 1.0,
+			sampleRateErrors: this._parseSampleRate(process.env.SENTRY_SAMPLE_RATE_ERRORS, 1.0),
+			tracesSampleRate,
 			consoleLogLevels: this._parseConsoleLogLevels(),
 		};
 	}
@@ -246,8 +285,8 @@ class SentryService {
 				return;
 			}
 
-			// Initialize Sentry SDK
-			Sentry.init({
+			/** @type {import('@sentry/node').NodeOptions} */
+			const initOptions = {
 				dsn: this.config.dsn,
 				environment: this.config.environment,
 				release: this.config.release,
@@ -255,8 +294,6 @@ class SentryService {
 				sendDefaultPii: true,
 				// Enable Sentry Logs and forward high-severity console output as searchable logs.
 				enableLogs: true,
-				// Disable tracing/performance for this feature (FR-010)
-				tracesSampleRate: 0,
 
 				// Configure process-level error capture (FR-002)
 				integrations: (integrations) => {
@@ -272,7 +309,15 @@ class SentryService {
 					// Can be used for additional filtering or modification
 					return event;
 				},
-			});
+			};
+
+			// Per Sentry docs, tracing is fully disabled when tracesSampleRate/tracesSampler is not defined.
+			if (this.config.tracesSampleRate !== undefined) {
+				initOptions.tracesSampleRate = this.config.tracesSampleRate;
+			}
+
+			// Initialize Sentry SDK
+			Sentry.init(initOptions);
 
 			this.state = {
 				configured: true,
@@ -302,6 +347,14 @@ class SentryService {
 	}
 
 	/**
+	 * Check if trace capture is enabled
+	 * @returns {boolean}
+	 */
+	isTracingEnabled() {
+		return this.state.enabled && !!this.config && this.config.tracesSampleRate !== undefined;
+	}
+
+	/**
 	 * Get current service state (for testing and health checks)
 	 * @returns {MonitoringServiceState}
 	 */
@@ -315,6 +368,72 @@ class SentryService {
 	 */
 	getConfig() {
 		return this.config ? { ...this.config } : null;
+	}
+
+	/**
+	 * Execute callback within a Sentry span
+	 * @template T
+	 * @param {import('@sentry/node').StartSpanOptions} options
+	 * @param {(span?: import('@sentry/node').Span) => T} callback
+	 * @returns {T}
+	 */
+	withSpan(options, callback) {
+		if (typeof callback !== 'function') {
+			throw new Error('withSpan callback must be a function');
+		}
+
+		// If tracing is disabled or options are incomplete, run callback directly
+		if (!this.isTracingEnabled() || !options || !options.name) {
+			return callback();
+		}
+
+		let callbackHasStarted = false;
+		try {
+			return Sentry.startSpan(options, (span) => {
+				callbackHasStarted = true;
+				return callback(span);
+			});
+		} catch (error) {
+			// Preserve original control flow if callback itself throws
+			if (callbackHasStarted) {
+				throw error;
+			}
+
+			console.warn(`[SentryService] Failed to start span "${options.name}": ${error.message}`);
+			return callback();
+		}
+	}
+
+	/**
+	 * Execute callback within a manually controlled Sentry span
+	 * @template T
+	 * @param {import('@sentry/node').StartSpanOptions} options
+	 * @param {(span?: import('@sentry/node').Span) => T} callback
+	 * @returns {T}
+	 */
+	withManualSpan(options, callback) {
+		if (typeof callback !== 'function') {
+			throw new Error('withManualSpan callback must be a function');
+		}
+
+		if (!this.isTracingEnabled() || !options || !options.name) {
+			return callback();
+		}
+
+		let callbackHasStarted = false;
+		try {
+			return Sentry.startSpanManual(options, (span) => {
+				callbackHasStarted = true;
+				return callback(span);
+			});
+		} catch (error) {
+			if (callbackHasStarted) {
+				throw error;
+			}
+
+			console.warn(`[SentryService] Failed to start manual span "${options.name}": ${error.message}`);
+			return callback();
+		}
 	}
 
 	/**

--- a/src/services/monitoring/SentryService.js
+++ b/src/services/monitoring/SentryService.js
@@ -371,6 +371,23 @@ class SentryService {
 	}
 
 	/**
+	 * Get the current active Sentry span
+	 * @returns {import('@sentry/node').Span|undefined}
+	 */
+	getActiveSpan() {
+		if (!this.isTracingEnabled()) {
+			return undefined;
+		}
+
+		try {
+			return Sentry.getActiveSpan();
+		} catch (error) {
+			console.warn('[SentryService] Failed to get active span:', error.message);
+			return undefined;
+		}
+	}
+
+	/**
 	 * Start an inactive Sentry span for explicit lifecycle management
 	 * @param {import('@sentry/node').StartSpanOptions} options
 	 * @returns {import('@sentry/node').Span|null}

--- a/src/services/monitoring/SentryService.js
+++ b/src/services/monitoring/SentryService.js
@@ -371,6 +371,65 @@ class SentryService {
 	}
 
 	/**
+	 * Start an inactive Sentry span for explicit lifecycle management
+	 * @param {import('@sentry/node').StartSpanOptions} options
+	 * @returns {import('@sentry/node').Span|null}
+	 */
+	startInactiveSpan(options) {
+		if (!this.isTracingEnabled() || !options || !options.name) {
+			return null;
+		}
+
+		try {
+			return Sentry.startInactiveSpan(options);
+		} catch (error) {
+			console.warn(`[SentryService] Failed to start inactive span "${options.name}": ${error.message}`);
+			return null;
+		}
+	}
+
+	/**
+	 * Run code with the provided span as the active span
+	 * @template T
+	 * @param {import('@sentry/node').Span|null|undefined} span
+	 * @param {() => T} callback
+	 * @returns {T}
+	 */
+	withActiveSpan(span, callback) {
+		if (typeof callback !== 'function') {
+			throw new Error('withActiveSpan callback must be a function');
+		}
+
+		if (!this.isTracingEnabled() || !span) {
+			return callback();
+		}
+
+		try {
+			return Sentry.withActiveSpan(span, callback);
+		} catch (error) {
+			console.warn('[SentryService] Failed to activate span:', error.message);
+			return callback();
+		}
+	}
+
+	/**
+	 * End a span safely
+	 * @param {import('@sentry/node').Span|null|undefined} span
+	 * @returns {void}
+	 */
+	endSpan(span) {
+		if (!span || typeof span.end !== 'function') {
+			return;
+		}
+
+		try {
+			span.end();
+		} catch (error) {
+			console.warn('[SentryService] Failed to end span:', error.message);
+		}
+	}
+
+	/**
 	 * Execute callback within a Sentry span
 	 * @template T
 	 * @param {import('@sentry/node').StartSpanOptions} options

--- a/src/services/notification/NotificationManager.js
+++ b/src/services/notification/NotificationManager.js
@@ -63,33 +63,48 @@ class NotificationManager {
 		}
 
 		console.debug('[NotificationManager] Sending alert to', enabledChannels.length, 'enabled channel(s):', enabledChannels.map(ch => ch.name).join(', '));
-		const sendPromises = enabledChannels.map((ch) => sentryService.withSpan(
-			{
-				name: `notification.send.${ch.name}`,
-				op: 'notification.send',
-				onlyIfParent: true,
-				attributes: {
-					'notification.channel': ch.name,
-					'alert.enriched': !!(alert && alert.enriched),
-					'alert.length': alert && alert.text ? alert.text.length : 0,
-				},
+		const dispatchSpan = sentryService.startInactiveSpan({
+			name: 'notification.send_to_all',
+			op: 'notification.dispatch',
+			onlyIfParent: true,
+			attributes: {
+				'notification.enabled_channels_count': enabledChannels.length,
+				'notification.enabled_channels': enabledChannels.map(ch => ch.name).join(','),
+				'alert.enriched': !!(alert && alert.enriched),
 			},
-			() => ch.send(alert),
-		));
+		});
 
-		const results = await sentryService.withSpan(
-			{
-				name: 'notification.send_to_all',
-				op: 'notification.dispatch',
-				onlyIfParent: true,
-				attributes: {
-					'notification.enabled_channels_count': enabledChannels.length,
-					'notification.enabled_channels': enabledChannels.map(ch => ch.name).join(','),
-					'alert.enriched': !!(alert && alert.enriched),
-				},
-			},
-			() => Promise.allSettled(sendPromises),
-		);
+		let results;
+		try {
+			const sendPromises = enabledChannels.map((ch) => {
+				const sendSpanOptions = {
+					name: `notification.send.${ch.name}`,
+					op: 'notification.send',
+					onlyIfParent: true,
+					attributes: {
+						'notification.channel': ch.name,
+						'alert.enriched': !!(alert && alert.enriched),
+						'alert.length': alert && alert.text ? alert.text.length : 0,
+					},
+				};
+
+				if (dispatchSpan) {
+					sendSpanOptions.parentSpan = dispatchSpan;
+				}
+
+				const sendSpan = sentryService.startInactiveSpan(sendSpanOptions);
+
+				return Promise.resolve(
+					sentryService.withActiveSpan(sendSpan, () => ch.send(alert)),
+				).finally(() => {
+					sentryService.endSpan(sendSpan);
+				});
+			});
+
+			results = await Promise.allSettled(sendPromises);
+		} finally {
+			sentryService.endSpan(dispatchSpan);
+		}
 
 		const formattedResults = results.map((r, idx) =>
 			r.status === 'fulfilled'

--- a/src/services/notification/NotificationManager.js
+++ b/src/services/notification/NotificationManager.js
@@ -63,8 +63,33 @@ class NotificationManager {
 		}
 
 		console.debug('[NotificationManager] Sending alert to', enabledChannels.length, 'enabled channel(s):', enabledChannels.map(ch => ch.name).join(', '));
-		const sendPromises = enabledChannels.map((ch) => ch.send(alert));
-		const results = await Promise.allSettled(sendPromises);
+		const sendPromises = enabledChannels.map((ch) => sentryService.withSpan(
+			{
+				name: `notification.send.${ch.name}`,
+				op: 'notification.send',
+				onlyIfParent: true,
+				attributes: {
+					'notification.channel': ch.name,
+					'alert.enriched': !!(alert && alert.enriched),
+					'alert.length': alert && alert.text ? alert.text.length : 0,
+				},
+			},
+			() => ch.send(alert),
+		));
+
+		const results = await sentryService.withSpan(
+			{
+				name: 'notification.send_to_all',
+				op: 'notification.dispatch',
+				onlyIfParent: true,
+				attributes: {
+					'notification.enabled_channels_count': enabledChannels.length,
+					'notification.enabled_channels': enabledChannels.map(ch => ch.name).join(','),
+					'alert.enriched': !!(alert && alert.enriched),
+				},
+			},
+			() => Promise.allSettled(sendPromises),
+		);
 
 		const formattedResults = results.map((r, idx) =>
 			r.status === 'fulfilled'

--- a/src/services/notification/NotificationManager.js
+++ b/src/services/notification/NotificationManager.js
@@ -53,9 +53,10 @@ class NotificationManager {
    * @param {Object} alert - Alert object with text and optional enriched content
    * @returns {Promise<Array>} Array of SendResult objects (one per enabled channel)
    */
-	async sendToAll(alert) {
+	async sendToAll(alert, options = {}) {
 		const enabledChannels = Array.from(this.channels.values()).filter((ch) => ch.isEnabled());
 		const startTime = Date.now();
+		const { parentSpan } = options;
 
 		if (enabledChannels.length === 0) {
 			console.warn('[NotificationManager] No notification channels enabled');
@@ -67,6 +68,7 @@ class NotificationManager {
 			name: 'notification.send_to_all',
 			op: 'notification.dispatch',
 			onlyIfParent: true,
+			parentSpan,
 			attributes: {
 				'notification.enabled_channels_count': enabledChannels.length,
 				'notification.enabled_channels': enabledChannels.map(ch => ch.name).join(','),
@@ -77,28 +79,23 @@ class NotificationManager {
 		let results;
 		try {
 			const sendPromises = enabledChannels.map((ch) => {
-				const sendSpanOptions = {
+				const sendSpan = sentryService.startInactiveSpan({
 					name: `notification.send.${ch.name}`,
 					op: 'notification.send',
 					onlyIfParent: true,
+					parentSpan: dispatchSpan,
 					attributes: {
 						'notification.channel': ch.name,
 						'alert.enriched': !!(alert && alert.enriched),
 						'alert.length': alert && alert.text ? alert.text.length : 0,
 					},
-				};
-
-				if (dispatchSpan) {
-					sendSpanOptions.parentSpan = dispatchSpan;
-				}
-
-				const sendSpan = sentryService.startInactiveSpan(sendSpanOptions);
-
-				return Promise.resolve(
-					sentryService.withActiveSpan(sendSpan, () => ch.send(alert)),
-				).finally(() => {
-					sentryService.endSpan(sendSpan);
 				});
+
+				return Promise.resolve()
+					.then(() => ch.send(alert))
+					.finally(() => {
+						sentryService.endSpan(sendSpan);
+					});
 			});
 
 			results = await Promise.allSettled(sendPromises);

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -52,6 +52,7 @@ jest.mock('@sentry/node', () => ({
 	startSpan: jest.fn((_options, callback) => callback(createMockSpan())),
 	startSpanManual: jest.fn((_options, callback) => callback(createMockSpan())),
 	startInactiveSpan: jest.fn(() => createMockSpan()),
+	getActiveSpan: jest.fn(() => createMockSpan()),
 	withActiveSpan: jest.fn((_span, callback) => callback()),
 	captureException: jest.fn(() => 'mock-event-id'),
 	captureMessage: jest.fn(() => 'mock-event-id'),

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -42,6 +42,18 @@ jest.mock('@sentry/node', () => ({
 	init: jest.fn(),
 	consoleIntegration: jest.fn(() => 'console-breadcrumb-integration'),
 	consoleLoggingIntegration: jest.fn(() => 'console-logging-integration'),
+	startSpan: jest.fn((_options, callback) => callback({
+		end: jest.fn(),
+		setAttribute: jest.fn(),
+		setStatus: jest.fn(),
+		setHttpStatus: jest.fn(),
+	})),
+	startSpanManual: jest.fn((_options, callback) => callback({
+		end: jest.fn(),
+		setAttribute: jest.fn(),
+		setStatus: jest.fn(),
+		setHttpStatus: jest.fn(),
+	})),
 	captureException: jest.fn(() => 'mock-event-id'),
 	captureMessage: jest.fn(() => 'mock-event-id'),
 	flush: jest.fn().mockResolvedValue(true),

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -38,22 +38,21 @@ global.bot = {
 };
 
 // Mock @sentry/node globally to prevent real network calls
+const createMockSpan = () => ({
+	end: jest.fn(),
+	setAttribute: jest.fn(),
+	setStatus: jest.fn(),
+	setHttpStatus: jest.fn(),
+});
+
 jest.mock('@sentry/node', () => ({
 	init: jest.fn(),
 	consoleIntegration: jest.fn(() => 'console-breadcrumb-integration'),
 	consoleLoggingIntegration: jest.fn(() => 'console-logging-integration'),
-	startSpan: jest.fn((_options, callback) => callback({
-		end: jest.fn(),
-		setAttribute: jest.fn(),
-		setStatus: jest.fn(),
-		setHttpStatus: jest.fn(),
-	})),
-	startSpanManual: jest.fn((_options, callback) => callback({
-		end: jest.fn(),
-		setAttribute: jest.fn(),
-		setStatus: jest.fn(),
-		setHttpStatus: jest.fn(),
-	})),
+	startSpan: jest.fn((_options, callback) => callback(createMockSpan())),
+	startSpanManual: jest.fn((_options, callback) => callback(createMockSpan())),
+	startInactiveSpan: jest.fn(() => createMockSpan()),
+	withActiveSpan: jest.fn((_span, callback) => callback()),
 	captureException: jest.fn(() => 'mock-event-id'),
 	captureMessage: jest.fn(() => 'mock-event-id'),
 	flush: jest.fn().mockResolvedValue(true),

--- a/tests/unit/sentry-service.test.js
+++ b/tests/unit/sentry-service.test.js
@@ -669,6 +669,18 @@ describe('SentryService', () => {
 			);
 		});
 
+		it('should return active span when tracing is enabled', () => {
+			process.env.ENABLE_SENTRY = 'true';
+			process.env.SENTRY_DSN = 'https://key@sentry.io/123';
+			process.env.SENTRY_TRACES_SAMPLE_RATE = '1';
+			service.init();
+
+			const span = service.getActiveSpan();
+
+			expect(span).toBeDefined();
+			expect(Sentry.getActiveSpan).toHaveBeenCalledTimes(1);
+		});
+
 		it('should execute callback directly when withActiveSpan receives no span', () => {
 			process.env.ENABLE_SENTRY = 'true';
 			process.env.SENTRY_DSN = 'https://key@sentry.io/123';

--- a/tests/unit/sentry-service.test.js
+++ b/tests/unit/sentry-service.test.js
@@ -185,6 +185,36 @@ describe('SentryService', () => {
 				const config = service._buildConfiguration();
 				expect(config.sampleRateErrors).toBe(0.5);
 			});
+
+			it('should allow zero value from env', () => {
+				process.env.SENTRY_SAMPLE_RATE_ERRORS = '0';
+
+				const config = service._buildConfiguration();
+				expect(config.sampleRateErrors).toBe(0);
+			});
+		});
+
+		describe('tracesSampleRate', () => {
+			it('should be undefined when not configured', () => {
+				delete process.env.SENTRY_TRACES_SAMPLE_RATE;
+
+				const config = service._buildConfiguration();
+				expect(config.tracesSampleRate).toBeUndefined();
+			});
+
+			it('should parse traces sample rate from env', () => {
+				process.env.SENTRY_TRACES_SAMPLE_RATE = '0.25';
+
+				const config = service._buildConfiguration();
+				expect(config.tracesSampleRate).toBe(0.25);
+			});
+
+			it('should clamp traces sample rate above 1.0', () => {
+				process.env.SENTRY_TRACES_SAMPLE_RATE = '5';
+
+				const config = service._buildConfiguration();
+				expect(config.tracesSampleRate).toBe(1);
+			});
 		});
 
 		describe('console log levels', () => {
@@ -228,10 +258,23 @@ describe('SentryService', () => {
 			expect(Sentry.init).toHaveBeenCalledTimes(1);
 			expect(Sentry.init).toHaveBeenCalledWith(expect.objectContaining({
 				dsn: 'https://key@sentry.io/123',
-				tracesSampleRate: 0,
 			}));
+			const initOptions = Sentry.init.mock.calls[0][0];
+			expect(initOptions.tracesSampleRate).toBeUndefined();
 			expect(service.isEnabled()).toBe(true);
 			expect(service.getState().configured).toBe(true);
+		});
+
+		it('should initialize tracing when traces sample rate is configured', () => {
+			process.env.ENABLE_SENTRY = 'true';
+			process.env.SENTRY_DSN = 'https://key@sentry.io/123';
+			process.env.SENTRY_TRACES_SAMPLE_RATE = '0.2';
+
+			service.init();
+
+			const initOptions = Sentry.init.mock.calls[0][0];
+			expect(initOptions.tracesSampleRate).toBe(0.2);
+			expect(service.isTracingEnabled()).toBe(true);
 		});
 
 		it('should enable Sentry logs for console warn and error', () => {
@@ -596,6 +639,52 @@ describe('SentryService', () => {
 
 			await service.flush(3000);
 			expect(Sentry.flush).toHaveBeenCalledWith(3000);
+		});
+	});
+
+	describe('span helpers', () => {
+		it('should execute callback directly when tracing is disabled', () => {
+			process.env.ENABLE_SENTRY = 'true';
+			process.env.SENTRY_DSN = 'https://key@sentry.io/123';
+			delete process.env.SENTRY_TRACES_SAMPLE_RATE;
+			service.init();
+
+			const callback = jest.fn(() => 'ok');
+			const result = service.withSpan({ name: 'test-span' }, callback);
+
+			expect(result).toBe('ok');
+			expect(callback).toHaveBeenCalledTimes(1);
+			expect(Sentry.startSpan).not.toHaveBeenCalled();
+		});
+
+		it('should execute callback inside Sentry.startSpan when tracing is enabled', () => {
+			process.env.ENABLE_SENTRY = 'true';
+			process.env.SENTRY_DSN = 'https://key@sentry.io/123';
+			process.env.SENTRY_TRACES_SAMPLE_RATE = '1';
+			service.init();
+
+			const callback = jest.fn(() => 'ok');
+			const result = service.withSpan({ name: 'test-span', op: 'test' }, callback);
+
+			expect(result).toBe('ok');
+			expect(Sentry.startSpan).toHaveBeenCalledTimes(1);
+			expect(Sentry.startSpan).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'test-span', op: 'test' }),
+				expect.any(Function),
+			);
+		});
+
+		it('should execute callback inside Sentry.startSpanManual when tracing is enabled', () => {
+			process.env.ENABLE_SENTRY = 'true';
+			process.env.SENTRY_DSN = 'https://key@sentry.io/123';
+			process.env.SENTRY_TRACES_SAMPLE_RATE = '1';
+			service.init();
+
+			const callback = jest.fn(() => 'ok');
+			const result = service.withManualSpan({ name: 'test-span' }, callback);
+
+			expect(result).toBe('ok');
+			expect(Sentry.startSpanManual).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/tests/unit/sentry-service.test.js
+++ b/tests/unit/sentry-service.test.js
@@ -643,6 +643,69 @@ describe('SentryService', () => {
 	});
 
 	describe('span helpers', () => {
+		it('should return null from startInactiveSpan when tracing is disabled', () => {
+			process.env.ENABLE_SENTRY = 'true';
+			process.env.SENTRY_DSN = 'https://key@sentry.io/123';
+			delete process.env.SENTRY_TRACES_SAMPLE_RATE;
+			service.init();
+
+			const span = service.startInactiveSpan({ name: 'test-span' });
+
+			expect(span).toBeNull();
+			expect(Sentry.startInactiveSpan).not.toHaveBeenCalled();
+		});
+
+		it('should start inactive span when tracing is enabled', () => {
+			process.env.ENABLE_SENTRY = 'true';
+			process.env.SENTRY_DSN = 'https://key@sentry.io/123';
+			process.env.SENTRY_TRACES_SAMPLE_RATE = '1';
+			service.init();
+
+			const span = service.startInactiveSpan({ name: 'test-span', op: 'test' });
+
+			expect(span).toBeDefined();
+			expect(Sentry.startInactiveSpan).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'test-span', op: 'test' }),
+			);
+		});
+
+		it('should execute callback directly when withActiveSpan receives no span', () => {
+			process.env.ENABLE_SENTRY = 'true';
+			process.env.SENTRY_DSN = 'https://key@sentry.io/123';
+			process.env.SENTRY_TRACES_SAMPLE_RATE = '1';
+			service.init();
+
+			const callback = jest.fn(() => 'ok');
+			const result = service.withActiveSpan(null, callback);
+
+			expect(result).toBe('ok');
+			expect(callback).toHaveBeenCalledTimes(1);
+			expect(Sentry.withActiveSpan).not.toHaveBeenCalled();
+		});
+
+		it('should execute callback inside Sentry.withActiveSpan when tracing is enabled', () => {
+			process.env.ENABLE_SENTRY = 'true';
+			process.env.SENTRY_DSN = 'https://key@sentry.io/123';
+			process.env.SENTRY_TRACES_SAMPLE_RATE = '1';
+			service.init();
+
+			const span = service.startInactiveSpan({ name: 'test-span' });
+			const callback = jest.fn(() => 'ok');
+			const result = service.withActiveSpan(span, callback);
+
+			expect(result).toBe('ok');
+			expect(Sentry.withActiveSpan).toHaveBeenCalledTimes(1);
+			expect(Sentry.withActiveSpan).toHaveBeenCalledWith(span, expect.any(Function));
+		});
+
+		it('should end span safely', () => {
+			const span = { end: jest.fn() };
+
+			service.endSpan(span);
+
+			expect(span.end).toHaveBeenCalledTimes(1);
+		});
+
 		it('should execute callback directly when tracing is disabled', () => {
 			process.env.ENABLE_SENTRY = 'true';
 			process.env.SENTRY_DSN = 'https://key@sentry.io/123';


### PR DESCRIPTION
## Summary
- Adds Sentry tracing/span instrumentation to core bot flows, including command handling, webhook processing, price fetching, and notification delivery.
- Updates Sentry service initialization and test setup to support the new observability behavior.
- Refreshes project docs and env examples to reflect the monitoring configuration.

## Testing
- Added/updated unit coverage for `SentryService` behavior.
- Updated existing tests around command and webhook flows to validate tracing-aware execution paths.
- Not run (not requested)