### PR TITLE
ci: Align Render, CI, and docs with pnpm and Node 20

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,6 +16,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Setup Node.js 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: pnpm
     - name: Install pnpm
       uses: pnpm/action-setup@v3
       with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,15 +16,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v3
+      with:
+        version: 10 # Compatible with node 20.x
     - name: Setup Node.js 20
       uses: actions/setup-node@v4
       with:
         node-version: 20
         cache: pnpm
-    - name: Install pnpm
-      uses: pnpm/action-setup@v3
-      with:
-        version: 10 # Compatible with node 20.x
     - run: pnpm install --frozen-lockfile
     # - run: pnpm run build --if-present # No build step needed for this project, yet.
     - run: pnpm test

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 ### 1. Install Dependencies
 
 ```bash
-npm install
+pnpm install --frozen-lockfile
 ```
 
 ### 2. Create `.env` File
@@ -134,13 +134,13 @@ See [Environment Configuration](#environment-configuration) section below for de
 ### 3. Run Development Server
 
 ```bash
-npm run start-dev
+pnpm start-dev
 ```
 
 ### 4. Run Production Server
 
 ```bash
-npm start
+pnpm start
 ```
 
 ## API Endpoints
@@ -680,7 +680,7 @@ SENTRY_CONSOLE_LOG_LEVELS=warn,error
 3. Verify DSN format: `https://<key>@<org>.ingest.sentry.io/<project>`
 
 **Console warnings/errors not appearing in Sentry Logs**:
-1. Verify the installed `@sentry/node` version is `10.13.0` or newer
+1. Verify the installed `@sentry/node` version is `10.53.1` or newer
 2. Confirm Sentry initialized with `enableLogs: true`
 3. Confirm `SENTRY_CONSOLE_LOG_LEVELS` includes the level you are testing
 4. Check the Sentry Logs view, not only the Issues view
@@ -737,13 +737,13 @@ The system prevents alert fatigue using an intelligent cache:
 
 ```bash
 # Run all tests
-npm test
+pnpm test
 
 # Run with watch mode
-npm run test:watch
+pnpm test:watch
 
 # Generate coverage report
-npm run test:coverage
+pnpm test:coverage
 ```
 
 ## Architecture
@@ -923,7 +923,7 @@ The application includes support for Render.com deployment:
 
 ```bash
 # Start dev server with auto-reload
-npm run start-dev
+pnpm start-dev
 
 # Open ngrok tunnel for webhook testing
 ngrok http 80

--- a/render.yaml
+++ b/render.yaml
@@ -7,8 +7,8 @@ services:
   runtime: node
   repo: https://github.com/francovp/cabros-crypto-bot-telegram
   branch: master
-  buildCommand: npm install
-  startCommand: npm start
+  buildCommand: corepack enable && pnpm install --frozen-lockfile
+  startCommand: corepack enable && pnpm start
   healthCheckPath: /healthcheck
   pullRequestPreviewsEnabled: true
   envVars:


### PR DESCRIPTION
## Summary
- Switched Render deployment commands to `corepack` + `pnpm` so production matches the repo’s pnpm-only install flow.
- Pinned GitHub Actions CI to Node 20 and enabled pnpm caching to match the declared engine floor.
- Updated README setup, dev, test, and local run instructions to pnpm.
- Refreshed the Sentry troubleshooting note to match the currently pinned `@sentry/node` version.

## Testing
- Not run (not requested)

## Notes
- No package-lock drift was found; the lockfile already matched the declared dependency ranges.
- PR URL not available in this context.