### PR TITLE
fix: Telegram startup sequencing and alert route reinitialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const port = process.env.PORT || 80;
 const now = new Date();
 
 // Always mount routes (they gate access based on feature flags)
-app.use('/api', getRoutes());
+app.use('/api', getRoutes(() => bot));
 
 app.get('/debug-sentry', function mainHandler() {
 	throw new Error('Sentry debug test error!');
@@ -50,6 +50,7 @@ app.listen(port, async () => {
 		bot = new Telegraf(token);
 		bot.command(['precio'], getPrice);
 		bot.command(['cryptobot'], cryptoBotCmd);
+		await bot.launch();
 
 		// Initialize notification services
 		await initializeNotificationServices(bot);

--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ app.listen(port, async () => {
 		bot = new Telegraf(token);
 		bot.command(['precio'], getPrice);
 		bot.command(['cryptobot'], cryptoBotCmd);
-		await bot.launch();
 
 		// Initialize notification services
 		await initializeNotificationServices(bot);
@@ -58,6 +57,11 @@ app.listen(port, async () => {
 		// Enable graceful stop
 		process.once('SIGINT', () => bot.stop('SIGINT'));
 		process.once('SIGTERM', () => bot.stop('SIGTERM'));
+
+		// Start polling without blocking the rest of bootstrap.
+		void bot.launch().catch((error) => {
+			console.error('[index] Failed to launch Telegram bot:', error.message);
+		});
 
 		if (process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID !== undefined) {
 			console.log('Telegram Admin Notifications Chat ID:', process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID);

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -49,6 +49,14 @@ function getNotificationManager() {
 	return notificationManager;
 }
 
+function resolveBot(botOrGetter) {
+	if (typeof botOrGetter === 'function') {
+		return botOrGetter();
+	}
+
+	return botOrGetter || null;
+}
+
 async function processEnrichment(alert, options) {
 	const { tokenUsage, useTradingViewData, parentSpan } = options;
 	const isGeminiEnabled = process.env.ENABLE_GEMINI_GROUNDING === 'true';
@@ -91,7 +99,7 @@ async function processEnrichment(alert, options) {
 	return enriched;
 }
 
-function postAlert(bot) {
+function postAlert(botOrGetter) {
 	return async (req, res) => {
 		const { body } = req;
 		const useTradingViewData = req.query && (req.query.useTradingViewData === true || req.query.useTradingViewData === 'true');
@@ -101,8 +109,9 @@ function postAlert(bot) {
 
 		try {
 			const requestSpan = sentryService.getActiveSpan();
+			const bot = resolveBot(botOrGetter);
 			if (!notificationManager) {
-				await initializeNotificationServices(bot || null);
+				await initializeNotificationServices(bot);
 			}
 
 			if (typeof body === 'object' && 'text' in body) {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,9 +2,9 @@ const express = require('express');
 const { postAlert } = require('../controllers/webhooks/handlers/alert/alert');
 const { validateApiKey } = require('../lib/auth');
 
-function getRoutes() {
+function getRoutes(botOrGetter) {
 	const router = express.Router();
-	router.post('/webhook/alert', validateApiKey, postAlert());
+	router.post('/webhook/alert', validateApiKey, postAlert(botOrGetter));
 
 	const { getNewsMonitor } = require('../controllers/webhooks/handlers/newsMonitor/newsMonitor');
 	const newsMonitor = getNewsMonitor();


### PR DESCRIPTION
## Summary
- Restore Telegram bot startup so `initializeNotificationServices()` runs before long-polling blocks bootstrap.
- Keep the alert webhook able to recover a missing notification manager by wiring the live bot reference through route creation.
- Preserve the existing null-safe alert delivery flow while avoiding silent startup stalls.

## Testing
- Ran the targeted alert and Sentry integration suites covering webhook delivery and startup paths.
- Ran the full Jest suite; all tests passed.