### PR TITLE
feat: Migrate TradingView MCP client to the new schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,7 @@ LANGFUSE_PROMPT_CACHE_TTL_SECONDS=0
 ENABLE_TRADINGVIEW_MCP_ENRICHMENT=false
 
 # MCP server endpoint (Streamable HTTP)
-TRADINGVIEW_MCP_URL=http://localhost:8000/mcp
+TRADINGVIEW_MCP_URL=https://tradingview-mcp.onrender.com/mcp
 
 # Request timeout per MCP call in milliseconds
 TRADINGVIEW_MCP_TIMEOUT_MS=12000

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 #### TradingView MCP Enrichment
 
 - `ENABLE_TRADINGVIEW_MCP_ENRICHMENT` - Enable TradingView MCP enrichment for TradingView-like webhook messages (`true` or `false`, default: `false`)
-- `TRADINGVIEW_MCP_URL` - MCP server HTTP endpoint (default: `http://localhost:8000/mcp`)
+- `TRADINGVIEW_MCP_URL` - MCP server HTTP endpoint (default: `https://tradingview-mcp.onrender.com/mcp`)
 - `TRADINGVIEW_MCP_TIMEOUT_MS` - Timeout per MCP request in milliseconds (default: `12000`)
 - `TRADINGVIEW_MCP_MAX_RETRIES` - Retries for MCP failures (default: `3`)
 - `TRADINGVIEW_MCP_DEFAULT_EXCHANGE` - Default exchange when not present in signal (default: `BINANCE`)

--- a/src/services/tradingview/TradingViewMcpService.js
+++ b/src/services/tradingview/TradingViewMcpService.js
@@ -24,7 +24,7 @@ class TradingViewMcpService {
 		);
 
 		return {
-			url: this.config.url || process.env.TRADINGVIEW_MCP_URL || 'http://localhost:8000/mcp',
+			url: this.config.url || process.env.TRADINGVIEW_MCP_URL || 'https://tradingview-mcp.onrender.com/mcp',
 			timeoutMs,
 			maxRetries,
 			defaultExchange,
@@ -70,12 +70,17 @@ class TradingViewMcpService {
 			exchange,
 			timeframe,
 		});
+		const normalizedResult = this._unwrapSchemaResult(rpcResult);
 
-		if (rpcResult && rpcResult.error) {
-			throw new Error(rpcResult.error);
+		if (normalizedResult && normalizedResult.error) {
+			throw new Error(normalizedResult.error);
 		}
 
-		return rpcResult;
+		if (!normalizedResult || typeof normalizedResult !== 'object' || Array.isArray(normalizedResult)) {
+			throw new Error('TradingView MCP coin_analysis returned invalid payload');
+		}
+
+		return normalizedResult;
 	}
 
 	async _callTool(toolName, args = {}) {
@@ -126,6 +131,10 @@ class TradingViewMcpService {
 		if (callResult.isError) {
 			const errorMessage = this._extractContentText(callResult) || `TradingView MCP tool ${toolName} returned isError=true`;
 			throw new Error(errorMessage);
+		}
+
+		if (callResult.structuredContent && typeof callResult.structuredContent === 'object') {
+			return callResult.structuredContent;
 		}
 
 		const contentText = this._extractContentText(callResult);
@@ -264,31 +273,59 @@ class TradingViewMcpService {
 		const { side, symbol, exchange, timeframe } = signal;
 		const sideLabel = side === 'SELL' ? 'VENTA' : 'COMPRA';
 		const sideSentiment = side === 'SELL' ? -0.55 : 0.55;
-		const rating = this._safeNumber(analysis && analysis.bollinger_analysis && analysis.bollinger_analysis.rating, 0);
+		const priceData = (analysis && analysis.price_data) || {};
+		const indicators = (analysis && analysis.technical_indicators) || {};
+		const rsiData = (analysis && analysis.rsi) || {};
+		const adxData = (analysis && analysis.adx) || {};
+		const legacyBollinger = (analysis && analysis.bollinger_analysis) || {};
+		const bollingerBands = (analysis && analysis.bollinger_bands) || {};
+		const supportResistance = (analysis && analysis.support_resistance) || {};
+		const marketSentiment = (analysis && analysis.market_sentiment) || {};
+		const marketStructure = (analysis && analysis.market_structure) || {};
+		const timeframeContext = (analysis && analysis.timeframe_context) || {};
+
+		const rating = this._firstNumber([
+			marketSentiment.overall_rating,
+			marketStructure.trend_score,
+			legacyBollinger.rating,
+		], 0);
 		const ratingBias = Math.max(-0.35, Math.min(0.35, rating / 10));
 		const sentimentScore = Math.max(-1, Math.min(1, sideSentiment + ratingBias));
 		const sentiment = sentimentScore > 0.15 ? 'BULLISH' : sentimentScore < -0.15 ? 'BEARISH' : 'NEUTRAL';
 
-		const priceData = (analysis && analysis.price_data) || {};
-		const indicators = (analysis && analysis.technical_indicators) || {};
-		const bollinger = (analysis && analysis.bollinger_analysis) || {};
-		const marketSentiment = (analysis && analysis.market_sentiment) || {};
+		const rsiValue = this._firstNumber([rsiData.value, indicators.rsi], null);
+		const adxValue = this._firstNumber([adxData.value, indicators.adx], null);
+		const rsiSignal = rsiData.signal || indicators.rsi_signal || 'N/A';
+		const trendStrength = adxData.trend_strength || indicators.trend_strength || 'N/A';
+		const bollingerPosition = bollingerBands.position || legacyBollinger.position || 'N/A';
+		const momentumLabel = marketSentiment.momentum || marketSentiment.buy_sell_signal || marketStructure.trend || 'N/A';
+		const trendLabel = marketStructure.trend || timeframeContext.bias || 'N/A';
 
 		const supports = this._compactUnique([
-			this._formatLevel(bollinger.bb_lower),
+			this._formatLevel(supportResistance.nearest_support),
+			this._formatLevel(supportResistance.support_1),
+			this._formatLevel(supportResistance.support_2),
+			this._formatLevel(supportResistance.support_3),
+			this._formatLevel(bollingerBands.lower),
+			this._formatLevel(legacyBollinger.bb_lower),
 			this._formatLevel(priceData.low),
-		]);
+		]).slice(0, 4);
 
 		const resistances = this._compactUnique([
-			this._formatLevel(bollinger.bb_upper),
+			this._formatLevel(supportResistance.nearest_resistance),
+			this._formatLevel(supportResistance.resistance_1),
+			this._formatLevel(supportResistance.resistance_2),
+			this._formatLevel(supportResistance.resistance_3),
+			this._formatLevel(bollingerBands.upper),
+			this._formatLevel(legacyBollinger.bb_upper),
 			this._formatLevel(priceData.high),
-		]);
+		]).slice(0, 4);
 
 		const insights = this._compactUnique([
 			`Señal detectada: ${sideLabel} para ${symbol} en ${timeframe} (${exchange})`,
 			`Precio actual: ${this._formatLevel(priceData.current_price)} (${this._formatPercent(priceData.change_percent)})`,
-			`RSI ${this._formatLevel(indicators.rsi)} (${indicators.rsi_signal || 'N/A'}) · ADX ${this._formatLevel(indicators.adx)} (${indicators.trend_strength || 'N/A'})`,
-			`Bollinger rating ${rating} (${bollinger.position || 'N/A'}) · Momentum ${marketSentiment.momentum || 'N/A'}`,
+			`RSI ${this._formatLevel(rsiValue)} (${rsiSignal}) · ADX ${this._formatLevel(adxValue)} (${trendStrength})`,
+			`Tendencia ${trendLabel} · Bollinger ${bollingerPosition} · Momentum ${momentumLabel} · Rating ${rating}`,
 		]);
 
 		return {
@@ -341,6 +378,32 @@ class TradingViewMcpService {
 		}
 
 		return value;
+	}
+
+	_firstNumber(values = [], fallback = null) {
+		for (const value of values) {
+			if (typeof value === 'number' && !Number.isNaN(value)) {
+				return value;
+			}
+		}
+
+		return fallback;
+	}
+
+	_unwrapSchemaResult(result) {
+		if (!result || typeof result !== 'object' || Array.isArray(result)) {
+			return result;
+		}
+
+		const keys = Object.keys(result);
+		if (keys.length === 1 && Object.prototype.hasOwnProperty.call(result, 'result')) {
+			const innerResult = result.result;
+			if (innerResult && typeof innerResult === 'object' && !Array.isArray(innerResult)) {
+				return innerResult;
+			}
+		}
+
+		return result;
 	}
 
 	_nextRequestId(prefix) {

--- a/tests/unit/tradingview-mcp-service.test.js
+++ b/tests/unit/tradingview-mcp-service.test.js
@@ -7,7 +7,7 @@ describe('TradingViewMcpService', () => {
 		expect(result).toBeNull();
 	});
 
-	it('maps coin analysis into webhook enriched alert', async () => {
+	it('maps new coin_analysis schema into webhook enriched alert', async () => {
 		const service = new TradingViewMcpService({
 			maxRetries: 1,
 			defaultExchange: 'BINANCE',
@@ -22,19 +22,29 @@ describe('TradingViewMcpService', () => {
 				high: 64997.44,
 				low: 64828.62,
 			},
-			bollinger_analysis: {
-				rating: -3,
-				bb_upper: 69468.88,
-				bb_lower: 65664.11,
-				position: 'Below Lower',
+			bollinger_bands: {
+				upper: 69468.88,
+				lower: 65664.11,
+				position: 'Lower Half',
 			},
-			technical_indicators: {
-				rsi: 29.38,
-				rsi_signal: 'Oversold',
-				adx: 15.97,
+			rsi: {
+				value: 29.38,
+				signal: 'Oversold',
+			},
+			adx: {
+				value: 15.97,
 				trend_strength: 'Weak',
 			},
+			support_resistance: {
+				support_1: 64000.5,
+				resistance_1: 66000.2,
+			},
+			market_structure: {
+				trend: 'Bearish',
+				trend_score: -3,
+			},
 			market_sentiment: {
+				overall_rating: -2,
 				momentum: 'Bearish',
 			},
 		});
@@ -51,11 +61,60 @@ describe('TradingViewMcpService', () => {
 		}));
 		expect(result.insights.join(' ')).toContain('BTCUSDT');
 		expect(result.insights.join(' ')).toContain('4h');
+		expect(result.insights.join(' ')).toContain('Rating -2');
 		expect(result.extraText).toContain('tradingview-mcp');
 		expect(service.callCoinAnalysis).toHaveBeenCalledWith({
 			symbol: 'BTCUSDT',
 			exchange: 'BINANCE',
 			timeframe: '4h',
+		});
+	});
+
+	it('prefers structuredContent when MCP server returns schema-native tool results', async () => {
+		const service = new TradingViewMcpService({ logger: { warn: jest.fn(), error: jest.fn(), log: jest.fn() } });
+
+		service._rpcRequest = jest
+			.fn()
+			.mockResolvedValueOnce({ sessionId: 'test-session' })
+			.mockResolvedValueOnce({ status: 202 })
+			.mockResolvedValueOnce({
+				rpc: {
+					result: {
+						content: [{ type: 'text', text: 'non-json fallback text' }],
+						structuredContent: {
+							symbol: 'BINANCE:BTCUSDT',
+							price_data: { current_price: 70000 },
+						},
+						isError: false,
+					},
+				},
+			});
+
+		const result = await service._callTool('coin_analysis', { symbol: 'BTCUSDT' });
+		expect(result).toEqual({
+			symbol: 'BINANCE:BTCUSDT',
+			price_data: { current_price: 70000 },
+		});
+	});
+
+	it('unwraps schema result wrapper from coin_analysis payloads', async () => {
+		const service = new TradingViewMcpService({ logger: { warn: jest.fn(), error: jest.fn() } });
+		service._callTool = jest.fn().mockResolvedValue({
+			result: {
+				symbol: 'BINANCE:BTCUSDT',
+				price_data: { current_price: 71000 },
+			},
+		});
+
+		const result = await service.callCoinAnalysis({
+			symbol: 'BTCUSDT',
+			exchange: 'BINANCE',
+			timeframe: '4h',
+		});
+
+		expect(result).toEqual({
+			symbol: 'BINANCE:BTCUSDT',
+			price_data: { current_price: 71000 },
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Updates the TradingView MCP client to work with the new `coin_analysis` schema exposed by the remote server.
- Prefers `structuredContent` when the MCP server returns schema-native tool results, with fallback to legacy text JSON for compatibility.
- Normalizes enrichment mapping to the new response fields such as `rsi`, `adx`, `bollinger_bands`, `support_resistance`, and `market_structure`.
- Sets the TradingView MCP default endpoint to `https://tradingview-mcp.onrender.com/mcp` and updates the related config documentation.

## Testing
- Added unit coverage for the new schema mapping, `structuredContent` handling, and schema wrapper unwrapping.
- Ran the TradingView MCP unit tests, the alert handler unit tests, the TradingView MCP integration test, and the full test suite successfully.