### PR TITLE
fix: Gemini metrics tagging in LLM calls

### DIFF
--- a/src/services/grounding/genaiClient.js
+++ b/src/services/grounding/genaiClient.js
@@ -287,6 +287,7 @@ class GenaiClient {
 				// Previous calls were like: prompt = `${systemPrompt}\n\n${userPrompt}`.
 				const startTime = Date.now();
 				const combinedPrompt = `${systemPrompt}\n\n${userPrompt}`;
+				const modelUsed = opts.model || GEMINI_MODEL_NAME || GEMINI_MODEL_NAME_FALLBACK;
 				console.debug('[GenaiClient] Attempting Gemini LLM call');
 				const response = await this.llmCall({
 					prompt: combinedPrompt,
@@ -294,11 +295,16 @@ class GenaiClient {
 					opts,
 				});
 				const durationMs = Date.now() - startTime;
-				sentryService.captureLlmMetric({ model: response.modelUsed, inputTokens: response.usage?.inputTokens || 0, outputTokens: response.usage?.outputTokens || 0, durationMs });
+				sentryService.captureLlmMetric({
+					model: modelUsed,
+					inputTokens: response.usage?.inputTokens || 0,
+					outputTokens: response.usage?.outputTokens || 0,
+					durationMs,
+				});
 
 				return {
 					...response,
-					modelUsed: opts.model || GEMINI_MODEL_NAME || GEMINI_MODEL_NAME_FALLBACK,
+					modelUsed,
 				};
 			} catch (error) {
 				console.warn('[GenaiClient] Gemini call failed, attempting failover:', error.message);

--- a/tests/unit/genaiClient.test.js
+++ b/tests/unit/genaiClient.test.js
@@ -14,6 +14,7 @@ jest.mock('../../src/services/grounding/config', () => ({
 }));
 
 const genaiClient = require('../../src/services/grounding/genaiClient');
+const sentryService = require('../../src/services/monitoring/SentryService');
 
 // Mock fetch globally
 global.fetch = jest.fn();
@@ -183,6 +184,34 @@ describe('GenaiClient robustness', () => {
 			const out = await genaiClient.llmCall({ prompt: 'p' });
 			expect(out.text).toBe('');
 			expect(out.citations).toEqual([]);
+		});
+	});
+
+	describe('llmCallv2 metrics', () => {
+		it('captures Gemini metrics with the resolved model name', async () => {
+			const captureSpy = jest.spyOn(sentryService, 'captureLlmMetric').mockImplementation(() => {});
+			genaiClient.llmCall = jest.fn().mockResolvedValue({
+				text: 'llm response',
+				citations: [],
+				usage: {
+					inputTokens: 12,
+					outputTokens: 34,
+				},
+			});
+
+			const out = await genaiClient.llmCallv2({
+				systemPrompt: 'system',
+				userPrompt: 'user',
+			});
+
+			expect(out.modelUsed).toBe('test-gemini-model');
+			expect(captureSpy).toHaveBeenCalledWith(expect.objectContaining({
+				model: 'test-gemini-model',
+				inputTokens: 12,
+				outputTokens: 34,
+				durationMs: expect.any(Number),
+			}));
+			captureSpy.mockRestore();
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Fixes Gemini LLM metric emission so Sentry tags the resolved model name instead of an undefined value
- Keeps the returned `modelUsed` value aligned with the metric tag for Gemini calls
- Adds a regression test to lock the metrics contract in place

## Testing
- Added unit coverage for `llmCallv2()` to verify Gemini metrics use the resolved model name
- Existing recent TradingView, Telegram, and storage test suites remained green in local validation