### PR TITLE
feat: implement combined analysis upgrade for expanded alert

### DIFF
--- a/context/feat-combined-analysis-expanded-alert.md
+++ b/context/feat-combined-analysis-expanded-alert.md
@@ -1,0 +1,123 @@
+## Summary
+
+Implement Feature 4: "Combined Analysis Upgrade for Expanded Alert" to optionally request combined technical indicators, Reddit sentiment, RSS financial news, and confluence recommendations from the TradingView MCP server, broadcasting a comprehensive formatted Spanish report to Telegram and WhatsApp.
+
+## Key Changes
+
+### 📡 POST /api/webhook/expanded-analysis-alert
+
+- Enhanced parameters parsing to accept `"analysisMode": "combined"` (defaults to `"standard"`).
+- Forwarded parameter to the symbol analysis execution flow.
+
+### 📊 Spanish Report Formatter
+
+- Modified `buildReportRow` to extract indicators nested in `technical` objects returned by the `combined_analysis` tool.
+- Extended the group row formatting in Spanish:
+  - **Sentimiento Reddit**: Translates sentiment labels (Alcista/Bajista/Neutral), outputs sentiment scores, posts analyzed, and displays matching emojis (🐂/🐻/😐).
+  - **Confluencia**: Formats the final recommendation actions (e.g. `🟢 STRONG BUY`, `🔴 SELL`) and alerts on signal alignments.
+  - **Últimas Noticias**: Lists up to 3 news headlines, extracting and displaying clear domain/publisher names as sources (e.g., `(bloomberg.com)`).
+
+### 🔌 MCP Combined Analysis Wrapper
+
+- Exposed the `callCombinedAnalysis({ symbol, exchange, timeframe, signal })` service method in `TradingViewMcpService.js` to call the `combined_analysis` tool.
+
+---
+
+## Technical Implementation
+
+### Architecture changes
+
+Updated request parsing, analysis routing, and Spanish formatting logic to support the new `combined_analysis` tool integration.
+
+#### TradingViewMcpService
+
+- Routes request to `callCombinedAnalysis` vs `callCoinAnalysis` based on `analysisMode`.
+
+#### expandedAnalysisAlertReport
+
+- Handles parameter validation and checks for nested technical payloads.
+- Constructs multi-layered formatting blocks for Reddit sentiment, confluence, and news headlines.
+
+### Dependencies Added
+
+- None.
+
+### File Structure Additions
+
+```text
+docs/antigravity/7052c381-6c81-4b22-92f1-c783f2c674c5/
+├── implementation_plan.md
+├── task.md
+└── walkthrough.md
+```
+
+## Testing infrastructure
+
+### Test Suite
+
+- **1 Unit Test** (inside `tradingview-mcp-service.test.js` for routing)
+- **1 Unit Test** (inside `tradingview-mcp-service.test.js` for combined analysis wrapper)
+- **3 Unit Tests** (inside `expanded-analysis-alert-report.test.js` for request validation)
+- **1 Unit Test** (inside `expanded-analysis-alert-report.test.js` for combined report Spanish formatting)
+- **1 Integration Test** (inside `expanded-analysis-alert-endpoint.test.js` for end-to-end webhook execution and reporting)
+
+### Test Coverage
+
+- `analysisMode` request validation parsing.
+- Service tool selection routing.
+- Spanish formatting translation and structure of Reddit sentiment, confluence indicators, and RSS news headlines.
+- Webhook JSON payload routing and integration mock testing.
+
+### Test Files
+
+- `tests/unit/tradingview-mcp-service.test.js`
+- `tests/unit/expanded-analysis-alert-report.test.js`
+- `tests/integration/expanded-analysis-alert-endpoint.test.js`
+
+## Configuration Updates
+
+### Environment Variables
+
+No new environment variables added.
+
+## Documentation Updates
+
+- **Walkthrough**: Added implementation walkthrough and testing results.
+
+## Examples
+
+Example JSON response body for combined mode:
+```json
+{
+  "success": true,
+  "alertText": "📊 *ANÁLISIS AMPLIADO — Friday 22/05/2026*\n...\n*🟢 TOP GANADORES*\nBTCUSDT $68,450.20 (+1.2%) | RSI 55.4\n- *Tendencia (SMA20):* Alcista | *MACD:* Bullish\n- *Volumen:* Normal | *ATR:* $120.50\n- *Stop Loss sugerido:* $68,269.45\n- *Sugerencia:* MANTENER / ACUMULAR\n- *Sentimiento Reddit:* 🐂 Alcista (Score: 0.45, 12 posts)\n- *Confluencia:* 🟢 STRONG BUY · Señales Alineadas ✅ (Confianza: high)\n- *Últimas Noticias:*\n  • Bitcoin surges past 68k (CoinDesk)",
+  "results": [
+    {
+      "symbol": "BINANCE:BTCUSDT",
+      "status": "analyzed",
+      "price": 68450.2,
+      "rsi": 55.4
+    }
+  ]
+}
+```
+
+## Testing
+
+### Pre-merge Verification
+
+- [x] Run `npm test -- tests/unit/tradingview-mcp-service.test.js tests/unit/expanded-analysis-alert-report.test.js tests/integration/expanded-analysis-alert-endpoint.test.js`
+- [x] Run `npm test` to verify no regressions (495 tests passed)
+
+### Post-merge Verification
+
+- [ ] Execute `POST /api/webhook/expanded-analysis-alert` with `"analysisMode": "combined"` and verify formatted Telegram/WhatsApp channels receive sentiment, confluence, and news details.
+
+---
+
+**Review Checklist:**
+
+- [x] Code quality meets project standards
+- [x] All tests pass and coverage is maintained
+- [x] Documentation is complete and accurate
+- [x] Breaking change assessment completed

--- a/docs/antigravity/7052c381-6c81-4b22-92f1-c783f2c674c5/implementation_plan.md
+++ b/docs/antigravity/7052c381-6c81-4b22-92f1-c783f2c674c5/implementation_plan.md
@@ -1,0 +1,54 @@
+# Combined Analysis Upgrade for Expanded Alert
+
+Enhance the `/api/webhook/expanded-analysis-alert` webhook to optionally request a combined analysis (integrating technical indicators, Reddit sentiment, RSS financial news, and confluence recommendation) from the TradingView MCP server when `analysisMode: "combined"` is provided in the request body.
+
+## User Review Required
+
+> [!IMPORTANT]
+> **API Parameter Gating**: The new mode is requested by passing `"analysisMode": "combined"` in the JSON request body (defaults to `"standard"` for backward compatibility).
+> **Aesthetic Spanish Format**: Reddit sentiment shows translated labels (Alcista/Bajista/Neutral) with emojis (🐂/🐻/😐) and posts count. Confluence recommendation shows clear labels (e.g., `🟢 STRONG BUY`, `🔴 SELL`) and signals alignment. Latest RSS news headlines display up to 3 articles with source publishers without rendering broken URLs.
+> **Fail-Open Strategy**: Like other integrations, if the `combined_analysis` MCP tool call fails or times out, the webhook will log a warning and proceed without blocking alert delivery.
+
+## Open Questions
+
+None. The requirements for parameter routing, Spanish translation, and formatting are clear and aligned with existing code patterns.
+
+## Proposed Changes
+
+### TradingView MCP Service
+
+#### [MODIFY] [TradingViewMcpService.js](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/src/services/tradingview/TradingViewMcpService.js)
+- Add `callCombinedAnalysis({ symbol, exchange, timeframe, signal })` to invoke the remote MCP tool `combined_analysis`.
+- Update `analyzeSymbolIdentifier` to accept an optional `analysisMode` parameter and select the correct analysis function (`callCombinedAnalysis` vs `callCoinAnalysis`).
+
+---
+
+### Expanded Analysis Alert Formatting and Validation
+
+#### [MODIFY] [expandedAnalysisAlertReport.js](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/src/services/tradingview/expandedAnalysisAlertReport.js)
+- In `parseExpandedAnalysisAlertRequest`, validate that `analysisMode` (if provided) is a string and either `"standard"` or `"combined"`. Default to `"standard"`.
+- Update `buildReportRow` to extract `price_data`, `technical_indicators`, `rsi`, `bollinger_bands`, etc. from the nested `analysis.technical` object when it is present (as returned by `combined_analysis`), fell back to `analysis` for backward compatibility.
+- Extract `sentiment`, `confluence`, and `news` from the combined analysis payload.
+- Update `formatGroupRows` to append Reddit sentiment summary, confluence recommendation (with emojis), and latest RSS news headlines (up to 3 articles with titles and sources, e.g. `(CoinDesk)`) in Spanish.
+
+---
+
+### Expanded Analysis Alert Controller
+
+#### [MODIFY] [expandedAnalysisAlert.js](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js)
+- Pass `analysisMode` from the parsed request down to `analyzeSymbols` and `analyzeSymbolIdentifier`.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+
+- **Unit Tests**:
+  - Update `tests/unit/tradingview-mcp-service.test.js` to verify `callCombinedAnalysis` invokes the remote tool and handles the payload correctly.
+  - Update `tests/unit/expanded-analysis-alert-report.test.js` to test `parseExpandedAnalysisAlertRequest` validates `analysisMode` correctly, and `buildExpandedAnalysisAlertReport` correctly formats Reddit sentiment, confluence recommendations, and RSS news headlines.
+- **Integration Tests**:
+  - Update `tests/integration/expanded-analysis-alert-endpoint.test.js` to mock `combined_analysis` tool responses and verify the endpoint responds with the formatted report.
+
+Run tests using:
+`npm test -- tests/unit/tradingview-mcp-service.test.js tests/unit/expanded-analysis-alert-report.test.js tests/integration/expanded-analysis-alert-endpoint.test.js`

--- a/docs/antigravity/7052c381-6c81-4b22-92f1-c783f2c674c5/task.md
+++ b/docs/antigravity/7052c381-6c81-4b22-92f1-c783f2c674c5/task.md
@@ -1,0 +1,9 @@
+# Checklist - Feature 4: Combined Analysis Upgrade
+
+- [x] Expose `callCombinedAnalysis` in `TradingViewMcpService.js` and support `analysisMode` routing in `analyzeSymbolIdentifier`
+- [x] Add `analysisMode` request validation/defaults to `parseExpandedAnalysisAlertRequest` in `expandedAnalysisAlertReport.js`
+- [x] Update `buildReportRow` to extract indicators from nested `analysis.technical` (from `combined_analysis` response)
+- [x] Extend formatting in `expandedAnalysisAlertReport.js` to output Reddit sentiment, confluence recommendation, and RSS headlines in Spanish
+- [x] Update the controller `expandedAnalysisAlert.js` to forward `analysisMode`
+- [x] Add unit and integration tests for validation, formatting, and endpoint execution
+- [x] Verify everything works and run tests

--- a/docs/antigravity/7052c381-6c81-4b22-92f1-c783f2c674c5/walkthrough.md
+++ b/docs/antigravity/7052c381-6c81-4b22-92f1-c783f2c674c5/walkthrough.md
@@ -1,0 +1,57 @@
+# Walkthrough - Feature 4: Combined Analysis Upgrade
+
+Implemented support for requesting and formatting combined technical, sentiment, news, and confluence reports from the TradingView MCP server.
+
+## Changes Made
+
+### 1. Service Layer
+- **[TradingViewMcpService.js](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/src/services/tradingview/TradingViewMcpService.js)**:
+  - Added the `callCombinedAnalysis({ symbol, exchange, timeframe, signal })` wrapper method to invoke the remote MCP tool `combined_analysis`.
+  - Updated `analyzeSymbolIdentifier` to accept `analysisMode` and select either `callCombinedAnalysis` or `callCoinAnalysis`.
+
+### 2. Request Parsing and Report Formatting
+- **[expandedAnalysisAlertReport.js](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/src/services/tradingview/expandedAnalysisAlertReport.js)**:
+  - Updated request parsing to validate and extract `analysisMode` (with values `"standard"` or `"combined"`, default `"standard"`).
+  - Updated `buildReportRow` to extract nested indicators under `analysis.technical` when processing the `combined_analysis` response structure.
+  - Added logic to capture Reddit sentiment data, RSS news headlines, and confluence recommendations.
+  - Created Spanish formatting functions:
+    - `formatRedditSentiment`: displays a friendly sentiment label translated to Spanish, alongside sentiment score, posts analyzed, and custom bull/bear emojis (🐂/🐻/😐).
+    - `formatConfluence`: formats overall confluence recommendation action (e.g. `🟢 STRONG BUY`, `🔴 SELL`) and alignment validation.
+    - `formatNewsSection`: lists up to 3 news headlines from RSS feeds and cleanly extracts publisher source names from URLs (e.g., `(bloomberg.com)`).
+
+### 3. Controller
+- **[expandedAnalysisAlert.js](file:///Users/fgvaleriop/repositorios/cabros-crypto-bot-telegram/src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js)**:
+  - Updated `analyzeSymbols` to forward the `analysisMode` parameter to `TradingViewMcpService`.
+
+---
+
+## Verification Results
+
+### Automated Tests
+
+1. **Unit Tests**:
+   - Verified request validation of `analysisMode` and default value behaviors.
+   - Verified that `TradingViewMcpService` routes calls correctly to `combined_analysis` RPC.
+   - Verified that Spanish report formatting translates sentiment labels, formats confluence emojis, and renders headlines with sources correctly.
+
+2. **Integration Tests**:
+   - Verified the end-to-end endpoint `POST /api/webhook/expanded-analysis-alert` handles the new `analysisMode: "combined"` payload and returns formatted content in the `alertText` response.
+
+All unit and integration test suites run successfully:
+```bash
+npm test -- tests/unit/tradingview-mcp-service.test.js tests/unit/expanded-analysis-alert-report.test.js tests/integration/expanded-analysis-alert-endpoint.test.js
+```
+Output:
+```
+PASS tests/unit/expanded-analysis-alert-report.test.js
+PASS tests/integration/expanded-analysis-alert-endpoint.test.js
+PASS tests/unit/tradingview-mcp-service.test.js
+
+Test Suites: 3 passed, 3 total
+Tests:       41 passed, 41 total
+```
+The entire test suite also ran and passed:
+```
+Test Suites: 41 passed, 41 total
+Tests:       495 passed, 495 total
+```

--- a/src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js
+++ b/src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js
@@ -118,7 +118,7 @@ function postExpandedAnalysisAlert(botOrGetter) {
 	};
 }
 
-async function analyzeSymbols({ symbols, timeframe, includeMultiTimeframe }, options = {}) {
+async function analyzeSymbols({ symbols, timeframe, includeMultiTimeframe, analysisMode }, options = {}) {
 	const { signal } = options;
 	const results = [];
 
@@ -133,6 +133,7 @@ async function analyzeSymbols({ symbols, timeframe, includeMultiTimeframe }, opt
 			const analysisRequest = {
 				...input,
 				timeframe,
+				analysisMode,
 			};
 			if (signal) {
 				analysisRequest.signal = signal;

--- a/src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js
+++ b/src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js
@@ -203,15 +203,17 @@ function compactResults(results) {
 			};
 		}
 
+		const technicalAnalysis = result.analysis && result.analysis.technical
+			? result.analysis.technical
+			: result.analysis || {};
+		const priceData = technicalAnalysis.price_data || {};
+		const indicators = technicalAnalysis.technical_indicators || {};
+
 		return {
 			symbol: result.symbol,
 			status: result.status,
-			price: result.analysis && result.analysis.price_data
-				? result.analysis.price_data.current_price ?? result.analysis.price_data.close
-				: undefined,
-			rsi: result.analysis
-				? result.analysis.technical_indicators?.rsi ?? result.analysis.rsi?.value
-				: undefined,
+			price: priceData.current_price ?? priceData.close,
+			rsi: indicators.rsi ?? technicalAnalysis.rsi?.value,
 			multiTimeframe: result.multiTimeframe ? 'success' : undefined,
 		};
 	});

--- a/src/services/tradingview/TradingViewMcpService.js
+++ b/src/services/tradingview/TradingViewMcpService.js
@@ -125,9 +125,8 @@ class TradingViewMcpService {
 	}
 
 	async callCombinedAnalysis({ symbol, exchange, timeframe, signal }) {
-		const fullSymbol = symbol.includes(':') ? symbol : `${exchange}:${symbol}`;
 		const rpcResult = await this._callTool('combined_analysis', {
-			symbol: fullSymbol,
+			symbol,
 			exchange,
 			timeframe,
 		}, { signal });

--- a/src/services/tradingview/TradingViewMcpService.js
+++ b/src/services/tradingview/TradingViewMcpService.js
@@ -96,11 +96,16 @@ class TradingViewMcpService {
 		return normalizedResult;
 	}
 
-	async analyzeSymbolIdentifier({ raw, exchange, symbol, timeframe, signal }) {
+	async analyzeSymbolIdentifier({ raw, exchange, symbol, timeframe, analysisMode, signal }) {
 		const cfg = this.getConfig();
 		const result = await sendWithRetry(async () => {
 			try {
-				const analysis = await this.callCoinAnalysis({ symbol, exchange, timeframe, signal });
+				let analysis;
+				if (analysisMode === 'combined') {
+					analysis = await this.callCombinedAnalysis({ symbol, exchange, timeframe, signal });
+				} else {
+					analysis = await this.callCoinAnalysis({ symbol, exchange, timeframe, signal });
+				}
 				return { success: true, channel: 'tradingview-mcp', analysis };
 			} catch (error) {
 				return { success: false, channel: 'tradingview-mcp', error: error.message };
@@ -117,6 +122,26 @@ class TradingViewMcpService {
 			requested_exchange: exchange,
 			requested_timeframe: timeframe,
 		};
+	}
+
+	async callCombinedAnalysis({ symbol, exchange, timeframe, signal }) {
+		const fullSymbol = symbol.includes(':') ? symbol : `${exchange}:${symbol}`;
+		const rpcResult = await this._callTool('combined_analysis', {
+			symbol: fullSymbol,
+			exchange,
+			timeframe,
+		}, { signal });
+		const normalizedResult = this._unwrapSchemaResult(rpcResult);
+
+		if (normalizedResult && normalizedResult.error) {
+			throw new Error(normalizedResult.error);
+		}
+
+		if (!normalizedResult || typeof normalizedResult !== 'object' || Array.isArray(normalizedResult)) {
+			throw new Error('TradingView MCP combined_analysis returned invalid payload');
+		}
+
+		return normalizedResult;
 	}
 
 	async callMultiTimeframeAnalysis({ symbol, exchange, signal }) {

--- a/src/services/tradingview/expandedAnalysisAlertReport.js
+++ b/src/services/tradingview/expandedAnalysisAlertReport.js
@@ -39,6 +39,7 @@ function parseExpandedAnalysisAlertRequest(req = {}) {
 	validateTimeframeType(body);
 	const timeframe = parseTimeframe(body.timeframe);
 	const includeMultiTimeframe = parseIncludeMultiTimeframe(body);
+	const analysisMode = parseAnalysisMode(body);
 
 	if (symbols.length === 0) {
 		throw new ExpandedAnalysisAlertRequestError(
@@ -51,7 +52,7 @@ function parseExpandedAnalysisAlertRequest(req = {}) {
 		throw new ExpandedAnalysisAlertRequestError(`Too many symbols requested (max: ${MAX_SYMBOLS})`);
 	}
 
-	return { symbols, timeframe, includeMultiTimeframe };
+	return { symbols, timeframe, includeMultiTimeframe, analysisMode };
 }
 
 function parseIncludeMultiTimeframe(body = {}) {
@@ -68,6 +69,21 @@ function parseIncludeMultiTimeframe(body = {}) {
 		throw new ExpandedAnalysisAlertRequestError('includeMultiTimeframe must be a boolean');
 	}
 	return val;
+}
+
+function parseAnalysisMode(body = {}) {
+	const val = body.analysisMode !== undefined ? body.analysisMode : body.analysis_mode;
+	if (val === undefined || val === null) {
+		return 'standard';
+	}
+	if (typeof val !== 'string') {
+		throw new ExpandedAnalysisAlertRequestError('analysisMode must be a string');
+	}
+	const normalized = val.trim().toLowerCase();
+	if (normalized !== 'standard' && normalized !== 'combined') {
+		throw new ExpandedAnalysisAlertRequestError('analysisMode must be either "standard" or "combined"');
+	}
+	return normalized;
 }
 
 function getRequestBody(req = {}) {
@@ -178,24 +194,29 @@ function buildExpandedAnalysisAlertReport(items = [], options = {}) {
 }
 
 function buildReportRow({ input = {}, analysis = {}, multiTimeframe }) {
-	const priceData = analysis.price_data || {};
-	const indicators = analysis.technical_indicators || {};
-	const bollinger = analysis.bollinger_analysis || {};
-	const currentBollinger = analysis.bollinger_bands || {};
+	const techData = analysis.technical || analysis || {};
+	const priceData = techData.price_data || {};
+	const indicators = techData.technical_indicators || {};
+	const bollinger = techData.bollinger_analysis || {};
+	const currentBollinger = techData.bollinger_bands || {};
 	const price = numberOrNull(priceData.current_price ?? priceData.close);
 	const changePercent = numberOrNull(priceData.change_percent);
-	const rsi = numberOrNull(indicators.rsi ?? analysis.rsi?.value);
-	const sma20 = numberOrNull(indicators.sma20 ?? bollinger.bb_middle ?? analysis.sma?.sma20 ?? currentBollinger.middle);
-	const macd = numberOrNull(indicators.macd ?? analysis.macd?.macd_line);
-	const macdSignal = numberOrNull(indicators.macd_signal ?? analysis.macd?.signal_line);
-	const atr = numberOrNull(indicators.atr ?? analysis.atr?.value ?? analysis.atr ?? analysis.volatility?.atr);
+	const rsi = numberOrNull(indicators.rsi ?? techData.rsi?.value);
+	const sma20 = numberOrNull(indicators.sma20 ?? bollinger.bb_middle ?? techData.sma?.sma20 ?? currentBollinger.middle);
+	const macd = numberOrNull(indicators.macd ?? techData.macd?.macd_line);
+	const macdSignal = numberOrNull(indicators.macd_signal ?? techData.macd?.signal_line);
+	const atr = numberOrNull(indicators.atr ?? techData.atr?.value ?? techData.atr ?? techData.volatility?.atr);
 	const trend = getTrend(price, sma20);
 	const macdDirection = getMacdDirection(macd, macdSignal);
-	const volume = getVolumeLabel(analysis);
+	const volume = getVolumeLabel(techData);
 	const stopLoss = getStopLoss(price, atr, bollinger, currentBollinger);
 
+	const sentiment = analysis.sentiment || null;
+	const confluence = analysis.confluence || null;
+	const news = analysis.news || null;
+
 	return {
-		symbol: input.symbol || stripExchange(analysis.symbol) || 'UNKNOWN',
+		symbol: input.symbol || stripExchange(techData.symbol) || 'UNKNOWN',
 		price,
 		changePercent,
 		rsi,
@@ -206,6 +227,9 @@ function buildReportRow({ input = {}, analysis = {}, multiTimeframe }) {
 		stopLoss,
 		suggestion: getSuggestion({ rsi, trend, macdDirection }),
 		multiTimeframe,
+		sentiment,
+		confluence,
+		news,
 	};
 }
 
@@ -223,6 +247,27 @@ function formatGroupRows(rows) {
 			`- *Sugerencia:* ${row.suggestion}`,
 		];
 
+		if (row.sentiment) {
+			const sentText = formatRedditSentiment(row.sentiment);
+			if (sentText) {
+				lines.push(sentText);
+			}
+		}
+
+		if (row.confluence) {
+			const confText = formatConfluence(row.confluence);
+			if (confText) {
+				lines.push(confText);
+			}
+		}
+
+		if (row.news) {
+			const newsText = formatNewsSection(row.news);
+			if (newsText) {
+				lines.push(newsText);
+			}
+		}
+
 		if (row.multiTimeframe) {
 			lines.push(formatMultiTimeframeSection(row.multiTimeframe));
 		}
@@ -233,6 +278,73 @@ function formatGroupRows(rows) {
 
 		return lines;
 	});
+}
+
+function formatRedditSentiment(sentiment) {
+	if (!sentiment) return null;
+	const label = translateSentimentLabel(sentiment.sentiment_label || sentiment.label);
+	const score = typeof sentiment.sentiment_score === 'number' ? sentiment.sentiment_score : (sentiment.score ?? 0);
+	const posts = sentiment.posts_analyzed ?? sentiment.posts ?? 0;
+
+	let emoji = '😐';
+	if (score > 0.15 || label.toLowerCase() === 'alcista') emoji = '🐂';
+	else if (score < -0.15 || label.toLowerCase() === 'bajista') emoji = '🐻';
+
+	return `- *Sentimiento Reddit:* ${emoji} ${label} (Score: ${score.toFixed(2)}, ${posts} posts)`;
+}
+
+function translateSentimentLabel(label) {
+	if (!label) return 'Neutral';
+	const lower = String(label).toLowerCase().trim();
+	if (lower === 'bullish' || lower === 'alcista') return 'Alcista';
+	if (lower === 'bearish' || lower === 'bajista') return 'Bajista';
+	if (lower === 'neutral') return 'Neutral';
+	return label;
+}
+
+function formatConfluence(confluence) {
+	if (!confluence) return null;
+	const rec = formatRecommendation(confluence.recommendation || confluence.action || 'N/A');
+	const confidence = confluence.confidence || 'N/A';
+	const agree = confluence.signals_agree === true || String(confluence.signals_agree).toLowerCase() === 'yes';
+	const agreeText = agree ? ' · Señales Alineadas ✅' : '';
+	return `- *Confluencia:* ${rec}${agreeText} (Confianza: ${confidence})`;
+}
+
+function formatRecommendation(rec) {
+	if (!rec) return 'N/A';
+	const upper = String(rec).toUpperCase().trim();
+	if (upper.includes('STRONG BUY')) return '🟢 STRONG BUY';
+	if (upper.includes('BUY')) return '🟢 BUY';
+	if (upper.includes('STRONG SELL')) return '🔴 STRONG SELL';
+	if (upper.includes('SELL')) return '🔴 SELL';
+	if (upper.includes('HOLD') || upper.includes('NEUTRAL')) return '🟡 HOLD';
+	return rec;
+}
+
+function formatNewsSection(news) {
+	if (!news || !Array.isArray(news.latest) || news.latest.length === 0) {
+		return null;
+	}
+
+	const articles = news.latest.slice(0, 3);
+	const lines = ['- *Últimas Noticias:*'];
+	articles.forEach(art => {
+		const title = art.title || 'Noticia';
+		let source = art.source || art.publisher || '';
+		if (!source && art.url) {
+			try {
+				const urlObj = new URL(art.url);
+				source = urlObj.hostname.replace('www.', '');
+			} catch {
+				source = '';
+			}
+		}
+		const sourceText = source ? ` (${source})` : '';
+		lines.push(`  • ${title}${sourceText}`);
+	});
+
+	return lines.join('\n');
 }
 
 function formatMultiTimeframeSection(mtf) {

--- a/tests/integration/expanded-analysis-alert-endpoint.test.js
+++ b/tests/integration/expanded-analysis-alert-endpoint.test.js
@@ -459,6 +459,12 @@ describe('Expanded Analysis Alert endpoint', () => {
 		expect(res.body.alertText).toContain('- *Confluencia:* 🟢 STRONG BUY · Señales Alineadas ✅ (Confianza: high)');
 		expect(res.body.alertText).toContain('- *Últimas Noticias:*');
 		expect(res.body.alertText).toContain('  • Bitcoin surges past 68k (CoinDesk)');
+		expect(res.body.results[0]).toEqual(expect.objectContaining({
+			symbol: 'BINANCE:BTCUSDT',
+			status: 'analyzed',
+			price: 68450.2,
+			rsi: 55.4,
+		}));
 		expect(tradingViewMcpService.analyzeSymbolIdentifier).toHaveBeenCalledWith(expect.objectContaining({
 			raw: 'BINANCE:BTCUSDT',
 			exchange: 'BINANCE',

--- a/tests/integration/expanded-analysis-alert-endpoint.test.js
+++ b/tests/integration/expanded-analysis-alert-endpoint.test.js
@@ -413,4 +413,58 @@ describe('Expanded Analysis Alert endpoint', () => {
 		expect(res.body.success).toBe(true);
 		expect(tradingViewMcpService.callMultiTimeframeAnalysis).not.toHaveBeenCalled();
 	});
+
+	it('generates a combined analysis report, sends it, and returns delivery results when analysisMode is combined', async () => {
+		tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValueOnce({
+			technical: {
+				price_data: {
+					current_price: 68450.2,
+					change_percent: 1.2,
+					volume: 70213090,
+				},
+				technical_indicators: {
+					rsi: 55.4,
+					sma20: 67000.0,
+					macd: 6.1,
+					macd_signal: 7.2,
+					atr: 120.5,
+				},
+			},
+			sentiment: {
+				sentiment_label: 'Bullish',
+				sentiment_score: 0.45,
+				posts_analyzed: 12,
+			},
+			confluence: {
+				recommendation: 'STRONG BUY',
+				confidence: 'high',
+				signals_agree: true,
+			},
+			news: {
+				latest: [
+					{ title: 'Bitcoin surges past 68k', url: 'https://coindesk.com/btc', source: 'CoinDesk' }
+				],
+			},
+		});
+
+		const res = await request(app)
+			.post('/api/webhook/expanded-analysis-alert')
+			.set('x-api-key', 'test-key')
+			.send({ symbols: ['BINANCE:BTCUSDT'], timeframe: '1D', analysisMode: 'combined' })
+			.expect(200);
+
+		expect(res.body.success).toBe(true);
+		expect(res.body.alertText).toContain('BTCUSDT $68,450.20 (+1.2%) | RSI 55.4');
+		expect(res.body.alertText).toContain('- *Sentimiento Reddit:* 🐂 Alcista (Score: 0.45, 12 posts)');
+		expect(res.body.alertText).toContain('- *Confluencia:* 🟢 STRONG BUY · Señales Alineadas ✅ (Confianza: high)');
+		expect(res.body.alertText).toContain('- *Últimas Noticias:*');
+		expect(res.body.alertText).toContain('  • Bitcoin surges past 68k (CoinDesk)');
+		expect(tradingViewMcpService.analyzeSymbolIdentifier).toHaveBeenCalledWith(expect.objectContaining({
+			raw: 'BINANCE:BTCUSDT',
+			exchange: 'BINANCE',
+			symbol: 'BTCUSDT',
+			timeframe: '1D',
+			analysisMode: 'combined',
+		}));
+	});
 });

--- a/tests/unit/expanded-analysis-alert-report.test.js
+++ b/tests/unit/expanded-analysis-alert-report.test.js
@@ -31,6 +31,7 @@ describe('Expanded Analysis Alert report', () => {
 			],
 			timeframe: '1D',
 			includeMultiTimeframe: false,
+			analysisMode: 'standard',
 		});
 	});
 
@@ -227,6 +228,90 @@ describe('Expanded Analysis Alert report', () => {
 			expect(report).toContain('• *Diario (1D):* Bajista (RSI 42.4)');
 			expect(report).toContain('• *Confluencia:* MIXED (Confianza: Low)');
 			expect(report).toContain('• *Recomendación:* HOLD');
+		});
+	});
+
+	describe('analysisMode request validation', () => {
+		it('parses analysisMode and analysis_mode correctly', () => {
+			const parsed1 = parseExpandedAnalysisAlertRequest({
+				body: {
+					symbols: ['BINANCE:BTCUSDT'],
+					analysisMode: 'combined',
+				},
+			});
+			expect(parsed1.analysisMode).toBe('combined');
+
+			const parsed2 = parseExpandedAnalysisAlertRequest({
+				body: {
+					symbols: ['BINANCE:BTCUSDT'],
+					analysis_mode: 'standard',
+				},
+			});
+			expect(parsed2.analysisMode).toBe('standard');
+
+			const parsed3 = parseExpandedAnalysisAlertRequest({
+				body: {
+					symbols: ['BINANCE:BTCUSDT'],
+				},
+			});
+			expect(parsed3.analysisMode).toBe('standard');
+		});
+
+		it('throws request error if analysisMode is not a string', () => {
+			expect(() => parseExpandedAnalysisAlertRequest({
+				body: {
+					symbols: ['BINANCE:BTCUSDT'],
+					analysisMode: true,
+				},
+			})).toThrow('analysisMode must be a string');
+		});
+
+		it('throws request error if analysisMode is invalid value', () => {
+			expect(() => parseExpandedAnalysisAlertRequest({
+				body: {
+					symbols: ['BINANCE:BTCUSDT'],
+					analysisMode: 'invalid_mode',
+				},
+			})).toThrow('analysisMode must be either "standard" or "combined"');
+		});
+	});
+
+	describe('combined analysis report formatting', () => {
+		it('formats the report with Reddit sentiment, confluence, and news correctly', () => {
+			const report = buildExpandedAnalysisAlertReport([
+				{
+					input: { raw: 'BINANCE:BTCUSDT', exchange: 'BINANCE', symbol: 'BTCUSDT' },
+					analysis: {
+						technical: {
+							price_data: { current_price: 68000, change_percent: 1.5 },
+							technical_indicators: { rsi: 50 },
+						},
+						sentiment: {
+							sentiment_label: 'Bullish',
+							sentiment_score: 0.45,
+							posts_analyzed: 12,
+						},
+						confluence: {
+							recommendation: 'STRONG BUY',
+							confidence: 'high',
+							signals_agree: true,
+						},
+						news: {
+							latest: [
+								{ title: 'Bitcoin surges past 68k', url: 'https://coindesk.com/btc', source: 'CoinDesk' },
+								{ title: 'Crypto market gains momentum', url: 'https://bloomberg.com/crypto' },
+							],
+						},
+					},
+				},
+			], { now: new Date('2026-05-22T12:00:00Z') });
+
+			expect(report).toContain('BTCUSDT $68,000.00 (+1.5%) | RSI 50.0');
+			expect(report).toContain('- *Sentimiento Reddit:* 🐂 Alcista (Score: 0.45, 12 posts)');
+			expect(report).toContain('- *Confluencia:* 🟢 STRONG BUY · Señales Alineadas ✅ (Confianza: high)');
+			expect(report).toContain('- *Últimas Noticias:*');
+			expect(report).toContain('  • Bitcoin surges past 68k (CoinDesk)');
+			expect(report).toContain('  • Crypto market gains momentum (bloomberg.com)');
 		});
 	});
 });

--- a/tests/unit/tradingview-mcp-service.test.js
+++ b/tests/unit/tradingview-mcp-service.test.js
@@ -191,4 +191,64 @@ describe('TradingViewMcpService', () => {
 		const rpc = service._decodeRpcBody(body, 'text/event-stream', 'abc');
 		expect(rpc).toEqual({ jsonrpc: '2.0', id: 'abc', result: { ok: true } });
 	});
+
+	it('calls combined_analysis tool and unwraps result in callCombinedAnalysis', async () => {
+		const service = new TradingViewMcpService({ logger: { warn: jest.fn(), error: jest.fn() } });
+		service._callTool = jest.fn().mockResolvedValue({
+			result: {
+				technical: { price_data: { current_price: 65000 } },
+				sentiment: { score: 0.8 },
+				news: { latest: [] },
+			},
+		});
+
+		const result = await service.callCombinedAnalysis({
+			symbol: 'BTCUSDT',
+			exchange: 'BINANCE',
+			timeframe: '1h',
+		});
+
+		expect(service._callTool).toHaveBeenCalledWith('combined_analysis', {
+			symbol: 'BINANCE:BTCUSDT',
+			exchange: 'BINANCE',
+			timeframe: '1h',
+		}, expect.anything());
+		expect(result).toEqual({
+			technical: { price_data: { current_price: 65000 } },
+			sentiment: { score: 0.8 },
+			news: { latest: [] },
+		});
+	});
+
+	it('routes to callCombinedAnalysis in analyzeSymbolIdentifier when analysisMode is combined', async () => {
+		const service = new TradingViewMcpService({
+			maxRetries: 1,
+			logger: { warn: jest.fn(), error: jest.fn(), log: jest.fn() },
+		});
+		service.callCombinedAnalysis = jest.fn().mockResolvedValue({
+			technical: { price_data: { current_price: 65000 } },
+			sentiment: { score: 0.8 },
+		});
+		service.callCoinAnalysis = jest.fn();
+
+		const result = await service.analyzeSymbolIdentifier({
+			raw: 'BINANCE:BTCUSDT',
+			exchange: 'BINANCE',
+			symbol: 'BTCUSDT',
+			timeframe: '1h',
+			analysisMode: 'combined',
+		});
+
+		expect(service.callCombinedAnalysis).toHaveBeenCalledWith(expect.objectContaining({
+			symbol: 'BTCUSDT',
+			exchange: 'BINANCE',
+			timeframe: '1h',
+		}));
+		expect(service.callCoinAnalysis).not.toHaveBeenCalled();
+		expect(result).toEqual(expect.objectContaining({
+			requested_symbol: 'BINANCE:BTCUSDT',
+			technical: { price_data: { current_price: 65000 } },
+			sentiment: { score: 0.8 },
+		}));
+	});
 });

--- a/tests/unit/tradingview-mcp-service.test.js
+++ b/tests/unit/tradingview-mcp-service.test.js
@@ -209,7 +209,7 @@ describe('TradingViewMcpService', () => {
 		});
 
 		expect(service._callTool).toHaveBeenCalledWith('combined_analysis', {
-			symbol: 'BINANCE:BTCUSDT',
+			symbol: 'BTCUSDT',
 			exchange: 'BINANCE',
 			timeframe: '1h',
 		}, expect.anything());


### PR DESCRIPTION
## Summary

Implement Feature 4: "Combined Analysis Upgrade for Expanded Alert" to optionally request combined technical indicators, Reddit sentiment, RSS financial news, and confluence recommendations from the TradingView MCP server, broadcasting a comprehensive formatted Spanish report to Telegram and WhatsApp.

## Key Changes

### 📡 POST /api/webhook/expanded-analysis-alert

- Enhanced parameters parsing to accept `"analysisMode": "combined"` (defaults to `"standard"`).
- Forwarded parameter to the symbol analysis execution flow.

### 📊 Spanish Report Formatter

- Modified `buildReportRow` to extract indicators nested in `technical` objects returned by the `combined_analysis` tool.
- Extended the group row formatting in Spanish:
  - **Sentimiento Reddit**: Translates sentiment labels (Alcista/Bajista/Neutral), outputs sentiment scores, posts analyzed, and displays matching emojis (🐂/🐻/😐).
  - **Confluencia**: Formats the final recommendation actions (e.g. `🟢 STRONG BUY`, `🔴 SELL`) and alerts on signal alignments.
  - **Últimas Noticias**: Lists up to 3 news headlines, extracting and displaying clear domain/publisher names as sources (e.g., `(bloomberg.com)`).

### 🔌 MCP Combined Analysis Wrapper

- Exposed the `callCombinedAnalysis({ symbol, exchange, timeframe, signal })` service method in `TradingViewMcpService.js` to call the `combined_analysis` tool.

---

## Technical Implementation

### Architecture changes

Updated request parsing, analysis routing, and Spanish formatting logic to support the new `combined_analysis` tool integration.

#### TradingViewMcpService

- Routes request to `callCombinedAnalysis` vs `callCoinAnalysis` based on `analysisMode`.

#### expandedAnalysisAlertReport

- Handles parameter validation and checks for nested technical payloads.
- Constructs multi-layered formatting blocks for Reddit sentiment, confluence, and news headlines.

### Dependencies Added

- None.

### File Structure Additions

```text
docs/antigravity/7052c381-6c81-4b22-92f1-c783f2c674c5/
├── implementation_plan.md
├── task.md
└── walkthrough.md
```

## Testing infrastructure

### Test Suite

- **1 Unit Test** (inside `tradingview-mcp-service.test.js` for routing)
- **1 Unit Test** (inside `tradingview-mcp-service.test.js` for combined analysis wrapper)
- **3 Unit Tests** (inside `expanded-analysis-alert-report.test.js` for request validation)
- **1 Unit Test** (inside `expanded-analysis-alert-report.test.js` for combined report Spanish formatting)
- **1 Integration Test** (inside `expanded-analysis-alert-endpoint.test.js` for end-to-end webhook execution and reporting)

### Test Coverage

- `analysisMode` request validation parsing.
- Service tool selection routing.
- Spanish formatting translation and structure of Reddit sentiment, confluence indicators, and RSS news headlines.
- Webhook JSON payload routing and integration mock testing.

### Test Files

- `tests/unit/tradingview-mcp-service.test.js`
- `tests/unit/expanded-analysis-alert-report.test.js`
- `tests/integration/expanded-analysis-alert-endpoint.test.js`

## Configuration Updates

### Environment Variables

No new environment variables added.

## Documentation Updates

- **Walkthrough**: Added implementation walkthrough and testing results.

## Examples

Example JSON response body for combined mode:
```json
{
  "success": true,
  "alertText": "📊 *ANÁLISIS AMPLIADO — Friday 22/05/2026*\n...\n*🟢 TOP GANADORES*\nBTCUSDT $68,450.20 (+1.2%) | RSI 55.4\n- *Tendencia (SMA20):* Alcista | *MACD:* Bullish\n- *Volumen:* Normal | *ATR:* $120.50\n- *Stop Loss sugerido:* $68,269.45\n- *Sugerencia:* MANTENER / ACUMULAR\n- *Sentimiento Reddit:* 🐂 Alcista (Score: 0.45, 12 posts)\n- *Confluencia:* 🟢 STRONG BUY · Señales Alineadas ✅ (Confianza: high)\n- *Últimas Noticias:*\n  • Bitcoin surges past 68k (CoinDesk)",
  "results": [
    {
      "symbol": "BINANCE:BTCUSDT",
      "status": "analyzed",
      "price": 68450.2,
      "rsi": 55.4
    }
  ]
}
```

## Testing

### Pre-merge Verification

- [x] Run `npm test -- tests/unit/tradingview-mcp-service.test.js tests/unit/expanded-analysis-alert-report.test.js tests/integration/expanded-analysis-alert-endpoint.test.js`
- [x] Run `npm test` to verify no regressions (495 tests passed)

### Post-merge Verification

- [ ] Execute `POST /api/webhook/expanded-analysis-alert` with `"analysisMode": "combined"` and verify formatted Telegram/WhatsApp channels receive sentiment, confluence, and news details.

---

**Review Checklist:**

- [x] Code quality meets project standards
- [x] All tests pass and coverage is maintained
- [x] Documentation is complete and accurate
- [x] Breaking change assessment completed
