### PR TITLE
chore(toolchain): align pnpm and sentry docs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,7 @@ FROM node:20
 
 # Install basic development tools
 RUN apt update && apt install -y less man-db sudo
+RUN corepack enable
 
 # Ensure default `node` user has access to `sudo`
 ARG USERNAME=node

--- a/agents.md
+++ b/agents.md
@@ -27,9 +27,9 @@ Environment and runtime behavior (discoverable)
 - Routes under `/api` (e.g. `/api/webhook/alert`) are mounted regardless of bot launch; individual features and notification channels are gated via env flags and per-channel validation.
 
 Dev / run commands
-- `npm install` — install deps.
-- `npm start` — run production entry (`node index.js`).
-- `npm run start-dev` — runs `nodemon index.js` for development.
+- `pnpm install --frozen-lockfile` — install deps.
+- `pnpm start` — run production entry (`node index.js`).
+- `pnpm run start-dev` — runs `nodemon index.js` for development.
 - Healthcheck endpoint: `GET /healthcheck` (provided by `app.js`).
 
 Patterns and conventions to follow
@@ -82,11 +82,11 @@ What an AI code change should preserve
 
 **Test Execution Strategy**:
 - **During development**: Run focused/specific tests only, NOT the full test suite. Examples:
-  - `npm test -- tests/unit/price-parsing.test.js` — test single unit file
-  - `npm test -- tests/integration/news-monitor-basic.test.js` — test single integration file
-  - `npm test -- tests/unit/ --testTimeout=5000` — test entire unit directory
-  - `npm test -- --testNamePattern="should parse price"` — test by test name pattern
-- **After completing all changes**: Run the full test suite `npm test` once per implementation to ensure no regressions
+  - `pnpm test -- tests/unit/price-parsing.test.js` — test single unit file
+  - `pnpm test -- tests/integration/news-monitor-basic.test.js` — test single integration file
+  - `pnpm test -- tests/unit/ --testTimeout=5000` — test entire unit directory
+  - `pnpm test -- --testNamePattern="should parse price"` — test by test name pattern
+- **After completing all changes**: Run the full test suite `pnpm test` once per implementation to ensure no regressions
 - **Rationale**: Full test runs take 2-5 minutes and consume significant token budget. Focused tests give rapid feedback (10-30s) during development. Only run full suite as final validation after full implementation phase.
 - **Performance tip**: Use `--testTimeout=5000` with unit tests to speed up execution; integration tests need higher timeouts (~10000ms)
 
@@ -415,7 +415,7 @@ The system provides an HTTP endpoint (`/api/news-monitor`) that analyzes financi
 - In-memory Map cache for news deduplication with TTL (003-news-monitor, no external storage)
 - Binance API client for precise crypto prices (003-news-monitor, optional fallback to Gemini GoogleSearch)
 - TradingView MCP remote Streamable HTTP server for technical `coin_analysis` report generation (`POST /api/webhook/expanded-analysis-alert`)
-- Sentry SDK for Node (`@sentry/node` v10) for backend runtime error monitoring and warn/error console log capture (005-sentry-runtime-errors; no tracing by default)
+- Sentry SDK for Node (`@sentry/node` v10.53.1) for backend runtime error monitoring and warn/error console log capture (005-sentry-runtime-errors; no tracing by default)
 - Cloud Firestore via `firebase-admin` v9.x for server-side alert document persistence (006-firestore-alert-storage; fire-and-forget, never blocks delivery)
 
 ## Firestore Alert Storage (006-firestore-alert-storage)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "main": "index.js",
+  "packageManager": "pnpm@10.34.1",
   "engines": {
     "node": ">=20.x"
   },

--- a/specs/005-sentry-runtime-errors/plan.md
+++ b/specs/005-sentry-runtime-errors/plan.md
@@ -23,7 +23,7 @@ The integration will be gated by environment configuration, defaulting to a safe
 
 - express – existing HTTP server framework
 - telegraf – existing Telegram bot framework
-- @sentry/node – Sentry SDK for Node.js v8, initialized once at process startup via a `SentryService` wrapper with error-monitoring-only configuration (no tracing; DSN read from `SENTRY_DSN`/env)
+- @sentry/node – Sentry SDK for Node.js v10.53.1, initialized once at process startup via a `SentryService` wrapper with error-monitoring-only configuration (no tracing; DSN read from `SENTRY_DSN`/env)
 - jest – existing test runner for unit and integration tests
 
 **Storage**: N/A (stateless service; no new persistence required for this feature)

--- a/specs/005-sentry-runtime-errors/quickstart.md
+++ b/specs/005-sentry-runtime-errors/quickstart.md
@@ -93,8 +93,8 @@ SENTRY_RELEASE=cabros-bot@dev
 1. Start the server:
 
 ```bash
-npm install
-npm run start-dev
+pnpm install --frozen-lockfile
+pnpm run start-dev
 ```
 
 1. Confirm in logs that monitoring initialized successfully (e.g., `Sentry monitoring enabled (environment=development, release=cabros-bot@dev)`).
@@ -208,7 +208,7 @@ To confirm that Sentry does not change user-visible behavior (User Story 2, FR-0
    - Run existing Jest suites (unit + integration):
 
    ```bash
-   npm test
+   pnpm test
    ```
 
    - Exercise manual scenarios for `/api/webhook/alert`, `/api/news-monitor`, Telegram, and WhatsApp.

--- a/specs/005-sentry-runtime-errors/research.md
+++ b/specs/005-sentry-runtime-errors/research.md
@@ -7,13 +7,13 @@
 
 ## Topic 1: Sentry SDK choice & initialization pattern
 
-**Decision**: Use the official `@sentry/node` v8 SDK with a minimal "error monitoring only" configuration, initialized once at process startup.
+**Decision**: Use the official `@sentry/node` v10 SDK with a minimal "error monitoring only" configuration, initialized once at process startup.
 
 **Rationale**:
 
 - The Sentry JavaScript docs recommend `@sentry/node` as the SDK for Node-based backends.
 - The SDK can load the DSN from `process.env.SENTRY_DSN` when `dsn` is omitted, avoiding hardcoded secrets.
-- The v8 Node docs (`v8-node.md`) show a simple initialization model plus optional Express helpers; we only need core error capture, not tracing/profiling.
+- The v10 Node docs show a simple initialization model plus optional Express helpers; we only need core error capture, not tracing/profiling.
 - Keeping initialization in a single `SentryService` module aligns with the Constitution's simplicity and readability goals.
 
 **Implementation notes** (conceptual):
@@ -26,7 +26,7 @@
 
 **Alternatives considered**:
 
-- **Using generic `@sentry/browser` or multi-environment SDKs only** – rejected because the official docs recommend `@sentry/node` for backend Node apps, and v8 provides Node-specific features (e.g., Express helpers, OnUnhandledRejection integration).
+- **Using generic `@sentry/browser` or multi-environment SDKs only** – rejected because the official docs recommend `@sentry/node` for backend Node apps, and v10 provides Node-specific features (e.g., Express helpers, OnUnhandledRejection integration).
 - **Custom HTTP client sending events directly to Sentry API** – rejected as unnecessary complexity and maintenance burden vs. using the official SDK.
 - **Using the Supabase Sentry JS integration** (`supabase-community/sentry-integration-js`) – rejected as it targets Supabase SDK instrumentation, which is not relevant here.
 
@@ -64,7 +64,7 @@
 
 **Rationale**:
 
-- The `v8-node` docs show `Sentry.setupExpressErrorHandler(app)` as a convenient way to capture Express errors, but our handlers already wrap their logic in `try/catch` and construct HTTP responses directly (they do not regularly call `next(err)`).
+- The Node docs show `Sentry.setupExpressErrorHandler(app)` as a convenient way to capture Express errors, but our handlers already wrap their logic in `try/catch` and construct HTTP responses directly (they do not regularly call `next(err)`).
 - Introducing global Express error middleware would require reworking existing error handling to route everything through `next(err)`, which is out-of-scope and risks changing observable HTTP behavior (conflicts with FR-003 and User Story 2).
 - Manual instrumentation in the few central catch blocks (`alert.js`, `newsMonitor.js`) is straightforward and makes it explicit which paths are monitored and how they are tagged.
 
@@ -146,10 +146,10 @@
 
 | Unknown (from Technical Context) | Resolution | Status |
 | -------------------------------- | ---------- | ------ |
-| Which SDK and init pattern to use for Node | Use official `@sentry/node` v8 with a single `SentryService` wrapper and error-only configuration | ✅ RESOLVED |
+| Which SDK and init pattern to use for Node | Use official `@sentry/node` v10 with a single `SentryService` wrapper and error-only configuration | ✅ RESOLVED |
 | How to capture `uncaughtException` / `unhandledRejection` safely | Rely on SDK's built-in integrations, configuring unhandled rejections to avoid changing process semantics | ✅ RESOLVED |
 | Whether to use Express helpers or manual instrumentation | Prefer manual instrumentation in existing catch blocks; skip `setupExpressErrorHandler` for now | ✅ RESOLVED |
 | How to map environments and releases | Derive from `SENTRY_ENVIRONMENT`/`SENTRY_RELEASE` when present, otherwise from `RENDER`, `IS_PULL_REQUEST`, `NODE_ENV`, and `RENDER_GIT_COMMIT` | ✅ RESOLVED |
 | How to structure tags/context for channels and external providers | Use Sentry tags and contexts for `channel`, `feature`, endpoints, and retry metadata; include full alert/news text by default per FR-007 | ✅ RESOLVED |
 
-All `NEEDS CLARIFICATION` items in the Technical Context have been addressed at the planning level. Details such as exact option names will be aligned with the current `@sentry/node` v8 documentation during implementation, but no additional research blockers remain for Phase 1 design.
+All `NEEDS CLARIFICATION` items in the Technical Context have been addressed at the planning level. Details such as exact option names will be aligned with the current `@sentry/node` v10 documentation during implementation, but no additional research blockers remain for Phase 1 design.

--- a/specs/005-sentry-runtime-errors/tasks.md
+++ b/specs/005-sentry-runtime-errors/tasks.md
@@ -33,7 +33,7 @@ description: "Task list for feature 005-sentry-runtime-errors (Sentry runtime er
 
 **Purpose**: Prepare Sentry dependencies and basic monitoring structure without changing runtime behavior.
 
-- [X] T001 Update Sentry dependency in `package.json` to add `@sentry/node` (v8) to the `dependencies` section for the Node.js service
+- [X] T001 Update Sentry dependency in `package.json` to add `@sentry/node` (v10.53.1) to the `dependencies` section for the Node.js service
 - [X] T002 [P] Create monitoring service directory `src/services/monitoring/` to host `SentryService.js` and related helpers
 - [X] T003 [P] Configure Jest global setup in `jest.config.js` and `tests/setup.js` so `@sentry/node` and the monitoring layer can be safely mocked without sending real events
 


### PR DESCRIPTION
# chore(toolchain): align pnpm and sentry docs

## Summary

This branch aligns the repository’s package-manager and Sentry documentation with the currently supported toolchain.

### What changed

- Added an exact `packageManager` pin in [`package.json`](/Users/fgvaleriop/.codex/worktrees/ef48/cabros-crypto-bot-telegram/package.json) so Corepack resolves pnpm `10.34.1` deterministically.
- Enabled Corepack in the devcontainer image so the pinned pnpm version is available in local container workflows.
- Updated [`agents.md`](/Users/fgvaleriop/.codex/worktrees/ef48/cabros-crypto-bot-telegram/agents.md) to use pnpm commands instead of npm and to reflect the installed `@sentry/node` version.
- Refreshed the Sentry planning docs in [`specs/005-sentry-runtime-errors/research.md`](/Users/fgvaleriop/.codex/worktrees/ef48/cabros-crypto-bot-telegram/specs/005-sentry-runtime-errors/research.md), [`specs/005-sentry-runtime-errors/plan.md`](/Users/fgvaleriop/.codex/worktrees/ef48/cabros-crypto-bot-telegram/specs/005-sentry-runtime-errors/plan.md), [`specs/005-sentry-runtime-errors/quickstart.md`](/Users/fgvaleriop/.codex/worktrees/ef48/cabros-crypto-bot-telegram/specs/005-sentry-runtime-errors/quickstart.md), and [`specs/005-sentry-runtime-errors/tasks.md`](/Users/fgvaleriop/.codex/worktrees/ef48/cabros-crypto-bot-telegram/specs/005-sentry-runtime-errors/tasks.md) so they match the repo’s current pnpm-based workflow and `@sentry/node` 10.53.1.

## Validation

- `pnpm test`
- `pnpm --version` now resolves to `10.34.1` from the pinned manifest

## Notes

- The lockfile did not need to change.
- The change is intentionally documentation and toolchain alignment only; runtime behavior is unchanged.
