### PR TITLE
fix(grounding): retry transient Gemini failures

### DIFF
--- a/src/services/grounding/gemini.js
+++ b/src/services/grounding/gemini.js
@@ -26,6 +26,28 @@ function buildContextSnippet(searchResultText = '') {
 		: '';
 }
 
+function shouldRetryGeminiWithFallback(error) {
+	if (!error) {
+		return false;
+	}
+
+	const status = Number(error.status);
+	if ([500, 503, 504].includes(status)) {
+		return true;
+	}
+
+	const errorMessage = String(error.message || '').toUpperCase();
+	return (
+		errorMessage.includes('500')
+		|| errorMessage.includes('503')
+		|| errorMessage.includes('504')
+		|| errorMessage.includes('INTERNAL')
+		|| errorMessage.includes('UNAVAILABLE')
+		|| errorMessage.includes('DEADLINE_EXCEEDED')
+		|| errorMessage.includes('OVERLOADED')
+	);
+}
+
 /**
  * Generates a summary with citations given an alert text and optional context
  * @param {string} text - Alert text to summarize
@@ -292,12 +314,32 @@ async function generateEnrichedAlert({ text, searchResults = [], searchResultTex
 	);
 
 	try {
-		const { text: responseText, usage, modelUsed } = await genaiClient.llmCallv2({
+		const llmParams = {
 			systemPrompt,
 			userPrompt,
 			context: { citations: searchResults },
 			opts: { temperature: 0.2 },
-		});
+		};
+		let llmResult;
+
+		try {
+			llmResult = await genaiClient.llmCallv2(llmParams);
+		} catch (error) {
+			if (!GEMINI_MODEL_NAME_FALLBACK || !shouldRetryGeminiWithFallback(error)) {
+				throw error;
+			}
+
+			console.warn('[Gemini] Primary enrichment model failed, attempting fallback model:', GEMINI_MODEL_NAME_FALLBACK);
+			llmResult = await genaiClient.llmCallv2({
+				...llmParams,
+				opts: {
+					...llmParams.opts,
+					model: GEMINI_MODEL_NAME_FALLBACK,
+				},
+			});
+		}
+
+		const { text: responseText, usage, modelUsed } = llmResult;
 
 		if (tokenUsage && usage) {
 			const modelName = modelUsed || GEMINI_MODEL_NAME;

--- a/tests/integration/alert-grounding.test.js
+++ b/tests/integration/alert-grounding.test.js
@@ -5,6 +5,7 @@ const app = require('../../app');
 const { getRoutes } = require('../../src/routes');
 const genaiClient = require('../../src/services/grounding/genaiClient');
 const gemini = require('../../src/services/grounding/gemini');
+const { GEMINI_MODEL_NAME_FALLBACK } = require('../../src/services/grounding/config');
 const { initializeNotificationServices } = require('../../src/controllers/webhooks/handlers/alert/alert');
 
 // Define mock search results
@@ -129,6 +130,44 @@ describe('Alert Grounding Integration', () => {
 				expect(messageText).toContain('[Test Result 1](https://test1.com)');
 			}
 		}, 10000);
+
+		it('should retry webhook enrichment with the fallback Gemini model on transient 500 INTERNAL errors', async () => {
+			genaiClient.llmCallv2
+				.mockRejectedValueOnce(Object.assign(
+					new Error('LLM call failed: ApiError: {"error":{"code":500,"message":"Internal error encountered.","status":"INTERNAL"}}'),
+					{ status: 500 },
+				))
+				.mockResolvedValueOnce({
+					text: JSON.stringify({
+						sentiment: 'BULLISH',
+						sentiment_score: 0.9,
+						insights: ['Fallback Insight'],
+					}),
+					citations: mockSearchResults,
+					modelUsed: 'gemini-2.5-flash-lite',
+				});
+
+			const response = await request(app)
+				.post('/api/webhook/alert').set('x-api-key', 'test-key')
+				.send({ text: 'Bitcoin breaks $50,000 mark after volatile trading' })
+				.expect(200);
+
+			expect(response.body.success).toBe(true);
+			expect(response.body.enriched).toBe(true);
+			expect(genaiClient.llmCallv2).toHaveBeenCalledTimes(2);
+			expect(genaiClient.llmCallv2).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({
+					opts: expect.objectContaining({
+						model: GEMINI_MODEL_NAME_FALLBACK,
+					}),
+				}),
+			);
+
+			const telegramResult = response.body.results.find(r => r.channel === 'telegram');
+			expect(telegramResult).toBeDefined();
+			expect(telegramResult.success).toBe(true);
+		});
 
 		it('should handle invalid Gemini JSON by degrading to safe alert', async () => {
 			// Mock invalid JSON response

--- a/tests/unit/gemini-client.test.js
+++ b/tests/unit/gemini-client.test.js
@@ -15,6 +15,7 @@ jest.mock('../../src/services/grounding/config', () => ({
 	GEMINI_SYSTEM_PROMPT: 'Test system prompt',
 	GROUNDING_MODEL_NAME: 'gemini-2.0-flash',
 	GEMINI_MODEL_NAME: 'gemini-2.0-flash',
+	GEMINI_MODEL_NAME_FALLBACK: 'gemini-2.5-flash-lite',
 }));
 
 describe('Gemini Service', () => {
@@ -59,6 +60,45 @@ describe('Gemini Service', () => {
 			expect(result.insights).toHaveLength(2);
 			expect(result).not.toHaveProperty('technical_levels');
 			// sources are not returned by generateEnrichedAlert
+		});
+
+		it('retries with the fallback Gemini model on transient 500 INTERNAL errors', async () => {
+			genaiClient.llmCallv2
+				.mockRejectedValueOnce(Object.assign(
+					new Error('LLM call failed: ApiError: {"error":{"code":500,"message":"Internal error encountered.","status":"INTERNAL"}}'),
+					{ status: 500 },
+				))
+				.mockResolvedValueOnce({
+					text: JSON.stringify(mockEnrichedResponse),
+					citations: mockSearchResults,
+					modelUsed: 'gemini-2.5-flash-lite',
+				});
+
+			const result = await generateEnrichedAlert({
+				text: 'Bitcoin breaks 83k after a volatile session',
+				searchResults: mockSearchResults,
+			});
+
+			expect(result.sentiment).toBe('BULLISH');
+			expect(result.modelUsed).toBe('gemini-2.5-flash-lite');
+			expect(genaiClient.llmCallv2).toHaveBeenCalledTimes(2);
+			expect(genaiClient.llmCallv2).toHaveBeenNthCalledWith(
+				1,
+				expect.objectContaining({
+					opts: expect.objectContaining({
+						temperature: 0.2,
+					}),
+				}),
+			);
+			expect(genaiClient.llmCallv2).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({
+					opts: expect.objectContaining({
+						model: 'gemini-2.5-flash-lite',
+						temperature: 0.2,
+					}),
+				}),
+			);
 		});
 
 		it('should handle non-English text with preserved language', async () => {


### PR DESCRIPTION
# fix(grounding): retry transient Gemini failures

## Summary

Harden webhook alert enrichment against transient Gemini backend failures so `POST /api/webhook/alert` can recover with a fallback model instead of dropping enrichment on the first `500 INTERNAL` response.

## Key Changes

### :ambulance: Retry transient Gemini enrichment failures

- Added transient Gemini error classification for `500`, `503`, and `504`-class failures plus `INTERNAL`, `UNAVAILABLE`, `DEADLINE_EXCEEDED`, and `OVERLOADED` provider messages.
- Retried `generateEnrichedAlert()` once with `GEMINI_MODEL_NAME_FALLBACK` when the primary enrichment call fails with a transient backend error.
- Preserved the existing fail-open webhook behavior when both enrichment attempts fail.

### :test_tube: Add regression coverage for webhook enrichment fallback

- Added a unit test that reproduces the `500 INTERNAL` Gemini error shape and verifies the fallback model path.
- Added an integration test that verifies `/api/webhook/alert` still returns `200` and remains enriched when the fallback model succeeds.

## Technical Implementation

### Architecture changes

#### `src/services/grounding/gemini.js`

- Added `shouldRetryGeminiWithFallback()` to distinguish retryable backend/provider failures from non-retryable failures.
- Updated `generateEnrichedAlert()` to retry once with the configured fallback model before surfacing the enrichment error to the existing fail-open controller flow.

#### Test coverage

- `tests/unit/gemini-client.test.js`: covers transient `500 INTERNAL` fallback retry behavior.
- `tests/integration/alert-grounding.test.js`: covers HTTP-level webhook behavior when the fallback model succeeds.

## Testing

### Pre-merge Verification

- [x] `pnpm test -- tests/unit/alert-handler.test.js tests/unit/genaiClient.test.js tests/unit/gemini-client.test.js tests/integration/alert-grounding.test.js --runInBand`
- [x] `pnpm exec eslint src/services/grounding/gemini.js tests/unit/gemini-client.test.js tests/integration/alert-grounding.test.js`

## References

- Linear: `CB-13`
- Sentry issue referenced by Linear: `CABROS-BOT-7`

---

**Review Checklist:**

- [ ] Code quality meets project standards
- [ ] All tests pass and coverage is maintained
- [ ] Documentation is complete and accurate
- [ ] Breaking change assessment completed
