### PR TITLE
feat: add volume confirmation api (CB-12)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,8 @@
 - Stored alert reads now live at:
   - `GET /api/alerts`
   - `GET /api/alerts/:alertId`
+- TradingView volume confirmation now also has a direct API:
+  - `POST /api/webhook/volume-confirmation`
 
 ## Stored Alerts
 
@@ -28,5 +30,7 @@
 ## Testing Pattern
 
 - Endpoint contract tests: `tests/integration/alerts-endpoint.test.js`
+- Volume confirmation endpoint contract tests: `tests/integration/volume-confirmation-endpoint.test.js`
 - Firestore read/write unit coverage: `tests/unit/alert-storage-service.test.js`
 - When extending the alerts read API, preserve `receivedAt` as the primary sort key but encode `nextBefore` with a deterministic tie-breaker (document ID) so paginated reads do not skip same-timestamp alerts, and preserve API-key protection on both list and detail routes.
+- `POST /api/webhook/volume-confirmation` should accept `symbol` in `EXCHANGE:SYMBOL` format, normalize timeframe aliases with the shared TradingView helpers, and return structured JSON instead of formatted notification text.

--- a/README.md
+++ b/README.md
@@ -474,6 +474,44 @@ The endpoint stops analysis at `EXPANDED_ANALYSIS_ALERT_TIMEOUT_MS` (default 60 
 }
 ```
 
+### POST /api/webhook/volume-confirmation
+
+Run TradingView MCP `volume_confirmation_analysis` on demand and return structured JSON without sending notifications.
+
+**Request (JSON):**
+```json
+{
+  "symbol": "BINANCE:BTCUSDT",
+  "timeframe": "4h"
+}
+```
+
+- `symbol`: Required `EXCHANGE:SYMBOL` identifier.
+- `timeframe`: Optional indicator interval. Defaults to `TRADINGVIEW_MCP_DEFAULT_TIMEFRAME` or `1h`.
+
+**Response (JSON):**
+```json
+{
+  "success": true,
+  "symbol": "BINANCE:BTCUSDT",
+  "exchange": "BINANCE",
+  "asset": "BTCUSDT",
+  "timeframe": "4h",
+  "confirmed": true,
+  "decision": "confirm",
+  "volumeRatio": 1.7,
+  "analysis": {
+    "symbol": "BINANCE:BTCUSDT",
+    "volume_analysis": {
+      "volume_ratio": 1.7,
+      "volume_strength": "HIGH"
+    }
+  }
+}
+```
+
+If the symbol format is invalid, the endpoint returns `400 INVALID_REQUEST`. If TradingView MCP fails, it returns `502 VOLUME_CONFIRMATION_FAILED` with the upstream error message.
+
 ### POST /api/webhook/market-scanner-alert
 
 Execute multiple market scanner tools on the TradingView MCP server (such as top gainers, top losers, volume breakout, smart volume, or Bollinger squeeze), generate a formatted technical summary report in Spanish, and send it through all enabled notification channels.

--- a/agents.md
+++ b/agents.md
@@ -11,6 +11,7 @@ Key files / entry points
 - `src/controllers/commands/handlers/core/fetchPriceCryptoSymbol.js` — calls Binance `MainClient.getAvgPrice` to fetch prices.
 - `src/controllers/webhooks/handlers/alert/alert.js` — webhook handler that forwards alert text to a Telegram chat.
 - `src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js` — `POST /api/webhook/expanded-analysis-alert` handler that builds TradingView MCP analysis reports and sends them through notification channels.
+- `src/controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation.js` — `POST /api/webhook/volume-confirmation` handler that returns structured TradingView MCP volume-confirmation data.
 - `src/controllers/webhooks/handlers/jobs/jobs.js` — job creation (`POST /api/jobs/tradingview-analysis`) and status polling (`GET /api/jobs/:jobId`) handler.
 - `src/controllers/alerts/alerts.js` — stored alert read handlers for `GET /api/alerts` and `GET /api/alerts/:alertId`.
 - `src/services/jobs/JobService.js` — manages in-memory job state, executes background TradingView analysis runs, and performs periodic expiration cleanup.
@@ -55,6 +56,7 @@ Small, concrete examples
 - Get price via Telegram: send message `/precio BTCUSDT` -> handler calls `client.getAvgPrice({ symbol: 'BTCUSDT' })` and replies with `Precio de BTCUSDT es <price>`.
 - Send a webhook alert (when bot enabled): POST to `/api/webhook/alert` with body `{ "text": "Alert body" }` or `text/plain` body `Alert body`.
 - Generate an expanded analysis alert: POST to `/api/webhook/expanded-analysis-alert` with body `{ "symbols": ["BINANCE:BTCUSDT", "NASDAQ:NVDA"], "timeframe": "1D" }`; if `symbols` is empty it falls back to `EXPANDED_ANALYSIS_ALERT_SYMBOLS`, and returns 400 if neither is present.
+- Run a direct volume confirmation check: POST to `/api/webhook/volume-confirmation` with body `{ "symbol": "BINANCE:BTCUSDT", "timeframe": "4h" }`.
 - Inspect stored alerts: `GET /api/alerts?limit=50&before=2026-06-06T12:00:00.000Z&source=webhook&enriched=true` for the legacy older-than timestamp behavior, or reuse the opaque `pagination.nextBefore` cursor from a prior `/api/alerts` response to page without skipping ties, plus `GET /api/alerts/:alertId`.
 
 What an AI code change should preserve
@@ -222,6 +224,26 @@ The `/api/webhook/alert` flow (with `?useTradingViewData=true`) supports volume 
   - `"Volume confirms: YES ({ratio}x avg)"` (if ratio is >= 1.2)
   - `"Volume confirms: NO ({ratio}x avg)"` (if ratio is < 1.2)
 - This volume confirmation is rendered in both Telegram and WhatsApp notification channels under the "Key Insights" section.
+
+## TradingView Volume Confirmation API
+
+The system also provides a dedicated `POST /api/webhook/volume-confirmation` endpoint for on-demand TradingView MCP volume checks without going through alert delivery.
+
+**Request pattern**:
+- Body must be a JSON object with `symbol` in full `EXCHANGE:SYMBOL` format, for example `BINANCE:BTCUSDT`.
+- `timeframe` is optional and accepts the same MCP-supported intervals and aliases already used in TradingView flows.
+- The endpoint reuses `TradingViewMcpService.callVolumeConfirmation()` and returns structured JSON including the normalized symbol, derived confirm/deny decision, numeric `volumeRatio`, and raw MCP payload as `analysis`.
+
+**Failure behavior**:
+- Invalid bodies or malformed symbols return `400 INVALID_REQUEST`.
+- TradingView MCP failures return `502 VOLUME_CONFIRMATION_FAILED`.
+- Existing alert fail-open behavior remains unchanged because this endpoint is separate from `/api/webhook/alert`.
+
+**Where to look first when extending or debugging**:
+- `src/routes/index.js` for route registration.
+- `src/controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation.js` for request/response handling.
+- `src/services/tradingview/volumeConfirmationRequest.js` for request parsing and decision derivation.
+- `tests/integration/volume-confirmation-endpoint.test.js` for endpoint behavior coverage.
 
 ## TradingView Expanded Alert Reports
 

--- a/src/controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation.js
+++ b/src/controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation.js
@@ -1,0 +1,78 @@
+const { v4: uuidv4 } = require('uuid');
+const { tradingViewMcpService } = require('../../../../services/tradingview/TradingViewMcpService');
+const {
+	VolumeConfirmationRequestError,
+	parseVolumeConfirmationRequest,
+	getVolumeDecision,
+} = require('../../../../services/tradingview/volumeConfirmationRequest');
+const sentryService = require('../../../../services/monitoring/SentryService');
+
+function postVolumeConfirmation() {
+	return async (req, res) => {
+		const requestId = uuidv4();
+		const startTime = Date.now();
+
+		try {
+			const parsed = parseVolumeConfirmationRequest(req);
+			const analysis = await tradingViewMcpService.callVolumeConfirmation({
+				symbol: parsed.symbol,
+				exchange: parsed.exchange,
+				timeframe: parsed.timeframe,
+			});
+			const decision = getVolumeDecision(analysis);
+
+			return res.status(200).json({
+				success: true,
+				symbol: parsed.rawSymbol,
+				exchange: parsed.exchange,
+				asset: parsed.symbol,
+				timeframe: parsed.timeframe,
+				...decision,
+				analysis,
+				requestId,
+				totalDurationMs: Date.now() - startTime,
+			});
+		} catch (error) {
+			if (error instanceof VolumeConfirmationRequestError) {
+				return res.status(400).json({
+					error: error.message,
+					code: error.code,
+					requestId,
+				});
+			}
+
+			if (error && error.message) {
+				console.warn('[VolumeConfirmation] TradingView MCP call failed:', error.message);
+				return res.status(502).json({
+					success: false,
+					error: error.message,
+					code: 'VOLUME_CONFIRMATION_FAILED',
+					requestId,
+					totalDurationMs: Date.now() - startTime,
+				});
+			}
+
+			console.error('[VolumeConfirmation] Request failed:', error.message);
+			sentryService.captureRuntimeError({
+				channel: 'http-alert',
+				error,
+				http: {
+					endpoint: '/api/webhook/volume-confirmation',
+					method: 'POST',
+					statusCode: 500,
+					requestId,
+				},
+			});
+
+			return res.status(500).json({
+				error: 'Internal server error. Please try again later.',
+				code: 'INTERNAL_ERROR',
+				requestId,
+			});
+		}
+	};
+}
+
+module.exports = {
+	postVolumeConfirmation,
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { postAlert } = require('../controllers/webhooks/handlers/alert/alert');
 const { postExpandedAnalysisAlert } = require('../controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert');
 const { postMarketScannerAlert } = require('../controllers/webhooks/handlers/marketScanner/marketScanner');
+const { postVolumeConfirmation } = require('../controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation');
 const { postCreateJob, getJobStatus } = require('../controllers/webhooks/handlers/jobs/jobs');
 const { listAlerts, getAlertById } = require('../controllers/alerts/alerts');
 const { validateApiKey } = require('../lib/auth');
@@ -12,6 +13,7 @@ function getRoutes(botOrGetter) {
 	router.post('/webhook/alert', validateApiKey, postAlert(botOrGetter));
 	router.post('/webhook/expanded-analysis-alert', validateApiKey, postExpandedAnalysisAlert(botOrGetter));
 	router.post('/webhook/market-scanner-alert', validateApiKey, postMarketScannerAlert(botOrGetter));
+	router.post('/webhook/volume-confirmation', validateApiKey, postVolumeConfirmation());
 	router.get('/alerts', validateApiKey, listAlerts);
 	router.get('/alerts/:alertId', validateApiKey, getAlertById);
 

--- a/src/services/tradingview/volumeConfirmationRequest.js
+++ b/src/services/tradingview/volumeConfirmationRequest.js
@@ -96,7 +96,8 @@ function parseTimeframe(body = {}) {
 }
 
 function getVolumeDecision(analysis = {}) {
-	const ratio = Number(analysis.volume_analysis?.volume_ratio);
+	const rawRatio = analysis.volume_analysis?.volume_ratio;
+	const ratio = rawRatio === null || rawRatio === undefined ? Number.NaN : Number(rawRatio);
 
 	if (!Number.isFinite(ratio)) {
 		return {

--- a/src/services/tradingview/volumeConfirmationRequest.js
+++ b/src/services/tradingview/volumeConfirmationRequest.js
@@ -1,0 +1,120 @@
+const {
+	normalizeTradingViewTimeframe,
+	SUPPORTED_MCP_TIMEFRAMES,
+} = require('./parseTradingViewSignal');
+
+const SUPPORTED_TIMEFRAME_ALIASES = new Set([
+	'5',
+	'5M',
+	'15',
+	'15M',
+	'60',
+	'1H',
+	'240',
+	'4H',
+	'1440',
+	'D',
+	'1D',
+	'10080',
+	'W',
+	'1W',
+	'43200',
+	'M',
+	'1M',
+]);
+
+class VolumeConfirmationRequestError extends Error {
+	constructor(message, code = 'INVALID_REQUEST') {
+		super(message);
+		this.name = 'VolumeConfirmationRequestError';
+		this.code = code;
+	}
+}
+
+function parseVolumeConfirmationRequest(req = {}) {
+	const body = getRequestBody(req);
+	const { exchange, symbol } = parseSymbolIdentifier(body.symbol);
+	const timeframe = parseTimeframe(body);
+
+	return {
+		exchange,
+		symbol,
+		rawSymbol: `${exchange}:${symbol}`,
+		timeframe,
+	};
+}
+
+function getRequestBody(req = {}) {
+	if (!Object.prototype.hasOwnProperty.call(req, 'body') || req.body === undefined) {
+		return {};
+	}
+
+	if (req.body === null || typeof req.body !== 'object' || Array.isArray(req.body)) {
+		throw new VolumeConfirmationRequestError('request body must be a JSON object');
+	}
+
+	return req.body;
+}
+
+function parseSymbolIdentifier(rawSymbol) {
+	if (typeof rawSymbol !== 'string' || !rawSymbol.trim()) {
+		throw new VolumeConfirmationRequestError('symbol must be a non-empty string in EXCHANGE:SYMBOL format');
+	}
+
+	const trimmed = rawSymbol.trim().toUpperCase();
+	const match = trimmed.match(/^(?<exchange>[A-Z0-9._-]+):(?<symbol>[A-Z0-9._-]{2,30})$/);
+
+	if (!match || !match.groups) {
+		throw new VolumeConfirmationRequestError('symbol must use EXCHANGE:SYMBOL format');
+	}
+
+	return {
+		exchange: match.groups.exchange,
+		symbol: match.groups.symbol,
+	};
+}
+
+function parseTimeframe(body = {}) {
+	if (
+		Object.prototype.hasOwnProperty.call(body, 'timeframe')
+		&& body.timeframe !== undefined
+		&& typeof body.timeframe !== 'string'
+	) {
+		throw new VolumeConfirmationRequestError('timeframe must be a string');
+	}
+
+	const rawTimeframe = typeof body.timeframe === 'string' && body.timeframe.trim()
+		? body.timeframe.trim()
+		: (process.env.TRADINGVIEW_MCP_DEFAULT_TIMEFRAME || '1h');
+	const normalizedToken = rawTimeframe.toUpperCase();
+
+	if (!SUPPORTED_MCP_TIMEFRAMES.has(rawTimeframe) && !SUPPORTED_TIMEFRAME_ALIASES.has(normalizedToken)) {
+		throw new VolumeConfirmationRequestError(`Unsupported timeframe: ${rawTimeframe}`);
+	}
+
+	return normalizeTradingViewTimeframe(rawTimeframe, '1h');
+}
+
+function getVolumeDecision(analysis = {}) {
+	const ratio = Number(analysis.volume_analysis?.volume_ratio);
+
+	if (!Number.isFinite(ratio)) {
+		return {
+			confirmed: null,
+			decision: 'unknown',
+			volumeRatio: null,
+		};
+	}
+
+	return {
+		confirmed: ratio >= 1.2,
+		decision: ratio >= 1.2 ? 'confirm' : 'deny',
+		volumeRatio: ratio,
+	};
+}
+
+module.exports = {
+	VolumeConfirmationRequestError,
+	parseVolumeConfirmationRequest,
+	getVolumeDecision,
+};

--- a/src/services/tradingview/volumeConfirmationRequest.js
+++ b/src/services/tradingview/volumeConfirmationRequest.js
@@ -62,7 +62,7 @@ function parseSymbolIdentifier(rawSymbol) {
 	}
 
 	const trimmed = rawSymbol.trim().toUpperCase();
-	const match = trimmed.match(/^(?<exchange>[A-Z0-9._-]+):(?<symbol>[A-Z0-9._-]{2,30})$/);
+	const match = trimmed.match(/^(?<exchange>[A-Z0-9._-]+):(?<symbol>[A-Z0-9._-]{1,30})$/);
 
 	if (!match || !match.groups) {
 		throw new VolumeConfirmationRequestError('symbol must use EXCHANGE:SYMBOL format');

--- a/tests/integration/volume-confirmation-endpoint.test.js
+++ b/tests/integration/volume-confirmation-endpoint.test.js
@@ -64,7 +64,6 @@ describe('Volume confirmation endpoint', () => {
 			symbol: 'BTCUSDT',
 			exchange: 'BINANCE',
 			timeframe: '4h',
-			signal: undefined,
 		});
 	});
 

--- a/tests/integration/volume-confirmation-endpoint.test.js
+++ b/tests/integration/volume-confirmation-endpoint.test.js
@@ -1,0 +1,100 @@
+const request = require('supertest');
+const app = require('../../app');
+const { getRoutes } = require('../../src/routes');
+const { tradingViewMcpService } = require('../../src/services/tradingview/TradingViewMcpService');
+
+jest.mock('../../src/services/tradingview/TradingViewMcpService', () => ({
+	tradingViewMcpService: {
+		callVolumeConfirmation: jest.fn(),
+	},
+}));
+
+describe('Volume confirmation endpoint', () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = {
+			...originalEnv,
+			WEBHOOK_API_KEY: 'test-key',
+			TRADINGVIEW_MCP_DEFAULT_TIMEFRAME: '4h',
+		};
+
+		jest.clearAllMocks();
+		app.use('/api', getRoutes(null));
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		if (app._router && app._router.stack && app._router.stack.length > 0) {
+			app._router.stack.pop();
+		}
+	});
+
+	it('returns structured volume confirmation data for a valid TradingView symbol', async () => {
+		tradingViewMcpService.callVolumeConfirmation.mockResolvedValueOnce({
+			symbol: 'BINANCE:BTCUSDT',
+			volume_analysis: {
+				volume_ratio: 1.7,
+				volume_strength: 'HIGH',
+			},
+			confidence: 0.91,
+		});
+
+		const res = await request(app)
+			.post('/api/webhook/volume-confirmation')
+			.set('x-api-key', 'test-key')
+			.send({ symbol: 'BINANCE:BTCUSDT' })
+			.expect(200);
+
+		expect(res.body).toEqual(expect.objectContaining({
+			success: true,
+			symbol: 'BINANCE:BTCUSDT',
+			exchange: 'BINANCE',
+			asset: 'BTCUSDT',
+			timeframe: '4h',
+			confirmed: true,
+			decision: 'confirm',
+			volumeRatio: 1.7,
+			analysis: expect.objectContaining({
+				symbol: 'BINANCE:BTCUSDT',
+				confidence: 0.91,
+			}),
+		}));
+		expect(tradingViewMcpService.callVolumeConfirmation).toHaveBeenCalledWith({
+			symbol: 'BTCUSDT',
+			exchange: 'BINANCE',
+			timeframe: '4h',
+			signal: undefined,
+		});
+	});
+
+	it('returns 400 for invalid symbol identifiers', async () => {
+		const res = await request(app)
+			.post('/api/webhook/volume-confirmation')
+			.set('x-api-key', 'test-key')
+			.send({ symbol: 'BTCUSDT' })
+			.expect(400);
+
+		expect(res.body).toEqual(expect.objectContaining({
+			code: 'INVALID_REQUEST',
+		}));
+		expect(res.body.error).toContain('EXCHANGE:SYMBOL');
+		expect(tradingViewMcpService.callVolumeConfirmation).not.toHaveBeenCalled();
+	});
+
+	it('returns 502 when TradingView MCP volume confirmation fails', async () => {
+		tradingViewMcpService.callVolumeConfirmation.mockRejectedValueOnce(new Error('MCP unavailable'));
+
+		const res = await request(app)
+			.post('/api/webhook/volume-confirmation')
+			.set('x-api-key', 'test-key')
+			.send({ symbol: 'BINANCE:BTCUSDT', timeframe: '1D' })
+			.expect(502);
+
+		expect(res.body).toEqual(expect.objectContaining({
+			success: false,
+			code: 'VOLUME_CONFIRMATION_FAILED',
+			error: 'MCP unavailable',
+		}));
+	});
+});

--- a/tests/unit/volume-confirmation-request.test.js
+++ b/tests/unit/volume-confirmation-request.test.js
@@ -68,4 +68,22 @@ describe('volumeConfirmationRequest', () => {
 			volumeRatio: 0.95,
 		});
 	});
+
+	it('treats null or missing volume ratios as unknown', () => {
+		expect(getVolumeDecision({
+			volume_analysis: { volume_ratio: null },
+		})).toEqual({
+			confirmed: null,
+			decision: 'unknown',
+			volumeRatio: null,
+		});
+
+		expect(getVolumeDecision({
+			volume_analysis: {},
+		})).toEqual({
+			confirmed: null,
+			decision: 'unknown',
+			volumeRatio: null,
+		});
+	});
 });

--- a/tests/unit/volume-confirmation-request.test.js
+++ b/tests/unit/volume-confirmation-request.test.js
@@ -40,6 +40,17 @@ describe('volumeConfirmationRequest', () => {
 		})).toThrow(VolumeConfirmationRequestError);
 	});
 
+	it('accepts one-character TradingView symbols', () => {
+		expect(parseVolumeConfirmationRequest({
+			body: { symbol: 'NYSE:F' },
+		})).toEqual({
+			exchange: 'NYSE',
+			symbol: 'F',
+			rawSymbol: 'NYSE:F',
+			timeframe: '4h',
+		});
+	});
+
 	it('derives confirm and deny decisions from volume_ratio', () => {
 		expect(getVolumeDecision({
 			volume_analysis: { volume_ratio: 1.25 },

--- a/tests/unit/volume-confirmation-request.test.js
+++ b/tests/unit/volume-confirmation-request.test.js
@@ -1,0 +1,60 @@
+const {
+	VolumeConfirmationRequestError,
+	parseVolumeConfirmationRequest,
+	getVolumeDecision,
+} = require('../../src/services/tradingview/volumeConfirmationRequest');
+
+describe('volumeConfirmationRequest', () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = {
+			...originalEnv,
+			TRADINGVIEW_MCP_DEFAULT_TIMEFRAME: '4h',
+		};
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	it('parses a valid request and normalizes the timeframe', () => {
+		const result = parseVolumeConfirmationRequest({
+			body: {
+				symbol: 'binance:btcusdt',
+				timeframe: '240',
+			},
+		});
+
+		expect(result).toEqual({
+			exchange: 'BINANCE',
+			symbol: 'BTCUSDT',
+			rawSymbol: 'BINANCE:BTCUSDT',
+			timeframe: '4h',
+		});
+	});
+
+	it('throws for malformed symbol identifiers', () => {
+		expect(() => parseVolumeConfirmationRequest({
+			body: { symbol: 'BTCUSDT' },
+		})).toThrow(VolumeConfirmationRequestError);
+	});
+
+	it('derives confirm and deny decisions from volume_ratio', () => {
+		expect(getVolumeDecision({
+			volume_analysis: { volume_ratio: 1.25 },
+		})).toEqual({
+			confirmed: true,
+			decision: 'confirm',
+			volumeRatio: 1.25,
+		});
+
+		expect(getVolumeDecision({
+			volume_analysis: { volume_ratio: 0.95 },
+		})).toEqual({
+			confirmed: false,
+			decision: 'deny',
+			volumeRatio: 0.95,
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add `POST /api/webhook/volume-confirmation` for direct TradingView MCP checks
- validate `EXCHANGE:SYMBOL` input and normalize timeframe aliases with shared helpers
- document the new route and cover it with unit + integration tests

## Validation
- `pnpm test -- tests/integration/volume-confirmation-endpoint.test.js tests/unit/volume-confirmation-request.test.js --runInBand`
- `pnpm test --runInBand`

## References
- CB-12
- Closes #54
