### PR TITLE
feat: add dry-run mode for webhook alert endpoints (CB-15)

### DIFF
--- a/context/feat-dry-run-webhook-alerts-cb-15.md
+++ b/context/feat-dry-run-webhook-alerts-cb-15.md
@@ -1,0 +1,120 @@
+# feat: add dry-run mode for webhook alert endpoints (CB-15)
+
+## Summary
+
+Adds a `dryRun` mode to the three webhook alert endpoints. When enabled, all validation and enrichment/analysis pipelines run as normal, but no messages are delivered to Telegram or WhatsApp and no data is persisted to Firestore. The response clearly indicates `dryRun: true` and returns the built message payload for inspection.
+
+## Key Changes
+
+### 🔧 Dry-run support for `POST /api/webhook/alert`
+
+- Accepts `dryRun=true` via query string (`?dryRun=true`) or request body (`{ "dryRun": true }`)
+- Runs request validation and enrichment (Gemini grounding, TradingView MCP) as usual
+- Skips `NotificationManager.sendToAll()` — no Telegram/WhatsApp delivery
+- Skips `alertStorageService.saveAlert()` — no Firestore side effects
+- Returns `{ success: true, dryRun: true, payload: { text, enrichedData }, enriched, tokenUsage }`
+
+### 🔧 Dry-run support for `POST /api/webhook/expanded-analysis-alert`
+
+- Same flag detection (`dryRun` query or body)
+- Runs per-symbol TradingView MCP analysis and report building as normal
+- Skips `notificationManager.sendToAll()`
+- Returns `{ success: true, dryRun: true, payload: { alertText }, results, summary, timedOut, ... }`
+
+### 🔧 Dry-run support for `POST /api/webhook/market-scanner-alert`
+
+- Same flag detection
+- Runs all configured scans via TradingView MCP as normal
+- Skips `notificationManager.sendToAll()`
+- Returns `{ success: true, dryRun: true, payload: { alertText }, scanResults, summary, timedOut, ... }`
+
+## Technical Implementation
+
+### Architecture changes
+
+#### `resolveDryRun(req)` helper
+
+Each handler exposes a shared `resolveDryRun(req)` function that reads the flag from both `req.query.dryRun` and `req.body.dryRun` (coercing string `'true'` to boolean).
+
+```js
+function resolveDryRun(req) {
+  const queryFlag = req.query && (req.query.dryRun === 'true' || req.query.dryRun === true);
+  const bodyFlag = req.body && typeof req.body === 'object' && (req.body.dryRun === true || req.body.dryRun === 'true');
+  return queryFlag || bodyFlag;
+}
+```
+
+### File Structure Additions
+
+```
+src/controllers/webhooks/handlers/
+├── alert/alert.js                     # Added resolveDryRun + dry-run guard
+├── expandedAnalysisAlert/expandedAnalysisAlert.js  # Same
+├── marketScanner/marketScanner.js     # Same
+tests/integration/
+└── dry-run-webhook-alerts.test.js     # 11 new integration tests
+```
+
+## Testing infrastructure
+
+### Test Suite
+
+- **11 Integration Tests** in `tests/integration/dry-run-webhook-alerts.test.js`
+
+### Test Coverage
+
+- Query string `?dryRun=true` skips delivery for all 3 endpoints
+- Request body `{ dryRun: true }` skips delivery for all 3 endpoints
+- Absent `dryRun` flag delivers normally (no regression)
+- `tokenUsage` is present in `/alert` dry-run response
+- `scanResults` and `summary` are present in market scanner dry-run response
+
+## Examples
+
+**Dry-run a simple alert:**
+```bash
+curl -X POST https://cabros-crypto-bot-telegram.onrender.com/api/webhook/alert?dryRun=true \
+  -H "x-api-key: $WEBHOOK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "BTC breaks $50K"}'
+
+# Response:
+{
+  "success": true,
+  "dryRun": true,
+  "enriched": false,
+  "payload": { "text": "BTC breaks $50K", "enrichedData": null },
+  "tokenUsage": { ... }
+}
+```
+
+**Dry-run an expanded analysis:**
+```bash
+curl -X POST https://cabros-crypto-bot-telegram.onrender.com/api/webhook/expanded-analysis-alert \
+  -H "x-api-key: $WEBHOOK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"symbols": ["BINANCE:BTCUSDT"], "timeframe": "1D", "dryRun": true}'
+```
+
+## Deployment Considerations
+
+No new environment variables required. Existing live behavior is unchanged when `dryRun` is absent.
+
+## Testing
+
+### Pre-merge Verification
+
+- [x] All 11 new dry-run integration tests pass
+- [x] Full test suite passes (no regressions)
+- [x] `dryRun` absent → live delivery unaffected
+
+### Post-merge Verification
+
+- [ ] Deploy to preview environment and test `?dryRun=true` against live endpoints
+- [ ] Verify no Telegram messages are sent in dry-run mode
+- [ ] Verify response contains `payload.text` with built message
+
+## References
+
+- GitHub Issue: https://github.com/francovp/cabros-bot/issues/59
+- Linear Issue: CB-15 (https://linear.app/knil/issue/CB-15/add-dry-run-mode-for-webhook-alert-endpoints)

--- a/docs/antigravity/75aa97d8-cf0a-4cf9-97ca-1c8152c20cb6/implementation_plan.md
+++ b/docs/antigravity/75aa97d8-cf0a-4cf9-97ca-1c8152c20cb6/implementation_plan.md
@@ -1,0 +1,36 @@
+# Defer notification service initialization in dry-run mode
+
+Address Codex review comment on pull request #79. When `/api/webhook/alert` is exercised in dry-run mode, the handler should not initialize or validate notification services (avoiding calls to `getMe()` and other setup/network calls).
+
+## User Review Required
+
+> [!IMPORTANT]
+> The fix has already been implemented in a local commit `c4301e9a` on the branch `feat/dry-run-webhook-alerts-cb-15`. Since agents are not allowed to push to remote repositories, the user will need to manually push the changes to GitHub via `git push origin feat/dry-run-webhook-alerts-cb-15` to trigger the CI checks and the Render preview environment build.
+
+## Open Questions
+
+No open questions.
+
+## Proposed Changes
+
+### Alert Webhook Handler
+
+#### [MODIFY] [alert.js](file:///Users/fgvaleriop/.gemini/antigravity/worktrees/cabros-crypto-bot-telegram/sync-github-linear-automation/src/controllers/webhooks/handlers/alert/alert.js)
+
+- Deferred the `resolveBot` and `initializeNotificationServices` calls until after the `dryRun` branch return in `postAlert`.
+
+## Verification Plan
+
+### Automated Tests
+- Running the targeted dry-run tests:
+  ```bash
+  pnpm test -- tests/integration/dry-run-webhook-alerts.test.js
+  ```
+- Running the full test suite:
+  ```bash
+  pnpm test
+  ```
+
+### Manual Verification
+- Verify the build and checks pass on GitHub once the branch is pushed.
+- Perform an E2E check against the deployed Render preview environment.

--- a/docs/antigravity/75aa97d8-cf0a-4cf9-97ca-1c8152c20cb6/task.md
+++ b/docs/antigravity/75aa97d8-cf0a-4cf9-97ca-1c8152c20cb6/task.md
@@ -1,0 +1,9 @@
+- [x] Post a summary of pending work as a comment on the PR
+- [x] Make implementation changes (defer notification service initialization after dry-run checks)
+- [x] Run full test suite locally and verify all tests pass
+- [ ] Push local commit `c4301e9a` to GitHub remote branch (user manually runs `git push`)
+- [ ] Wait for PR checks to pass on GitHub
+- [ ] Wait for Render preview environment deployment
+- [ ] E2E test the deployed Render preview environment
+- [ ] Label GitHub Issue and PR as "In review", update Linear issue status to "In review"
+- [ ] Post walkthrough and final summary

--- a/docs/antigravity/75aa97d8-cf0a-4cf9-97ca-1c8152c20cb6/walkthrough.md
+++ b/docs/antigravity/75aa97d8-cf0a-4cf9-97ca-1c8152c20cb6/walkthrough.md
@@ -1,0 +1,111 @@
+# Walkthrough — Dry-run mode for webhook alert endpoints
+
+We resolved the Codex review feedback on pull request #79 by deferring notifier initialization until after the dry-run check in `/api/webhook/alert`. This decouples dry-run validation from any dependency on notification service configuration, startup, or network calls (e.g. Telegram `getMe()`).
+
+## Changes Made
+
+### Alert Webhook Handler
+
+#### [MODIFY] [alert.js](file:///Users/fgvaleriop/.gemini/antigravity/worktrees/cabros-crypto-bot-telegram/sync-github-linear-automation/src/controllers/webhooks/handlers/alert/alert.js)
+- Moved the `resolveBot` and `initializeNotificationServices` calls after the `dryRun` return block in `postAlert`.
+
+---
+
+## Verification Results
+
+### Automated Tests
+- Ran the 11 dry-run integration tests locally. All passed successfully:
+  ```bash
+  PASS tests/integration/dry-run-webhook-alerts.test.js
+  ```
+- Ran the entire suite of 589 tests across 51 test suites. All passed successfully without any regressions.
+
+### E2E Tests on Render Preview Environment
+Verified the endpoints against the deployed Render preview environment at `https://cabros-crypto-bot-telegram-pr-79.onrender.com`:
+
+1. **POST /api/webhook/alert?dryRun=true**:
+   - Status: `200 OK`
+   - Response:
+     ```json
+     {
+       "success": true,
+       "dryRun": true,
+       "enriched": false,
+       "payload": {
+         "text": "BTCUSDT test alert",
+         "enrichedData": null
+       },
+       "tokenUsage": {
+         "inputTokens": 0,
+         "outputTokens": 0,
+         "totalTokens": 0,
+         "inputCost": 0,
+         "outputCost": 0,
+         "totalCost": 0,
+         "formattedSummary": "Token usage:\n- In 0 ($0.00)\n- Out 0 ($0.00)\n- Total 0 ($0.00)"
+       }
+     }
+     ```
+
+2. **POST /api/webhook/expanded-analysis-alert?dryRun=true**:
+   - Status: `200 OK`
+   - Response:
+     ```json
+     {
+       "success": true,
+       "dryRun": true,
+       "payload": {
+         "alertText": "📊 *ANÁLISIS AMPLIADO — Thursday 11/06/2026*\n\n*🔴 SOBRESVENDIDOS EXTREMOS*\nNo hay.\n\n*⚠️ SOBRESVENDIDOS*\nBTCUSDT $62,843.43 (+2.2%) | RSI 29.9\n- *Tendencia (SMA20):* Bajista | *MACD:* Bearish\n- *Volumen:* Normal\n- *Stop Loss sugerido:* $56,493.36\n- *Sugerencia:* VIGILAR / ACUMULAR GRADUAL (RSI en zona de sobreventa)\n\n*🟡 NEUTROS*\nNo hay.\n\n*🔴 SOBRECOMPRADOS*\nNo hay."
+       },
+       "results": [
+         {
+           "symbol": "BINANCE:BTCUSDT",
+           "status": "analyzed",
+           "price": 62843.43,
+           "rsi": 29.89
+         }
+       ],
+       "summary": {
+         "total": 1,
+         "analyzed": 1,
+         "error": 0,
+         "delivered": 0
+       },
+       "timedOut": false,
+       "timeoutMs": 60000,
+       "requestId": "68560f53-1bd6-41be-a0d9-47353692ea83",
+       "totalDurationMs": 167
+     }
+     ```
+
+3. **POST /api/webhook/market-scanner-alert?dryRun=true**:
+   - Status: `200 OK`
+   - Response:
+     ```json
+     {
+       "success": true,
+       "dryRun": true,
+       "payload": {
+         "alertText": "📡 *SCANNER DE MERCADO — Thursday 11/06/2026*\n_BINANCE · 4h_\n\n*🟢 TOP GANADORES*\n1. STGUSDT $0.431400 (+6.4%) | RSI 69.4\n2. CVXUSDT $1.31 (+4.0%) | RSI 59.5\n3. CRVUSDT $0.244400 (+3.3%) | RSI 82.2\n4. SUSHIUSDT $0.179000 (+2.5%) | RSI 57.6\n5. PROMUSDT $1.12 (+2.1%) | RSI 74.6"
+       },
+       "scanResults": [
+         {
+           "scan": "top_gainers",
+           "status": "success",
+           "itemCount": 5
+         }
+       ],
+       "summary": {
+         "totalScans": 1,
+         "success": 1,
+         "error": 0,
+         "timeout": 0,
+         "totalItems": 5,
+         "delivered": 0
+       },
+       "timedOut": false,
+       "timeoutMs": 90000,
+       "requestId": "df9965e4-85eb-4f89-b091-c78d1907bf2b",
+       "totalDurationMs": 933
+     }
+     ```

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -100,10 +100,17 @@ async function processEnrichment(alert, options) {
 	return enriched;
 }
 
+function resolveDryRun(req) {
+	const queryFlag = req.query && (req.query.dryRun === 'true' || req.query.dryRun === true);
+	const bodyFlag = req.body && typeof req.body === 'object' && (req.body.dryRun === true || req.body.dryRun === 'true');
+	return queryFlag || bodyFlag;
+}
+
 function postAlert(botOrGetter) {
 	return async (req, res) => {
 		const { body } = req;
 		const useTradingViewData = req.query && (req.query.useTradingViewData === true || req.query.useTradingViewData === 'true');
+		const dryRun = resolveDryRun(req);
 
 		let alertText = '';
 		let alert = null;
@@ -127,12 +134,27 @@ function postAlert(botOrGetter) {
 			const tokenUsage = new TokenUsageTracker();
 			const enriched = await processEnrichment(alert, { tokenUsage, useTradingViewData, parentSpan: requestSpan });
 
+			const tokenUsageJSON = tokenUsage.toJSON();
+			tokenUsageJSON.formattedSummary = tokenUsage.formatSummary();
+
+			if (dryRun) {
+				console.debug('[Alert] Dry-run mode: skipping delivery and Firestore persistence');
+				return res.json({
+					success: true,
+					dryRun: true,
+					enriched,
+					payload: {
+						text: alert.text,
+						enrichedData: alert.enriched || null,
+					},
+					tokenUsage: tokenUsageJSON,
+				});
+			}
+
 			// NotificationManager owns the custom dispatch spans.
 			const results = await notificationManager.sendToAll(alert, { parentSpan: requestSpan });
 
 			// Return 200 OK regardless of delivery success (fail-open pattern)
-			const tokenUsageJSON = tokenUsage.toJSON();
-			tokenUsageJSON.formattedSummary = tokenUsage.formatSummary();
 			res.json({ success: true, results, enriched, tokenUsage: tokenUsageJSON });
 
 			// Fire-and-forget: persist alert to Firestore after responding to the caller.

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -117,10 +117,6 @@ function postAlert(botOrGetter) {
 
 		try {
 			const requestSpan = sentryService.getActiveSpan();
-			const bot = resolveBot(botOrGetter);
-			if (!notificationManager) {
-				await initializeNotificationServices(bot);
-			}
 
 			if (typeof body === 'object' && 'text' in body) {
 				alertText = body.text;
@@ -149,6 +145,12 @@ function postAlert(botOrGetter) {
 					},
 					tokenUsage: tokenUsageJSON,
 				});
+			}
+
+			// Defer notification service initialization until we know we need delivery.
+			const bot = resolveBot(botOrGetter);
+			if (!notificationManager) {
+				await initializeNotificationServices(bot);
 			}
 
 			// NotificationManager owns the custom dispatch spans.

--- a/src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js
+++ b/src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js
@@ -24,6 +24,12 @@ function resolveBot(botOrGetter) {
 	return botOrGetter || null;
 }
 
+function resolveDryRun(req) {
+	const queryFlag = req.query && (req.query.dryRun === 'true' || req.query.dryRun === true);
+	const bodyFlag = req.body && typeof req.body === 'object' && (req.body.dryRun === true || req.body.dryRun === 'true');
+	return queryFlag || bodyFlag;
+}
+
 function postExpandedAnalysisAlert(botOrGetter) {
 	return async (req, res) => {
 		const requestId = uuidv4();
@@ -69,6 +75,22 @@ function postExpandedAnalysisAlert(botOrGetter) {
 			}
 
 			const alertText = buildExpandedAnalysisAlertReport(analyzedItems);
+			const dryRun = resolveDryRun(req);
+			if (dryRun) {
+				console.debug('[ExpandedAnalysisAlert] Dry-run mode: skipping delivery');
+				return res.status(200).json({
+					success: true,
+					dryRun: true,
+					payload: { alertText },
+					results: compactResults(results),
+					summary: buildSummary(results, []),
+					timedOut,
+					timeoutMs,
+					requestId,
+					totalDurationMs: Date.now() - startTime,
+				});
+			}
+
 			let notificationManager = getNotificationManager();
 			if (!notificationManager) {
 				notificationManager = await initializeNotificationServices(resolveBot(botOrGetter));

--- a/src/controllers/webhooks/handlers/marketScanner/marketScanner.js
+++ b/src/controllers/webhooks/handlers/marketScanner/marketScanner.js
@@ -24,6 +24,12 @@ function resolveBot(botOrGetter) {
 	return botOrGetter || null;
 }
 
+function resolveDryRun(req) {
+	const queryFlag = req.query && (req.query.dryRun === 'true' || req.query.dryRun === true);
+	const bodyFlag = req.body && typeof req.body === 'object' && (req.body.dryRun === true || req.body.dryRun === 'true');
+	return queryFlag || bodyFlag;
+}
+
 function postMarketScannerAlert(botOrGetter) {
 	return async (req, res) => {
 		const requestId = uuidv4();
@@ -74,6 +80,22 @@ function postMarketScannerAlert(botOrGetter) {
 				timeframe: parsed.timeframe,
 				now: new Date(),
 			});
+
+			const dryRun = resolveDryRun(req);
+			if (dryRun) {
+				console.debug('[MarketScanner] Dry-run mode: skipping delivery');
+				return res.status(200).json({
+					success: true,
+					dryRun: true,
+					payload: { alertText },
+					scanResults: compactScanResults(scanResults),
+					summary: buildSummary(scanResults, []),
+					timedOut,
+					timeoutMs,
+					requestId,
+					totalDurationMs: Date.now() - startTime,
+				});
+			}
 
 			let notificationManager = getNotificationManager();
 			if (!notificationManager) {

--- a/tests/integration/dry-run-webhook-alerts.test.js
+++ b/tests/integration/dry-run-webhook-alerts.test.js
@@ -1,0 +1,245 @@
+/* global jest, describe, it, beforeEach, afterEach, expect */
+
+const request = require('supertest');
+const app = require('../../app');
+const { getRoutes } = require('../../src/routes');
+const { initializeNotificationServices } = require('../../src/controllers/webhooks/handlers/alert/alert');
+const { tradingViewMcpService } = require('../../src/services/tradingview/TradingViewMcpService');
+
+jest.mock('../../src/services/tradingview/TradingViewMcpService', () => ({
+	tradingViewMcpService: {
+		analyzeSymbolIdentifier: jest.fn(),
+		callScanTool: jest.fn(),
+		callMultiTimeframeAnalysis: jest.fn(),
+	},
+}));
+
+describe('Dry-run mode for webhook alert endpoints', () => {
+	const originalEnv = process.env;
+	let mockTelegramSendMessage;
+	let mockBot;
+
+	beforeEach(async () => {
+		process.env = {
+			...originalEnv,
+			WEBHOOK_API_KEY: 'test-key',
+			ENABLE_TELEGRAM_BOT: 'true',
+			ENABLE_WHATSAPP_ALERTS: 'false',
+			BOT_TOKEN: 'test-bot-token',
+			TELEGRAM_CHAT_ID: '123456789',
+			ENABLE_GEMINI_GROUNDING: 'false',
+			ENABLE_MARKET_SCANNER: 'true',
+		};
+
+		jest.clearAllMocks();
+
+		mockTelegramSendMessage = jest.fn().mockResolvedValue({ message_id: 'test-msg-id' });
+		mockBot = {
+			telegram: {
+				sendMessage: mockTelegramSendMessage,
+				getMe: jest.fn().mockResolvedValue({ id: 123456789, username: 'TestBot' }),
+			},
+		};
+
+		await initializeNotificationServices(mockBot);
+		app.use('/api', getRoutes(mockBot));
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		if (app._router && app._router.stack && app._router.stack.length > 0) {
+			app._router.stack.pop();
+		}
+	});
+
+	// ---------------------------------------------------------------------------
+	// POST /api/webhook/alert
+	// ---------------------------------------------------------------------------
+	describe('POST /api/webhook/alert', () => {
+		it('returns dryRun:true via query string and skips delivery', async () => {
+			const res = await request(app)
+				.post('/api/webhook/alert?dryRun=true')
+				.set('x-api-key', 'test-key')
+				.send({ text: 'Bitcoin breaks $50,000 mark' })
+				.expect(200);
+
+			expect(res.body.success).toBe(true);
+			expect(res.body.dryRun).toBe(true);
+			expect(res.body.payload).toBeDefined();
+			expect(res.body.payload.text).toBe('Bitcoin breaks $50,000 mark');
+			expect(res.body.results).toBeUndefined();
+			expect(mockTelegramSendMessage).not.toHaveBeenCalled();
+		});
+
+		it('returns dryRun:true via request body and skips delivery', async () => {
+			const res = await request(app)
+				.post('/api/webhook/alert')
+				.set('x-api-key', 'test-key')
+				.send({ text: 'ETH consolidates above $3,000', dryRun: true })
+				.expect(200);
+
+			expect(res.body.success).toBe(true);
+			expect(res.body.dryRun).toBe(true);
+			expect(res.body.payload).toBeDefined();
+			expect(res.body.payload.text).toBe('ETH consolidates above $3,000');
+			expect(res.body.results).toBeUndefined();
+			expect(mockTelegramSendMessage).not.toHaveBeenCalled();
+		});
+
+		it('delivers normally when dryRun is absent', async () => {
+			const res = await request(app)
+				.post('/api/webhook/alert')
+				.set('x-api-key', 'test-key')
+				.send({ text: 'Live alert text' })
+				.expect(200);
+
+			expect(res.body.success).toBe(true);
+			expect(res.body.dryRun).toBeUndefined();
+			expect(res.body.results).toBeDefined();
+			expect(mockTelegramSendMessage).toHaveBeenCalledTimes(1);
+		});
+
+		it('returns tokenUsage in dry-run response', async () => {
+			const res = await request(app)
+				.post('/api/webhook/alert?dryRun=true')
+				.set('x-api-key', 'test-key')
+				.send({ text: 'Price alert for BTC' })
+				.expect(200);
+
+			expect(res.body.tokenUsage).toBeDefined();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// POST /api/webhook/expanded-analysis-alert
+	// ---------------------------------------------------------------------------
+	describe('POST /api/webhook/expanded-analysis-alert', () => {
+		const mockAnalysis = {
+			technical: {
+				price_data: { current_price: 50000 },
+				technical_indicators: { rsi: 58 },
+				trend: { direction: 'bullish' },
+				macd: { histogram: 1.5, signal: 'buy' },
+				support_resistance: { support: [48000], resistance: [52000] },
+			},
+		};
+
+		beforeEach(() => {
+			tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValue(mockAnalysis);
+		});
+
+		it('returns dryRun:true via query string and skips delivery', async () => {
+			const res = await request(app)
+				.post('/api/webhook/expanded-analysis-alert?dryRun=true')
+				.set('x-api-key', 'test-key')
+				.send({ symbols: ['BINANCE:BTCUSDT'], timeframe: '1D' })
+				.expect(200);
+
+			expect(res.body.success).toBe(true);
+			expect(res.body.dryRun).toBe(true);
+			expect(res.body.payload).toBeDefined();
+			expect(typeof res.body.payload.alertText).toBe('string');
+			expect(res.body.payload.alertText.length).toBeGreaterThan(0);
+			expect(res.body.deliveryResults).toBeUndefined();
+			expect(mockTelegramSendMessage).not.toHaveBeenCalled();
+		});
+
+		it('returns dryRun:true via request body and skips delivery', async () => {
+			const res = await request(app)
+				.post('/api/webhook/expanded-analysis-alert')
+				.set('x-api-key', 'test-key')
+				.send({ symbols: ['BINANCE:BTCUSDT'], timeframe: '4h', dryRun: true })
+				.expect(200);
+
+			expect(res.body.success).toBe(true);
+			expect(res.body.dryRun).toBe(true);
+			expect(res.body.payload).toBeDefined();
+			expect(res.body.deliveryResults).toBeUndefined();
+			expect(mockTelegramSendMessage).not.toHaveBeenCalled();
+		});
+
+		it('delivers normally when dryRun is absent', async () => {
+			const res = await request(app)
+				.post('/api/webhook/expanded-analysis-alert')
+				.set('x-api-key', 'test-key')
+				.send({ symbols: ['BINANCE:BTCUSDT'], timeframe: '1D' })
+				.expect(200);
+
+			expect(res.body.success).toBe(true);
+			expect(res.body.dryRun).toBeUndefined();
+			expect(res.body.deliveryResults).toBeDefined();
+			expect(mockTelegramSendMessage).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// POST /api/webhook/market-scanner-alert
+	// ---------------------------------------------------------------------------
+	describe('POST /api/webhook/market-scanner-alert', () => {
+		const mockScanResult = [
+			{
+				symbol: 'BINANCE:BTCUSDT',
+				changePercent: 5.1,
+				indicators: { close: 50000, RSI: 62 },
+			},
+		];
+
+		beforeEach(() => {
+			tradingViewMcpService.callScanTool.mockResolvedValue(mockScanResult);
+		});
+
+		it('returns dryRun:true via query string and skips delivery', async () => {
+			const res = await request(app)
+				.post('/api/webhook/market-scanner-alert?dryRun=true')
+				.set('x-api-key', 'test-key')
+				.send({ scans: ['top_gainers'], exchange: 'BINANCE', timeframe: '4h' })
+				.expect(200);
+
+			expect(res.body.success).toBe(true);
+			expect(res.body.dryRun).toBe(true);
+			expect(res.body.payload).toBeDefined();
+			expect(typeof res.body.payload.alertText).toBe('string');
+			expect(res.body.payload.alertText.length).toBeGreaterThan(0);
+			expect(res.body.deliveryResults).toBeUndefined();
+			expect(mockTelegramSendMessage).not.toHaveBeenCalled();
+		});
+
+		it('returns dryRun:true via request body and skips delivery', async () => {
+			const res = await request(app)
+				.post('/api/webhook/market-scanner-alert')
+				.set('x-api-key', 'test-key')
+				.send({ scans: ['top_gainers'], dryRun: true })
+				.expect(200);
+
+			expect(res.body.success).toBe(true);
+			expect(res.body.dryRun).toBe(true);
+			expect(res.body.payload).toBeDefined();
+			expect(res.body.deliveryResults).toBeUndefined();
+			expect(mockTelegramSendMessage).not.toHaveBeenCalled();
+		});
+
+		it('delivers normally when dryRun is absent', async () => {
+			const res = await request(app)
+				.post('/api/webhook/market-scanner-alert')
+				.set('x-api-key', 'test-key')
+				.send({ scans: ['top_gainers'] })
+				.expect(200);
+
+			expect(res.body.success).toBe(true);
+			expect(res.body.dryRun).toBeUndefined();
+			expect(res.body.deliveryResults).toBeDefined();
+			expect(mockTelegramSendMessage).toHaveBeenCalledTimes(1);
+		});
+
+		it('includes scanResults and summary in dry-run response', async () => {
+			const res = await request(app)
+				.post('/api/webhook/market-scanner-alert?dryRun=true')
+				.set('x-api-key', 'test-key')
+				.send({ scans: ['top_gainers'] })
+				.expect(200);
+
+			expect(res.body.scanResults).toBeDefined();
+			expect(res.body.summary).toBeDefined();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds a `dryRun` mode to the three webhook alert endpoints. When enabled, all validation and enrichment/analysis pipelines run as normal, but no messages are delivered to Telegram or WhatsApp and no data is persisted to Firestore. The response clearly indicates `dryRun: true` and returns the built message payload for inspection.

## Key Changes

### 🔧 Dry-run support for `POST /api/webhook/alert`

- Accepts `dryRun=true` via query string (`?dryRun=true`) or request body (`{ "dryRun": true }`)
- Runs request validation and enrichment (Gemini grounding, TradingView MCP) as usual
- Skips `NotificationManager.sendToAll()` — no Telegram/WhatsApp delivery
- Skips `alertStorageService.saveAlert()` — no Firestore side effects
- Returns `{ success: true, dryRun: true, payload: { text, enrichedData }, enriched, tokenUsage }`

### 🔧 Dry-run support for `POST /api/webhook/expanded-analysis-alert`

- Same flag detection (`dryRun` query or body)
- Runs per-symbol TradingView MCP analysis and report building as normal
- Skips `notificationManager.sendToAll()`
- Returns `{ success: true, dryRun: true, payload: { alertText }, results, summary, timedOut, ... }`

### 🔧 Dry-run support for `POST /api/webhook/market-scanner-alert`

- Same flag detection
- Runs all configured scans via TradingView MCP as normal
- Skips `notificationManager.sendToAll()`
- Returns `{ success: true, dryRun: true, payload: { alertText }, scanResults, summary, timedOut, ... }`

## Examples

```bash
# Dry-run a simple alert (query string)
curl -X POST https://<host>/api/webhook/alert?dryRun=true \
  -H "x-api-key: $WEBHOOK_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"text": "BTC breaks $50K"}'

# Response:
# { "success": true, "dryRun": true, "enriched": false, "payload": { "text": "BTC breaks $50K", "enrichedData": null }, "tokenUsage": { ... } }

# Dry-run an expanded analysis (body flag)
curl -X POST https://<host>/api/webhook/expanded-analysis-alert \
  -H "x-api-key: $WEBHOOK_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"symbols": ["BINANCE:BTCUSDT"], "timeframe": "1D", "dryRun": true}'
```

## Testing

- 11 new integration tests in `tests/integration/dry-run-webhook-alerts.test.js`
- All 11 tests pass; no regressions in existing suite

## References

- Closes #59
- CB-15