### PR TITLE
fix: fallback to plain text when Telegram MarkdownV2 parse fails (CB-19)

### DIFF
--- a/src/services/notification/TelegramService.js
+++ b/src/services/notification/TelegramService.js
@@ -100,12 +100,22 @@ class TelegramService extends NotificationChannel {
 			this.logger?.debug?.(`Sending to Telegram chat ${this.chatId}`);
 			const messageParts = splitTelegramMessage(formattedText, this.maxMessageLength);
 
-			// Send to Telegram
+			// Send to Telegram with MarkdownV2 first, fallback to plain text on parse errors
 			const messageIds = [];
 			for (const messagePart of messageParts) {
 				const result = await this.bot.telegram.sendMessage(this.chatId, messagePart, {
 					parse_mode: 'MarkdownV2',
 					disable_web_page_preview: !!alert.enriched,
+				}).catch((err) => {
+					const errMsg = (err && (err.description || err.message)) || '';
+					// If MarkdownV2 parse fails (400 can't parse entities), retry as plain text
+					if (errMsg.includes("can't parse entities")) {
+						this.logger?.warn?.(`Telegram MarkdownV2 parse failed, retrying as plain text: ${errMsg}`);
+						return this.bot.telegram.sendMessage(this.chatId, messagePart, {
+							disable_web_page_preview: !!alert.enriched,
+						});
+					}
+					throw err;
 				});
 				messageIds.push(String(result.message_id));
 			}

--- a/tests/unit/telegram-service.test.js
+++ b/tests/unit/telegram-service.test.js
@@ -38,4 +38,64 @@ describe('TelegramService', () => {
 			expect(call[1].length).toBeLessThanOrEqual(10);
 		});
 	});
+
+	it('falls back to plain text when MarkdownV2 parse fails', async () => {
+		const parseErrorBot = {
+			telegram: {
+				sendMessage: jest.fn()
+					.mockRejectedValueOnce({
+						description: "Bad Request: can't parse entities: Can't find end of Bold entity at byte offset 10",
+					})
+					.mockResolvedValueOnce({ message_id: 201 }),
+			},
+		};
+		const fallbackService = new TelegramService({
+			bot: parseErrorBot,
+			chatId: 'chat-1',
+			formatter: {
+				format: (text) => text,
+			},
+			logger: { warn: jest.fn(), error: jest.fn() },
+		});
+
+		const result = await fallbackService.send({ text: '*unbalanced bold' });
+
+		expect(result).toEqual(expect.objectContaining({
+			success: true,
+			channel: 'telegram',
+			messageId: '201',
+		}));
+		// First call with MarkdownV2, second call as plain text
+		expect(parseErrorBot.telegram.sendMessage).toHaveBeenCalledTimes(2);
+		expect(parseErrorBot.telegram.sendMessage.mock.calls[0][2]).toEqual({
+			parse_mode: 'MarkdownV2',
+			disable_web_page_preview: false,
+		});
+		expect(parseErrorBot.telegram.sendMessage.mock.calls[1][2]).toEqual({
+			disable_web_page_preview: false,
+		});
+	});
+
+	it('does not fall back to plain text for non-parse Telegram errors', async () => {
+		const otherErrorBot = {
+			telegram: {
+				sendMessage: jest.fn()
+					.mockRejectedValueOnce(new Error('Telegram API timeout')),
+			},
+		};
+		const fallbackService = new TelegramService({
+			bot: otherErrorBot,
+			chatId: 'chat-1',
+			formatter: {
+				format: (text) => text,
+			},
+			logger: { warn: jest.fn(), error: jest.fn() },
+		});
+
+		const result = await fallbackService.send({ text: 'normal text' });
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Telegram error');
+		expect(otherErrorBot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+	});
 });


### PR DESCRIPTION
## Summary

When enriched alert text contains **unbalanced bold** (`*text` without closing `*`) or **italic** (`_text` without closing `_`) markup, Telegram rejects the message with `400: Bad Request: cant parse entities: Cant find end of Bold entity at byte offset N`.

### Root cause

The `MarkdownV2Formatter` intentionally does not escape `_` and `*` because they are needed for formatting. But when dynamic/generated text contains unbalanced markup (e.g., from Gemini enrichment), Telegram produces a parse failure — which crashes that specific message part delivery and surfaces as Sentry issue `CABROS-BOT-6`.

### Fix

`TelegramService.send()` now catches per-part `sendMessage` rejections that match the `"cant parse entities"` pattern and **retries that part as plain text** (no `parse_mode`). The retry is scoped to the failing message part only — other parts, channels, and non-parse errors are unaffected.

### Key design decisions

- **Scoped catch**: Uses per-call `.catch()` on each message part, not a wrapper around the whole loop. This prevents a bad MarkdownV2 part from blocking subsequent parts.
- **Narrow error pattern**: Only retries when `err.description` or `err.message` contains `"cant parse entities"`. Other Telegram failures (timeout, rate limit, auth) still propagate and are caught by the outer try/catch.
- **Logging**: Failed parse is logged at WARN level with the original error description for observability.
- **No formatter changes**: The formatter continues to use `_` and `*` for bold/italic — fixing the downstream delivery is more resilient than trying to predict all possible malformed inputs from upstream enrichment.

## Testing

- **`falls back to plain text when MarkdownV2 parse fails`**: Mock sends `*unbalanced bold`, first call rejects with parse error, second call succeeds as plain text without `parse_mode`.
- **`does not fall back to plain text for non-parse Telegram errors`**: Non-parse error (timeout) is not swallowed — returned as a regular failure.

## References

- Closes #83
- Sentry issue CABROS-BOT-6