### PR TITLE
feat: add generic message webhook POST /api/webhook/message (CB-21)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -233,7 +233,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"message\": \"Custom notification from automation\",\n  \"channels\": [\"telegram\", \"whatsapp\"]\n}"
+							"raw": "{\n  \"message\": \"Custom notification from automation\",\n  \"channels\": [\"telegram\", \"whatsapp\"],\n  \"telegramChatId\": \"-1001234567890\",\n  \"whatsappChatId\": \"120363000000000000@g.us\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/webhook/message",
@@ -259,6 +259,18 @@
 							"status": "Bad Request",
 							"code": 400,
 							"body": "{\n  \"success\": false,\n  \"error\": \"'message' is required and must be a non-empty string\",\n  \"details\": {\n    \"field\": \"message\"\n  }\n}"
+						},
+						{
+							"name": "Error (invalid telegramChatId)",
+							"status": "Bad Request",
+							"code": 400,
+							"body": "{\n  \"success\": false,\n  \"error\": \"\\\"telegramChatId\\\" must be a non-empty string if provided\",\n  \"details\": {\n    \"field\": \"telegramChatId\"\n  }\n}"
+						},
+						{
+							"name": "Error (invalid whatsappChatId)",
+							"status": "Bad Request",
+							"code": 400,
+							"body": "{\n  \"success\": false,\n  \"error\": \"\\\"whatsappChatId\\\" must be a non-empty string if provided\",\n  \"details\": {\n    \"field\": \"whatsappChatId\"\n  }\n}"
 						},
 						{
 							"name": "Error (unknown channel)",

--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -222,6 +222,63 @@
 							"path": ["api", "webhook", "volume-confirmation"]
 						}
 					}
+				},
+				{
+					"name": "POST Send Message",
+					"request": {
+						"method": "POST",
+						"header": [
+							{ "key": "Content-Type", "value": "application/json", "type": "text" },
+							{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"message\": \"Custom notification from automation\",\n  \"channels\": [\"telegram\", \"whatsapp\"]\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/webhook/message",
+							"host": ["{{baseUrl}}"],
+							"path": ["api", "webhook", "message"]
+						}
+					},
+					"response": [
+						{
+							"name": "Success (both channels)",
+							"status": "OK",
+							"code": 200,
+							"body": "{\n  \"success\": true,\n  \"results\": [\n    {\n      \"channel\": \"telegram\",\n      \"success\": true,\n      \"messageId\": \"tg-msg-123\",\n      \"attemptCount\": 1,\n      \"durationMs\": 450\n    },\n    {\n      \"channel\": \"whatsapp\",\n      \"success\": true,\n      \"messageId\": \"wa-msg-456\",\n      \"attemptCount\": 1,\n      \"durationMs\": 320\n    }\n  ]\n}"
+						},
+						{
+							"name": "Success (single channel)",
+							"status": "OK",
+							"code": 200,
+							"body": "{\n  \"success\": true,\n  \"results\": [\n    {\n      \"channel\": \"telegram\",\n      \"success\": true,\n      \"messageId\": \"tg-msg-789\",\n      \"attemptCount\": 1,\n      \"durationMs\": 410\n    }\n  ]\n}"
+						},
+						{
+							"name": "Error (empty message)",
+							"status": "Bad Request",
+							"code": 400,
+							"body": "{\n  \"success\": false,\n  \"error\": \"'message' is required and must be a non-empty string\",\n  \"details\": {\n    \"field\": \"message\"\n  }\n}"
+						},
+						{
+							"name": "Error (unknown channel)",
+							"status": "Bad Request",
+							"code": 400,
+							"body": "{\n  \"success\": false,\n  \"error\": \"Unknown channel(s): discord. Valid channels: telegram, whatsapp\",\n  \"details\": {\n    \"field\": \"channels\",\n    \"unknownChannels\": [\"discord\"]\n  }\n}"
+						},
+						{
+							"name": "Partial Failure (WhatsApp down)",
+							"status": "OK",
+							"code": 200,
+							"body": "{\n  \"success\": true,\n  \"results\": [\n    {\n      \"channel\": \"telegram\",\n      \"success\": true,\n      \"messageId\": \"tg-msg-789\",\n      \"attemptCount\": 1,\n      \"durationMs\": 450\n    },\n    {\n      \"channel\": \"whatsapp\",\n      \"success\": false,\n      \"error\": \"GreenAPI request timeout\",\n      \"attemptCount\": 3,\n      \"durationMs\": 7800\n    }\n  ]\n}"
+						},
+						{
+							"name": "Unauthorized (missing API key)",
+							"status": "Unauthorized",
+							"code": 401,
+							"body": "{\n  \"error\": \"Unauthorized: Missing API key\"\n}"
+						}
+					]
 				}
 			]
 		},

--- a/src/controllers/webhooks/handlers/message/message.js
+++ b/src/controllers/webhooks/handlers/message/message.js
@@ -19,7 +19,7 @@ function validateMessageRequest(body) {
 		throw new MessageValidationError('Request body must be a JSON object');
 	}
 
-	const { message, channels } = body;
+	const { message, channels, telegramChatId, whatsappChatId } = body;
 
 	if (!message || typeof message !== 'string') {
 		throw new MessageValidationError('"message" is required and must be a non-empty string', {
@@ -41,18 +41,30 @@ function validateMessageRequest(body) {
 		);
 	}
 
+	if (telegramChatId !== undefined && (typeof telegramChatId !== 'string' || telegramChatId.length === 0)) {
+		throw new MessageValidationError('"telegramChatId" must be a non-empty string if provided', {
+			field: 'telegramChatId',
+		});
+	}
+
+	if (whatsappChatId !== undefined && (typeof whatsappChatId !== 'string' || whatsappChatId.length === 0)) {
+		throw new MessageValidationError('"whatsappChatId" must be a non-empty string if provided', {
+			field: 'whatsappChatId',
+		});
+	}
+
 	const text = message.length > MAX_MESSAGE_LENGTH
 		? message.substring(0, MAX_MESSAGE_LENGTH) + '...'
 		: message;
 
-	return { text, channels };
+	return { text, channels, telegramChatId, whatsappChatId };
 }
 
 function postMessage(botOrGetter) {
 	return async (req, res) => {
 		try {
-			const { text, channels } = validateMessageRequest(req.body);
-			const alert = { text };
+			const { text, channels, telegramChatId, whatsappChatId } = validateMessageRequest(req.body);
+			const alert = { text, telegramChatId, whatsappChatId };
 
 			let notificationManager = getNotificationManager();
 			if (!notificationManager) {

--- a/src/controllers/webhooks/handlers/message/message.js
+++ b/src/controllers/webhooks/handlers/message/message.js
@@ -1,0 +1,103 @@
+require('dotenv').config();
+const sentryService = require('../../../../services/monitoring/SentryService');
+const { getNotificationManager } = require('../alert/alert');
+
+const VALID_CHANNELS = ['telegram', 'whatsapp'];
+const MAX_MESSAGE_LENGTH = 4000;
+
+class MessageValidationError extends Error {
+	constructor(message, details = null) {
+		super(message);
+		this.name = 'MessageValidationError';
+		this.details = details;
+		this.statusCode = 400;
+	}
+}
+
+function validateMessageRequest(body) {
+	if (!body || typeof body !== 'object') {
+		throw new MessageValidationError('Request body must be a JSON object');
+	}
+
+	const { message, channels } = body;
+
+	if (!message || typeof message !== 'string') {
+		throw new MessageValidationError('"message" is required and must be a non-empty string', {
+			field: 'message',
+		});
+	}
+
+	if (!channels || !Array.isArray(channels) || channels.length === 0) {
+		throw new MessageValidationError('"channels" is required and must be a non-empty array', {
+			field: 'channels',
+		});
+	}
+
+	const unknownChannels = channels.filter(ch => !VALID_CHANNELS.includes(ch));
+	if (unknownChannels.length > 0) {
+		throw new MessageValidationError(
+			`Unknown channel(s): ${unknownChannels.join(', ')}. Valid channels: ${VALID_CHANNELS.join(', ')}`,
+			{ field: 'channels', unknownChannels },
+		);
+	}
+
+	const text = message.length > MAX_MESSAGE_LENGTH
+		? message.substring(0, MAX_MESSAGE_LENGTH) + '...'
+		: message;
+
+	return { text, channels };
+}
+
+function postMessage() {
+	return async (req, res) => {
+		try {
+			const { text, channels } = validateMessageRequest(req.body);
+			const alert = { text };
+
+			const notificationManager = getNotificationManager();
+			if (!notificationManager) {
+				console.warn('[MessageWebhook] NotificationManager not initialized, initializing...');
+				// Cannot send without initialized services — this is a configuration problem.
+				return res.status(503).json({
+					success: false,
+					error: 'Notification services not initialized',
+				});
+			}
+
+			const results = await notificationManager.sendToChannels(alert, channels);
+
+			res.json({ success: true, results });
+		} catch (error) {
+			if (error instanceof MessageValidationError) {
+				return res.status(error.statusCode).json({
+					success: false,
+					error: error.message,
+					details: error.details,
+				});
+			}
+
+			console.error('[MessageWebhook] Request failed:', error.message);
+			sentryService.captureRuntimeError({
+				channel: 'http-message',
+				error,
+				http: {
+					endpoint: '/api/webhook/message',
+					method: 'POST',
+					statusCode: 500,
+				},
+			});
+
+			res.status(500).json({
+				success: false,
+				error: 'Internal server error',
+			});
+		}
+	};
+}
+
+module.exports = {
+	postMessage,
+	MessageValidationError,
+	VALID_CHANNELS,
+	MAX_MESSAGE_LENGTH,
+};

--- a/src/controllers/webhooks/handlers/message/message.js
+++ b/src/controllers/webhooks/handlers/message/message.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 const sentryService = require('../../../../services/monitoring/SentryService');
-const { getNotificationManager } = require('../alert/alert');
+const { getNotificationManager, initializeNotificationServices } = require('../alert/alert');
 
 const VALID_CHANNELS = ['telegram', 'whatsapp'];
 const MAX_MESSAGE_LENGTH = 4000;
@@ -48,20 +48,28 @@ function validateMessageRequest(body) {
 	return { text, channels };
 }
 
-function postMessage() {
+function postMessage(botOrGetter) {
 	return async (req, res) => {
 		try {
 			const { text, channels } = validateMessageRequest(req.body);
 			const alert = { text };
 
-			const notificationManager = getNotificationManager();
+			let notificationManager = getNotificationManager();
 			if (!notificationManager) {
 				console.warn('[MessageWebhook] NotificationManager not initialized, initializing...');
-				// Cannot send without initialized services — this is a configuration problem.
-				return res.status(503).json({
-					success: false,
-					error: 'Notification services not initialized',
-				});
+
+				const bot = typeof botOrGetter === 'function' ? botOrGetter() : (botOrGetter || null);
+				if (bot) {
+					await initializeNotificationServices(bot);
+					notificationManager = getNotificationManager();
+				}
+
+				if (!notificationManager) {
+					return res.status(503).json({
+						success: false,
+						error: 'Notification services not initialized',
+					});
+				}
 			}
 
 			const results = await notificationManager.sendToChannels(alert, channels);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -21,7 +21,7 @@ const { idempotencyMiddleware } = require('../lib/idempotency');
 function getRoutes(botOrGetter) {
 	const router = express.Router();
 	router.post('/webhook/alert', validateApiKey, idempotencyMiddleware, postAlert(botOrGetter));
-	router.post('/webhook/message', validateApiKey, postMessage());
+	router.post('/webhook/message', validateApiKey, postMessage(botOrGetter));
 	router.post('/webhook/expanded-analysis-alert', validateApiKey, idempotencyMiddleware, postExpandedAnalysisAlert(botOrGetter));
 	router.post('/webhook/market-scanner-alert', validateApiKey, idempotencyMiddleware, postMarketScannerAlert(botOrGetter));
 	router.post('/webhook/volume-confirmation', validateApiKey, postVolumeConfirmation());

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { postAlert } = require('../controllers/webhooks/handlers/alert/alert');
+const { postMessage } = require('../controllers/webhooks/handlers/message/message');
 const { postExpandedAnalysisAlert } = require('../controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert');
 const { postMarketScannerAlert } = require('../controllers/webhooks/handlers/marketScanner/marketScanner');
 const { postVolumeConfirmation } = require('../controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation');
@@ -12,6 +13,7 @@ const { idempotencyMiddleware } = require('../lib/idempotency');
 function getRoutes(botOrGetter) {
 	const router = express.Router();
 	router.post('/webhook/alert', validateApiKey, idempotencyMiddleware, postAlert(botOrGetter));
+	router.post('/webhook/message', validateApiKey, postMessage());
 	router.post('/webhook/expanded-analysis-alert', validateApiKey, idempotencyMiddleware, postExpandedAnalysisAlert(botOrGetter));
 	router.post('/webhook/market-scanner-alert', validateApiKey, idempotencyMiddleware, postMarketScannerAlert(botOrGetter));
 	router.post('/webhook/volume-confirmation', validateApiKey, postVolumeConfirmation());

--- a/src/services/notification/NotificationManager.js
+++ b/src/services/notification/NotificationManager.js
@@ -50,10 +50,129 @@ class NotificationManager {
 	}
 
 	/**
-   * Send alert to all enabled channels in parallel
-   * @param {Object} alert - Alert object with text and optional enriched content
-   * @returns {Promise<Array>} Array of SendResult objects (one per enabled channel)
-   */
+    * Send alert to specific channels by name, in parallel
+    * @param {Object} alert - Alert object with text and optional enriched content
+    * @param {Array<string>} channelNames - Array of channel names to send to (e.g. ['telegram', 'whatsapp'])
+    * @param {Object} [options] - Optional options (e.g. { parentSpan })
+    * @returns {Promise<Array>} Array of SendResult objects
+    */
+	async sendToChannels(alert, channelNames = [], options = {}) {
+		if (!channelNames || channelNames.length === 0) {
+			console.warn('[NotificationManager] No channels specified for sendToChannels');
+			return [];
+		}
+
+		const channels = channelNames
+			.map(name => {
+				const ch = this.channels.get(name);
+				if (!ch) {
+					console.warn(`[NotificationManager] Unknown channel: ${name}`);
+					return null;
+				}
+				if (!ch.isEnabled()) {
+					console.debug(`[NotificationManager] Channel ${name} is not enabled, skipping`);
+					return null;
+				}
+				return ch;
+			})
+			.filter(Boolean);
+
+		if (channels.length === 0) {
+			console.warn('[NotificationManager] No enabled channels matched the requested channel names');
+			return [];
+		}
+
+		const startTime = Date.now();
+		const { parentSpan } = options;
+
+		console.debug('[NotificationManager] Sending alert to', channels.length, 'specific channel(s):', channels.map(ch => ch.name).join(', '));
+		const dispatchSpan = sentryService.startInactiveSpan({
+			name: 'notification.send_to_channels',
+			op: 'notification.dispatch',
+			onlyIfParent: true,
+			parentSpan,
+			attributes: {
+				'notification.requested_channels': channelNames.join(','),
+				'notification.enabled_channels_count': channels.length,
+				'alert.enriched': !!(alert && alert.enriched),
+			},
+		});
+
+		let results;
+		try {
+			const sendPromises = channels.map((ch) => {
+				const sendSpan = sentryService.startInactiveSpan({
+					name: `notification.send.${ch.name}`,
+					op: 'notification.send',
+					onlyIfParent: true,
+					parentSpan: dispatchSpan,
+					attributes: {
+						'notification.channel': ch.name,
+						'alert.enriched': !!(alert && alert.enriched),
+						'alert.length': alert && alert.text ? alert.text.length : 0,
+					},
+				});
+
+				return Promise.resolve()
+					.then(() => ch.send(alert))
+					.finally(() => {
+						sentryService.endSpan(sendSpan);
+					});
+			});
+
+			results = await Promise.allSettled(sendPromises);
+		} finally {
+			sentryService.endSpan(dispatchSpan);
+		}
+
+		const formattedResults = results.map((r, idx) =>
+			r.status === 'fulfilled'
+				? r.value
+				: {
+					success: false,
+					channel: channels[idx].name,
+					error: (r.reason && r.reason.message) || 'Unknown error',
+				},
+		);
+
+		// Report external failures to Sentry
+		const totalDurationMs = Date.now() - startTime;
+		for (const result of formattedResults) {
+			if (!result.success && result.error) {
+				const providerMap = {
+					telegram: 'telegram-api',
+					whatsapp: 'whatsapp-greenapi',
+				};
+				const provider = providerMap[result.channel] || result.channel;
+
+				sentryService.captureExternalFailure({
+					channel: result.channel,
+					external: {
+						provider,
+						attemptCount: result.attemptCount || 1,
+						durationMs: result.durationMs || totalDurationMs,
+						lastErrorMessage: result.error,
+						lastErrorCode: result.statusCode,
+					},
+				});
+			}
+		}
+
+		console.info('[NotificationManager] Delivery results:', JSON.stringify(formattedResults.map(r => ({
+			channel: r.channel,
+			success: r.success,
+			messageId: r.messageId,
+			error: r.error,
+		}))));
+
+		return formattedResults;
+	}
+
+	/**
+    * Send alert to all enabled channels in parallel
+    * @param {Object} alert - Alert object with text and optional enriched content
+    * @returns {Promise<Array>} Array of SendResult objects (one per enabled channel)
+    */
 	async sendToAll(alert, options = {}) {
 		const enabledChannels = Array.from(this.channels.values()).filter((ch) => ch.isEnabled());
 		const startTime = Date.now();

--- a/src/services/notification/TelegramService.js
+++ b/src/services/notification/TelegramService.js
@@ -97,13 +97,14 @@ class TelegramService extends NotificationChannel {
 				console.debug('Formatted text for Telegram:', formattedText);
 			}
 
-			this.logger?.debug?.(`Sending to Telegram chat ${this.chatId}`);
+			const chatId = alert.telegramChatId || this.chatId;
+			this.logger?.debug?.(`Sending to Telegram chat ${chatId}`);
 			const messageParts = splitTelegramMessage(formattedText, this.maxMessageLength);
 
 			// Send to Telegram
 			const messageIds = [];
 			for (const messagePart of messageParts) {
-				const result = await this.bot.telegram.sendMessage(this.chatId, messagePart, {
+				const result = await this.bot.telegram.sendMessage(chatId, messagePart, {
 					parse_mode: 'MarkdownV2',
 					disable_web_page_preview: !!alert.enriched,
 				});

--- a/src/services/notification/WhatsAppService.js
+++ b/src/services/notification/WhatsAppService.js
@@ -101,9 +101,9 @@ class WhatsAppService extends NotificationChannel {
 			// Truncate to GreenAPI limit
 			const truncatedText = truncateMessage(formattedText, 20000);
 
-			// Build GreenAPI payload
+			// Build GreenAPI payload (support per-request chatId override)
 			const payload = {
-				chatId: this.chatId,
+				chatId: alert.whatsappChatId || this.chatId,
 				message: truncatedText,
 				customPreview: {
 					title: 'Trading View Alert',

--- a/tests/integration/generic-message-webhook.test.js
+++ b/tests/integration/generic-message-webhook.test.js
@@ -183,6 +183,136 @@ describe('POST /api/webhook/message - Generic message webhook', () => {
 	});
 
 	// ---------------------------------------------------------------------------
+	// Chat ID override cases
+	// ---------------------------------------------------------------------------
+	it('sends to a custom telegramChatId override', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Override TG chat', channels: ['telegram'], telegramChatId: '-100999888777' })
+			.expect(200);
+
+		expect(res.body.success).toBe(true);
+		expect(res.body.results).toHaveLength(1);
+		expect(res.body.results[0].channel).toBe('telegram');
+		expect(res.body.results[0].success).toBe(true);
+
+		// Verify sendMessage was called with the override chatId, not the default
+		expect(mockBot.telegram.sendMessage).toHaveBeenCalledWith(
+			'-100999888777',
+			expect.any(String),
+			expect.any(Object),
+		);
+	});
+
+	it('sends to a custom whatsappChatId override', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Override WA chat', channels: ['whatsapp'], whatsappChatId: '120363555555555555@g.us' })
+			.expect(200);
+
+		expect(res.body.success).toBe(true);
+		expect(res.body.results).toHaveLength(1);
+		expect(res.body.results[0].channel).toBe('whatsapp');
+		expect(res.body.results[0].success).toBe(true);
+
+		// Verify fetch was called with the override chatId in the body
+		const fetchCall = global.fetch.mock.calls[0];
+		const fetchBody = JSON.parse(fetchCall[1].body);
+		expect(fetchBody.chatId).toBe('120363555555555555@g.us');
+	});
+
+	it('sends with both chatId overrides simultaneously', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({
+				message: 'Override both chats',
+				channels: ['telegram', 'whatsapp'],
+				telegramChatId: '-100111222333',
+				whatsappChatId: '120363666666666666@g.us',
+			})
+			.expect(200);
+
+		expect(res.body.success).toBe(true);
+		expect(res.body.results).toHaveLength(2);
+
+		// Telegram used override
+		expect(mockBot.telegram.sendMessage).toHaveBeenCalledWith(
+			'-100111222333',
+			expect.any(String),
+			expect.any(Object),
+		);
+
+		// WhatsApp used override
+		const fetchCall = global.fetch.mock.calls[0];
+		const fetchBody = JSON.parse(fetchCall[1].body);
+		expect(fetchBody.chatId).toBe('120363666666666666@g.us');
+	});
+
+	it('returns 400 when telegramChatId is not a string', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello', channels: ['telegram'], telegramChatId: 12345 })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('telegramChatId');
+	});
+
+	it('returns 400 when telegramChatId is an empty string', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello', channels: ['telegram'], telegramChatId: '' })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('telegramChatId');
+	});
+
+	it('returns 400 when whatsappChatId is not a string', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello', channels: ['whatsapp'], whatsappChatId: true })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('whatsappChatId');
+	});
+
+	it('returns 400 when whatsappChatId is an empty string', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello', channels: ['whatsapp'], whatsappChatId: '' })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('whatsappChatId');
+	});
+
+	it('sends message without override when telegramChatId is not provided', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Default chat', channels: ['telegram'] })
+			.expect(200);
+
+		expect(res.body.success).toBe(true);
+
+		// Verify sendMessage was called with the default chatId
+		expect(mockBot.telegram.sendMessage).toHaveBeenCalledWith(
+			'123456789',
+			expect.any(String),
+			expect.any(Object),
+		);
+	});
+
+	// ---------------------------------------------------------------------------
 	// Provider failure isolation
 	// ---------------------------------------------------------------------------
 	it('does not block the other channel when one provider fails', async () => {

--- a/tests/integration/generic-message-webhook.test.js
+++ b/tests/integration/generic-message-webhook.test.js
@@ -1,0 +1,236 @@
+/* global jest, describe, it, beforeEach, afterEach, expect */
+
+const request = require('supertest');
+const app = require('../../app');
+const { getRoutes } = require('../../src/routes');
+const { initializeNotificationServices } = require('../../src/controllers/webhooks/handlers/alert/alert');
+
+describe('POST /api/webhook/message - Generic message webhook', () => {
+	const originalEnv = process.env;
+	let mockBot;
+
+	beforeEach(async () => {
+		process.env = {
+			...originalEnv,
+			WEBHOOK_API_KEY: 'test-key',
+			ENABLE_TELEGRAM_BOT: 'true',
+			ENABLE_WHATSAPP_ALERTS: 'true',
+			BOT_TOKEN: 'test-bot-token',
+			TELEGRAM_CHAT_ID: '123456789',
+			WHATSAPP_API_URL: 'https://api.greenapi.com/waInstance123/',
+			WHATSAPP_API_KEY: 'test-whatsapp-key',
+			WHATSAPP_CHAT_ID: '120363000000000000@g.us',
+			ENABLE_GEMINI_GROUNDING: 'false',
+		};
+
+		jest.clearAllMocks();
+
+		mockBot = {
+			telegram: {
+				sendMessage: jest.fn().mockResolvedValue({ message_id: 'tg-msg-123' }),
+				getMe: jest.fn().mockResolvedValue({ id: 123456789, username: 'TestBot' }),
+			},
+		};
+
+		// Mock global.fetch for WhatsApp GreenAPI calls
+		global.fetch = jest.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ idMessage: 'wa-msg-456' }),
+		});
+
+		await initializeNotificationServices(mockBot);
+		app.use('/api', getRoutes(mockBot));
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		if (app._router && app._router.stack && app._router.stack.length > 0) {
+			app._router.stack.pop();
+		}
+	});
+
+	// ---------------------------------------------------------------------------
+	// Success cases
+	// ---------------------------------------------------------------------------
+	it('sends a message to telegram only', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello from test', channels: ['telegram'] })
+			.expect(200);
+
+		expect(res.body.success).toBe(true);
+		expect(res.body.results).toHaveLength(1);
+		expect(res.body.results[0].channel).toBe('telegram');
+		expect(res.body.results[0].success).toBe(true);
+		expect(res.body.results[0].messageId).toBe('tg-msg-123');
+		expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it('sends a message to whatsapp only', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello WhatsApp', channels: ['whatsapp'] })
+			.expect(200);
+
+		expect(res.body.success).toBe(true);
+		expect(res.body.results).toHaveLength(1);
+		expect(res.body.results[0].channel).toBe('whatsapp');
+		expect(res.body.results[0].success).toBe(true);
+		expect(res.body.results[0].messageId).toBe('wa-msg-456');
+		expect(mockBot.telegram.sendMessage).not.toHaveBeenCalled();
+		expect(global.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it('sends a message to both channels', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello both channels', channels: ['telegram', 'whatsapp'] })
+			.expect(200);
+
+		expect(res.body.success).toBe(true);
+		expect(res.body.results).toHaveLength(2);
+		expect(res.body.results[0].channel).toBe('telegram');
+		expect(res.body.results[0].success).toBe(true);
+		expect(res.body.results[1].channel).toBe('whatsapp');
+		expect(res.body.results[1].success).toBe(true);
+		expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+		expect(global.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Validation error cases
+	// ---------------------------------------------------------------------------
+	it('returns 400 when message is empty', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: '', channels: ['telegram'] })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('non-empty string');
+	});
+
+	it('returns 400 when message is missing', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ channels: ['telegram'] })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('message');
+	});
+
+	it('returns 400 when message is not a string', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 12345, channels: ['telegram'] })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('message');
+	});
+
+	it('returns 400 when channels is missing', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello' })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('channels');
+	});
+
+	it('returns 400 when channels is empty array', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello', channels: [] })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('channels');
+	});
+
+	it('returns 400 when channels contains unknown channel', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello', channels: ['telegram', 'discord'] })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('Unknown channel');
+		expect(res.body.error).toContain('discord');
+	});
+
+	it('returns 400 when channels is not an array', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Hello', channels: 'telegram' })
+			.expect(400);
+
+		expect(res.body.success).toBe(false);
+		expect(res.body.error).toContain('channels');
+	});
+
+	// ---------------------------------------------------------------------------
+	// Provider failure isolation
+	// ---------------------------------------------------------------------------
+	it('does not block the other channel when one provider fails', async () => {
+		// Make WhatsApp fetch fail
+		global.fetch.mockRejectedValue(new Error('WhatsApp API timeout'));
+
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'test-key')
+			.send({ message: 'Partial failure test', channels: ['telegram', 'whatsapp'] })
+			.expect(200);
+
+		// Telegram still succeeds
+		expect(res.body.results[0].channel).toBe('telegram');
+		expect(res.body.results[0].success).toBe(true);
+
+		// WhatsApp fails (after retries)
+		expect(res.body.results[1].channel).toBe('whatsapp');
+		expect(res.body.results[1].success).toBe(false);
+		expect(res.body.results[1].error).toContain('WhatsApp API timeout');
+
+		// Overall success is still true (fail-open pattern)
+		expect(res.body.success).toBe(true);
+
+		expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+		// fetch is called multiple times due to WhatsApp retry logic
+		expect(global.fetch).toHaveBeenCalled();
+	});
+
+	// ---------------------------------------------------------------------------
+	// API key protection
+	// ---------------------------------------------------------------------------
+	it('returns 401 without API key', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.send({ message: 'Hello', channels: ['telegram'] })
+			.expect(401);
+
+		expect(res.body.error).toContain('Unauthorized');
+	});
+
+	it('returns 403 with wrong API key', async () => {
+		const res = await request(app)
+			.post('/api/webhook/message')
+			.set('x-api-key', 'wrong-key')
+			.send({ message: 'Hello', channels: ['telegram'] })
+			.expect(403);
+
+		expect(res.body.error).toContain('Forbidden');
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds a **generic message webhook** endpoint (`POST /api/webhook/message`) for sending custom text messages through configured notification channels, plus per-request chat ID overrides and preview environment support.

## Changes

### New endpoint: `POST /api/webhook/message`

Sends a plain text message to specified channels without the alert enrichment pipeline.

```json
{
  "message": "Custom notification from automation",
  "channels": ["telegram", "whatsapp"]
}
```

- Validates: message (non-empty string), channels (known values: telegram, whatsapp)
- Unaffected by enrichment — pure text delivery
- Supports partial failure isolation (one channel down doesn't block the other)
- Protected by `validateApiKey` middleware (same `x-api-key` as other endpoints)

### Per-request chat ID overrides

Both `telegramChatId` and `whatsappChatId` can be specified in the payload to override the default env-configured chat IDs:

```json
{
  "message": "Alert to specific group",
  "channels": ["telegram"],
  "telegramChatId": "-100999888777"
}
```

- Both fields are optional and validated as non-empty strings when provided
- **TelegramService**: reads `alert.telegramChatId` before falling back to `this.chatId`
- **WhatsAppService**: reads `alert.whatsappChatId` in the GreenAPI payload before falling back to `this.chatId`

### Preview environment support

`postMessage()` now accepts `botOrGetter` and auto-initializes notification services when not ready, ensuring `WhatsAppService` is created with the correct chatId and respecting `WHATSAPP_PREVIEW_CHAT_ID` from #93 in preview deployments.

### Files changed

| File | Change |
|------|--------|
| `src/controllers/webhooks/handlers/message/message.js` | New endpoint handler + chatId override support |
| `src/services/notification/TelegramService.js` | Support `alert.telegramChatId` override in `send()` |
| `src/services/notification/WhatsAppService.js` | Support `alert.whatsappChatId` override in `_sendSingle()` |
| `src/routes/index.js` | Register route, pass `botOrGetter` |
| `tests/integration/generic-message-webhook.test.js` | 21 tests: basic send, validation, chatId overrides, partial failure, auth |
| `CabrosBot.postman_collection.json` | Request + response examples, error variants |

### Testing

- 21 integration tests passing: success paths, validation errors, chatId overrides, partial failure isolation, API key protection
- Full suite: 633 tests pass (55 suites, 0 failures)