### PR TITLE
feat: add WHATSAPP_PREVIEW_CHAT_ID for preview env routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ WHATSAPP_API_KEY=your_whatsapp_api_key
 # WhatsApp chat/group ID (format: 120363xxxxx@g.us)
 WHATSAPP_CHAT_ID=your_whatsapp_chat_id_here
 
+# WhatsApp preview/PR chat/group ID (optional)
+# When IS_PULL_REQUEST=true, messages are sent here instead of WHATSAPP_CHAT_ID
+WHATSAPP_PREVIEW_CHAT_ID=your_whatsapp_preview_chat_id_here
+
 # ============================================================================
 # OPTIONAL: AI Grounding (Gemini GoogleSearch Enrichment)
 # ============================================================================

--- a/src/services/notification/WhatsAppService.js
+++ b/src/services/notification/WhatsAppService.js
@@ -22,7 +22,10 @@ class WhatsAppService extends NotificationChannel {
 		this.name = 'whatsapp';
 		this.apiUrl = config.apiUrl || process.env.WHATSAPP_API_URL;
 		this.apiKey = config.apiKey || process.env.WHATSAPP_API_KEY;
-		this.chatId = config.chatId || process.env.WHATSAPP_CHAT_ID;
+
+		// In preview environments (IS_PULL_REQUEST=true), prefer WHATSAPP_PREVIEW_CHAT_ID
+		const isPreview = process.env.IS_PULL_REQUEST === 'true';
+		this.chatId = config.chatId || (isPreview && process.env.WHATSAPP_PREVIEW_CHAT_ID) || process.env.WHATSAPP_CHAT_ID;
 		this.urlShortener = config.urlShortener || null;
 		this.formatter = config.formatter || new WhatsAppMarkdownFormatter({ urlShortener: this.urlShortener });
 		this.logger = config.logger;


### PR DESCRIPTION
## Summary

Add `WHATSAPP_PREVIEW_CHAT_ID` environment variable to route WhatsApp messages to a different group when `IS_PULL_REQUEST=true` (Render preview environments). This mirrors the existing preview isolation pattern used by Telegram (which disables entirely in PRs) while letting WhatsApp deliver alerts to a dedicated test group.

## Key Changes

### WhatsAppService preview-aware routing

- **`src/services/notification/WhatsAppService.js`**: When `IS_PULL_REQUEST=true`, the constructor prefers `WHATSAPP_PREVIEW_CHAT_ID` over `WHATSAPP_CHAT_ID`. Falls back gracefully to `WHATSAPP_CHAT_ID` if the preview var is unset, so existing deployments are unaffected.

### Documentation

- **`.env.example`**: Added `WHATSAPP_PREVIEW_CHAT_ID` with documentation under the WhatsApp Alerts section.

## Configuration Updates

### Environment Variables

```bash
# WhatsApp preview/PR chat/group ID (optional)
# When IS_PULL_REQUEST=true, messages are sent here instead of WHATSAPP_CHAT_ID
WHATSAPP_PREVIEW_CHAT_ID=your_whatsapp_preview_chat_id_here
```

## Deployment Considerations

No migration steps needed. Existing deployments with `IS_PULL_REQUEST=true` but without `WHATSAPP_PREVIEW_CHAT_ID` will continue using `WHATSAPP_CHAT_ID` as before.