### PR TITLE
feat(jobs): persist tradingview jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 #### Firestore Alert Storage
 
 - `ENABLE_FIRESTORE_ALERT_STORAGE` - Enable Firestore persistence and alert read API (`true` or `false`, default: `false`)
+- `ENABLE_FIRESTORE_JOB_STORAGE` - Enable Firestore persistence for async TradingView jobs without enabling alert read APIs (`true` or `false`, default: `false`)
 - `FIREBASE_SERVICE_ACCOUNT_JSON` - Inline Firebase service account JSON for server-side Firestore access
 - `FIREBASE_PROJECT_ID` - Optional Firebase project override for Admin SDK initialization
 - `GOOGLE_APPLICATION_CREDENTIALS` - Optional path to a service account JSON file for local development
@@ -655,7 +656,9 @@ Start a background analysis or scanner job.
 #### GET /api/jobs/:jobId
 
 Retrieve status, partial progress, final report, and delivery state of a job.
-Jobs are retained in memory and automatically evicted after 1 hour.
+Jobs are retained in memory and, when Firestore job storage is enabled, persisted to the `tradingviewJobs` collection so status survives process restarts. Completed and failed jobs are automatically evicted after 1 hour.
+
+Set `ENABLE_FIRESTORE_JOB_STORAGE=true` plus the normal Firebase Admin credentials (`FIREBASE_SERVICE_ACCOUNT_JSON` or `GOOGLE_APPLICATION_CREDENTIALS`) to enable durable job storage. The legacy in-memory path remains the fallback when Firestore is disabled or unavailable.
 
 **Response (200 OK - Processing):**
 ```json

--- a/agents.md
+++ b/agents.md
@@ -390,13 +390,15 @@ The system provides asynchronous job endpoints to support executing both `expand
 - `GET /api/jobs/:jobId` — Returns the current job status (`pending`, `processing`, `completed`, `failed`), progress, and final analysis/delivery outcomes.
 
 **Core Components**:
-- `src/services/jobs/JobService.js` — Coordinates job state tracking, background worker execution, progress reports, and job eviction (jobs older than 1 hour).
+- `src/services/jobs/JobService.js` — Coordinates job state tracking, background worker execution, progress reports, durable persistence checkpoints, and job eviction (jobs older than 1 hour).
+- `src/services/jobs/JobRepository.js` — Stores sanitized job records in memory and, when `ENABLE_FIRESTORE_JOB_STORAGE=true`, in Firestore collection `tradingviewJobs`.
 - `src/controllers/webhooks/handlers/jobs/jobs.js` — HTTP route controller handlers (`postCreateJob`, `getJobStatus`).
 
 **Failure and Edge Case Behavior**:
 - Sync validation: throws `400` synchronously on invalid inputs before job registration.
 - Feature checks: returns `404 FEATURE_DISABLED` if market scanner jobs are created but `ENABLE_MARKET_SCANNER` is not `'true'`.
-- Eviction: jobs older than 1 hour are deleted from memory and return `404 Not Found`.
+- Persistence: `createJob()` and `getJob()` are async because job metadata/results may be written to or read from Firestore.
+- Eviction: completed/failed jobs older than 1 hour are deleted from memory/Firestore and return `404 Not Found`; active jobs are preserved.
 - Background failures: if the worker runs into unexpected exceptions or timeouts, the job is marked `failed` and reported to Sentry.
 
 **Where to look first when extending or debugging**:

--- a/src/controllers/webhooks/handlers/jobs/jobs.js
+++ b/src/controllers/webhooks/handlers/jobs/jobs.js
@@ -4,7 +4,7 @@ const { jobService } = require('../../../../services/jobs/JobService');
 const sentryService = require('../../../../services/monitoring/SentryService');
 
 function postCreateJob(botOrGetter) {
-	return (req, res) => {
+	return async (req, res) => {
 		const { type } = req.body || {};
 
 		if (!type) {
@@ -15,7 +15,7 @@ function postCreateJob(botOrGetter) {
 		}
 
 		try {
-			const result = jobService.createJob(type, req.body, botOrGetter);
+			const result = await jobService.createJob(type, req.body, botOrGetter);
 			return res.status(201).json(result);
 		} catch (error) {
 			if (
@@ -48,7 +48,7 @@ function postCreateJob(botOrGetter) {
 	};
 }
 
-function getJobStatus(req, res) {
+async function getJobStatus(req, res) {
 	const { jobId } = req.params;
 
 	if (!jobId) {
@@ -59,7 +59,7 @@ function getJobStatus(req, res) {
 	}
 
 	try {
-		const job = jobService.getJob(jobId);
+		const job = await jobService.getJob(jobId);
 
 		if (!job) {
 			return res.status(404).json({

--- a/src/services/jobs/JobRepository.js
+++ b/src/services/jobs/JobRepository.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const alertStorageService = require('../storage/AlertStorageService');
+
+const COLLECTION_NAME = 'tradingviewJobs';
+const memoryJobs = new Map();
+
+function cloneJob(job) {
+	if (!job) return null;
+	return JSON.parse(JSON.stringify(job));
+}
+
+function isFirestoreEnabled() {
+	return process.env.ENABLE_FIRESTORE_JOB_STORAGE === 'true'
+		|| process.env.ENABLE_FIRESTORE_ALERT_STORAGE === 'true';
+}
+
+function sanitizeJob(job) {
+	const copy = cloneJob(job);
+	if (!copy) return null;
+	delete copy.payload;
+	delete copy.bot;
+	delete copy.botOrGetter;
+	delete copy.signal;
+	return copy;
+}
+
+class JobRepository {
+	async save(job) {
+		const sanitized = sanitizeJob(job);
+		if (!sanitized || !sanitized.jobId) {
+			return null;
+		}
+
+		memoryJobs.set(sanitized.jobId, cloneJob(sanitized));
+
+		const firestore = this._getFirestore();
+		if (!firestore) {
+			return sanitized.jobId;
+		}
+
+		try {
+			await firestore.collection(COLLECTION_NAME).doc(sanitized.jobId).set(sanitized);
+		} catch (error) {
+			console.warn('[JobRepository] Failed to persist job:', error.message);
+		}
+
+		return sanitized.jobId;
+	}
+
+	async get(jobId) {
+		if (!jobId) {
+			return null;
+		}
+
+		const firestore = this._getFirestore();
+		if (firestore) {
+			try {
+				const snapshot = await firestore.collection(COLLECTION_NAME).doc(jobId).get();
+				if (snapshot && snapshot.exists) {
+					const data = snapshot.data() || {};
+					const job = { ...data, jobId: data.jobId || snapshot.id };
+					memoryJobs.set(job.jobId, cloneJob(job));
+					return cloneJob(job);
+				}
+			} catch (error) {
+				console.warn('[JobRepository] Failed to read job from Firestore:', error.message);
+			}
+		}
+
+		return cloneJob(memoryJobs.get(jobId));
+	}
+
+	async delete(jobId) {
+		if (!jobId) {
+			return false;
+		}
+
+		let deleted = memoryJobs.delete(jobId);
+		const firestore = this._getFirestore();
+		if (firestore) {
+			try {
+				await firestore.collection(COLLECTION_NAME).doc(jobId).delete();
+				deleted = true;
+			} catch (error) {
+				console.warn('[JobRepository] Failed to delete job from Firestore:', error.message);
+			}
+		}
+
+		return deleted;
+	}
+
+	has(jobId) {
+		return memoryJobs.has(jobId);
+	}
+
+	setMemory(jobId, job) {
+		memoryJobs.set(jobId, cloneJob(job));
+	}
+
+	getMemory(jobId) {
+		return cloneJob(memoryJobs.get(jobId));
+	}
+
+	entries() {
+		return [...memoryJobs.entries()].map(([id, job]) => [id, cloneJob(job)]);
+	}
+
+	_getFirestore() {
+		if (!isFirestoreEnabled()) {
+			return null;
+		}
+		return alertStorageService.getFirestore();
+	}
+}
+
+const jobRepository = new JobRepository();
+
+module.exports = {
+	JobRepository,
+	jobRepository,
+	COLLECTION_NAME,
+	_resetForTesting() {
+		memoryJobs.clear();
+	},
+};

--- a/src/services/jobs/JobService.js
+++ b/src/services/jobs/JobService.js
@@ -15,26 +15,28 @@ const {
 	initializeNotificationServices,
 } = require('../../controllers/webhooks/handlers/alert/alert');
 const sentryService = require('../monitoring/SentryService');
+const { jobRepository } = require('./JobRepository');
 
 const EXPIRATION_MS = 3600000; // 1 hour
 const DEFAULT_JOB_TIMEOUT_MS = 300000; // 5 minutes
 
 class JobService {
-	constructor() {
-		this.jobs = new Map();
+	constructor(repository = jobRepository) {
+		this.repository = repository;
+		this.jobs = repository;
 	}
 
 	/**
 	 * Cleans up jobs older than 1 hour if they are completed or failed.
 	 */
-	_cleanExpiredJobs() {
+	async _cleanExpiredJobs() {
 		const now = Date.now();
-		for (const [id, job] of this.jobs.entries()) {
+		for (const [id, job] of this.repository.entries()) {
 			if (
 				now - new Date(job.createdAt).getTime() > EXPIRATION_MS &&
 				(job.status === 'completed' || job.status === 'failed')
 			) {
-				this.jobs.delete(id);
+				await this.repository.delete(id);
 			}
 		}
 	}
@@ -44,10 +46,18 @@ class JobService {
 	 * @param {string} jobId
 	 * @returns {Object|null}
 	 */
-	getJob(jobId) {
-		this._cleanExpiredJobs();
-		const job = this.jobs.get(jobId);
+	async getJob(jobId) {
+		await this._cleanExpiredJobs();
+		const job = await this.repository.get(jobId);
 		if (!job) {
+			return null;
+		}
+
+		if (
+			Date.now() - new Date(job.createdAt).getTime() > EXPIRATION_MS &&
+			(job.status === 'completed' || job.status === 'failed')
+		) {
+			await this.repository.delete(jobId);
 			return null;
 		}
 
@@ -103,8 +113,8 @@ class JobService {
 	 * @param {Function|Object} botOrGetter - Telegraf bot instance or getter
 	 * @returns {Object} The created job metadata
 	 */
-	createJob(type, payload, botOrGetter) {
-		this._cleanExpiredJobs();
+	async createJob(type, payload, botOrGetter) {
+		await this._cleanExpiredJobs();
 
 		// Synchronous validation based on job type
 		let parsed;
@@ -147,7 +157,7 @@ class JobService {
 		const job = {
 			jobId,
 			type,
-			status: 'pending',
+			status: 'processing',
 			progress: {
 				total: type === 'expanded-analysis' ? parsed.symbols.length : parsed.scans.length,
 				current: 0,
@@ -166,7 +176,7 @@ class JobService {
 			timeoutMs: validatedTimeoutMs,
 		};
 
-		this.jobs.set(jobId, job);
+		await this.repository.save(job);
 
 		// Execute background job (fire-and-forget)
 		this._runBackgroundJob(jobId, parsed, payload, botOrGetter).catch((error) => {
@@ -186,11 +196,12 @@ class JobService {
 	 */
 	async _runBackgroundJob(jobId, parsed, payload, botOrGetter) {
 		const startTime = Date.now();
-		const job = this.jobs.get(jobId);
+		const job = await this.repository.get(jobId);
 		if (!job) return;
 
 		job.status = 'processing';
 		job.updatedAt = new Date().toISOString();
+		await this._persistJob(job);
 
 		// Setup Timeout AbortController
 		const timeoutMs = job.timeoutMs || DEFAULT_JOB_TIMEOUT_MS;
@@ -226,6 +237,7 @@ class JobService {
 			clearTimeout(timeoutId);
 			job.totalDurationMs = Date.now() - startTime;
 			job.updatedAt = new Date().toISOString();
+			await this._persistJob(job);
 		}
 	}
 
@@ -237,6 +249,7 @@ class JobService {
 			job.progress.current = index;
 			job.progress.status = `Analyzing symbol ${input.raw} (${index + 1}/${symbols.length})`;
 			job.updatedAt = new Date().toISOString();
+			await this._persistJob(job);
 
 			if (signal && signal.aborted) {
 				this._appendTimeoutResults(job.fullResults, symbols.slice(index), this._getAbortMessage(signal));
@@ -304,6 +317,7 @@ class JobService {
 		job.progress.current = symbols.length;
 		job.progress.status = 'Completed analysis';
 		job.updatedAt = new Date().toISOString();
+		await this._persistJob(job);
 
 		const timedOut = job.fullResults.some((r) => r.status === 'timeout');
 		const analyzedItems = job.fullResults
@@ -320,6 +334,7 @@ class JobService {
 				? 'Expanded analysis job timed out.'
 				: 'TradingView MCP failed for all requested symbols.';
 			job.code = timedOut ? 'EXPANDED_ANALYSIS_ALERT_TIMEOUT' : 'ALL_SYMBOLS_FAILED';
+			await this._persistJob(job);
 			return;
 		}
 
@@ -335,6 +350,7 @@ class JobService {
 		job.deliveryResults = deliveryResults;
 		job.summary = this._buildExpandedSummary(job.fullResults, deliveryResults);
 		job.status = 'completed';
+		await this._persistJob(job);
 	}
 
 	async _executeMarketScanner(job, parsed, signal, botOrGetter) {
@@ -345,6 +361,7 @@ class JobService {
 			job.progress.current = index;
 			job.progress.status = `Running scan ${scanType} (${index + 1}/${scans.length})`;
 			job.updatedAt = new Date().toISOString();
+			await this._persistJob(job);
 
 			if (signal && signal.aborted) {
 				this._appendScannerTimeoutResults(job.fullScanResults, scans.slice(index), this._getAbortMessage(signal));
@@ -392,6 +409,7 @@ class JobService {
 		job.progress.current = scans.length;
 		job.progress.status = 'Completed scans';
 		job.updatedAt = new Date().toISOString();
+		await this._persistJob(job);
 
 		const timedOut = job.fullScanResults.some((r) => r.status === 'timeout');
 		const successfulScans = job.fullScanResults.filter((r) => r.status === 'success');
@@ -402,6 +420,7 @@ class JobService {
 				? 'Market scanner job timed out.'
 				: 'TradingView MCP failed for all requested scans.';
 			job.code = timedOut ? 'MARKET_SCANNER_TIMEOUT' : 'ALL_SCANS_FAILED';
+			await this._persistJob(job);
 			return;
 		}
 
@@ -421,6 +440,11 @@ class JobService {
 		job.deliveryResults = deliveryResults;
 		job.summary = this._buildScannerSummary(job.fullScanResults, deliveryResults);
 		job.status = 'completed';
+		await this._persistJob(job);
+	}
+
+	async _persistJob(job) {
+		await this.repository.save(job);
 	}
 
 	_buildScanArgs(parsed, scanType) {

--- a/src/services/storage/AlertStorageService.js
+++ b/src/services/storage/AlertStorageService.js
@@ -40,6 +40,10 @@ function isEnabled() {
 	return process.env.ENABLE_FIRESTORE_ALERT_STORAGE === 'true';
 }
 
+function canInitializeFirestore() {
+	return isEnabled() || process.env.ENABLE_FIRESTORE_JOB_STORAGE === 'true';
+}
+
 function clampLimit(limit) {
 	if (!Number.isInteger(limit) || limit < 1) {
 		return DEFAULT_PAGE_SIZE;
@@ -131,7 +135,7 @@ function getDocCursorValues(doc) {
  * @returns {FirebaseFirestore.Firestore | null}
  */
 function getFirestore() {
-	if (!isEnabled()) {
+	if (!canInitializeFirestore()) {
 		return null;
 	}
 

--- a/tests/unit/job-service.test.js
+++ b/tests/unit/job-service.test.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const admin = require('firebase-admin');
 const { JobService } = require('../../src/services/jobs/JobService');
 const { tradingViewMcpService } = require('../../src/services/tradingview/TradingViewMcpService');
+const JobRepository = require('../../src/services/jobs/JobRepository');
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 jest.mock('../../src/services/tradingview/TradingViewMcpService', () => ({
 	tradingViewMcpService: {
@@ -32,6 +36,11 @@ describe('JobService Unit Tests', () => {
 			...originalEnv,
 			ENABLE_MARKET_SCANNER: 'true',
 		};
+		delete process.env.ENABLE_FIRESTORE_JOB_STORAGE;
+		delete process.env.ENABLE_FIRESTORE_ALERT_STORAGE;
+		admin.__resetApps();
+		admin.__resetCollectionState();
+		JobRepository._resetForTesting();
 		jest.clearAllMocks();
 		jobService = new JobService();
 	});
@@ -41,37 +50,32 @@ describe('JobService Unit Tests', () => {
 	});
 
 	describe('createJob', () => {
-		it('throws UNSUPPORTED_TYPE for invalid job type', () => {
-			expect(() => {
-				jobService.createJob('invalid-type', {});
-			}).toThrow('Unsupported job type: invalid-type');
+		it('throws UNSUPPORTED_TYPE for invalid job type', async () => {
+			await expect(jobService.createJob('invalid-type', {}))
+				.rejects.toThrow('Unsupported job type: invalid-type');
 		});
 
-		it('throws FEATURE_DISABLED if market-scanner is requested but disabled', () => {
+		it('throws FEATURE_DISABLED if market-scanner is requested but disabled', async () => {
 			process.env.ENABLE_MARKET_SCANNER = 'false';
-			expect(() => {
-				jobService.createJob('market-scanner', {});
-			}).toThrow('Market scanner is not enabled');
+			await expect(jobService.createJob('market-scanner', {}))
+				.rejects.toThrow('Market scanner is not enabled');
 		});
 
-		it('throws validation error if request payload is invalid', () => {
-			expect(() => {
-				jobService.createJob('expanded-analysis', { symbols: 'not-an-array' });
-			}).toThrow();
+		it('throws validation error if request payload is invalid', async () => {
+			await expect(jobService.createJob('expanded-analysis', { symbols: 'not-an-array' }))
+				.rejects.toThrow();
 		});
 
-		it('throws validation error if timeoutMs is not a positive integer', () => {
-			expect(() => {
-				jobService.createJob('expanded-analysis', { symbols: ['BINANCE:BTCUSDT'], timeoutMs: 'invalid' });
-			}).toThrow('timeoutMs must be a positive integer');
+		it('throws validation error if timeoutMs is not a positive integer', async () => {
+			await expect(jobService.createJob('expanded-analysis', { symbols: ['BINANCE:BTCUSDT'], timeoutMs: 'invalid' }))
+				.rejects.toThrow('timeoutMs must be a positive integer');
 
-			expect(() => {
-				jobService.createJob('expanded-analysis', { symbols: ['BINANCE:BTCUSDT'], timeoutMs: -100 });
-			}).toThrow('timeoutMs must be a positive integer');
+			await expect(jobService.createJob('expanded-analysis', { symbols: ['BINANCE:BTCUSDT'], timeoutMs: -100 }))
+				.rejects.toThrow('timeoutMs must be a positive integer');
 		});
 
-		it('creates a job and returns metadata on success', () => {
-			const result = jobService.createJob('expanded-analysis', {
+		it('creates a job and returns metadata on success', async () => {
+			const result = await jobService.createJob('expanded-analysis', {
 				symbols: ['BINANCE:BTCUSDT'],
 			});
 
@@ -80,20 +84,18 @@ describe('JobService Unit Tests', () => {
 			expect(result.status).toBe('processing');
 		});
 
-		it('correctly validates and parses timeoutMs string format like 1e3', () => {
-			const metadata = jobService.createJob('expanded-analysis', {
+		it('correctly validates and parses timeoutMs string format like 1e3', async () => {
+			const metadata = await jobService.createJob('expanded-analysis', {
 				symbols: ['BINANCE:BTCUSDT'],
 				timeoutMs: '1e3',
 			});
 
-			const rawJob = jobService.jobs.get(metadata.jobId);
+			const rawJob = await jobService.repository.get(metadata.jobId);
 			expect(rawJob.timeoutMs).toBe(1000);
 		});
 	});
 
 	describe('Background execution and retrieval', () => {
-		const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
 		it('completes expanded-analysis job successfully', async () => {
 			tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValueOnce({
 				symbol: 'BINANCE:BTCUSDT',
@@ -101,18 +103,18 @@ describe('JobService Unit Tests', () => {
 				rsi: { value: 45 },
 			});
 
-			const metadata = jobService.createJob('expanded-analysis', {
+			const metadata = await jobService.createJob('expanded-analysis', {
 				symbols: ['BINANCE:BTCUSDT'],
 			});
 
 			const jobId = metadata.jobId;
 
 			// Poll until completed
-			let job = jobService.getJob(jobId);
+			let job = await jobService.getJob(jobId);
 			let attempts = 0;
 			while (job.status !== 'completed' && attempts < 10) {
 				await delay(20);
-				job = jobService.getJob(jobId);
+				job = await jobService.getJob(jobId);
 				attempts++;
 			}
 
@@ -137,18 +139,18 @@ describe('JobService Unit Tests', () => {
 		it('fails expanded-analysis job when all symbols fail', async () => {
 			tradingViewMcpService.analyzeSymbolIdentifier.mockRejectedValueOnce(new Error('MCP Failed'));
 
-			const metadata = jobService.createJob('expanded-analysis', {
+			const metadata = await jobService.createJob('expanded-analysis', {
 				symbols: ['BINANCE:BTCUSDT'],
 			});
 
 			const jobId = metadata.jobId;
 
 			// Poll until failed
-			let job = jobService.getJob(jobId);
+			let job = await jobService.getJob(jobId);
 			let attempts = 0;
 			while (job.status !== 'failed' && attempts < 10) {
 				await delay(20);
-				job = jobService.getJob(jobId);
+				job = await jobService.getJob(jobId);
 				attempts++;
 			}
 
@@ -167,18 +169,18 @@ describe('JobService Unit Tests', () => {
 				{ symbol: 'BINANCE:ETHUSDT', changePercent: 5.0, indicators: { close: 3200, RSI: 55 } },
 			]);
 
-			const metadata = jobService.createJob('market-scanner', {
+			const metadata = await jobService.createJob('market-scanner', {
 				scans: ['top_gainers'],
 			});
 
 			const jobId = metadata.jobId;
 
 			// Poll until completed
-			let job = jobService.getJob(jobId);
+			let job = await jobService.getJob(jobId);
 			let attempts = 0;
 			while (job.status !== 'completed' && attempts < 10) {
 				await delay(20);
-				job = jobService.getJob(jobId);
+				job = await jobService.getJob(jobId);
 				attempts++;
 			}
 
@@ -195,50 +197,88 @@ describe('JobService Unit Tests', () => {
 	});
 
 	describe('Job eviction / cleanup', () => {
-		it('evicts jobs older than 1 hour if status is completed or failed', () => {
-			const metadata = jobService.createJob('expanded-analysis', {
-				symbols: ['BINANCE:BTCUSDT'],
-			});
-
-			const jobId = metadata.jobId;
-
-			// Access internal jobs Map to manipulate the createdAt timestamp
-			const rawJob = jobService.jobs.get(jobId);
-			expect(rawJob).toBeDefined();
-
-			// Set createdAt to 2 hours ago
-			rawJob.createdAt = new Date(Date.now() - 7200000).toISOString();
-			rawJob.status = 'completed';
+		it('evicts jobs older than 1 hour if status is completed or failed', async () => {
+			const jobId = 'expired-completed-job';
+			const rawJob = {
+				jobId,
+				type: 'expanded-analysis',
+				status: 'completed',
+				progress: { total: 1, current: 1, status: 'Completed analysis' },
+				fullResults: [],
+				fullScanResults: [],
+				createdAt: new Date(Date.now() - 7200000).toISOString(),
+				updatedAt: new Date(Date.now() - 7200000).toISOString(),
+				totalDurationMs: 1000,
+			};
+			await jobService.repository.save(rawJob);
 
 			// Querying job should clean it up and return null
-			const job = jobService.getJob(jobId);
+			const job = await jobService.getJob(jobId);
 			expect(job).toBeNull();
-			expect(jobService.jobs.has(jobId)).toBe(false);
+			expect(jobService.repository.has(jobId)).toBe(false);
 		});
 
-		it('does not evict jobs older than 1 hour if they are not completed or failed', () => {
-			const metadata = jobService.createJob('expanded-analysis', {
-				symbols: ['BINANCE:BTCUSDT'],
-			});
-
-			const jobId = metadata.jobId;
-			const rawJob = jobService.jobs.get(jobId);
-			expect(rawJob).toBeDefined();
-
-			// Set createdAt to 2 hours ago
-			rawJob.createdAt = new Date(Date.now() - 7200000).toISOString();
-			rawJob.status = 'processing';
+		it('does not evict jobs older than 1 hour if they are not completed or failed', async () => {
+			const jobId = 'old-processing-job';
+			const rawJob = {
+				jobId,
+				type: 'expanded-analysis',
+				status: 'processing',
+				progress: { total: 1, current: 0, status: 'processing' },
+				fullResults: [],
+				fullScanResults: [],
+				createdAt: new Date(Date.now() - 7200000).toISOString(),
+				updatedAt: new Date(Date.now() - 7200000).toISOString(),
+				totalDurationMs: 0,
+			};
+			await jobService.repository.save(rawJob);
 
 			// Querying job should NOT clean it up
-			const job = jobService.getJob(jobId);
+			const job = await jobService.getJob(jobId);
 			expect(job).not.toBeNull();
-			expect(jobService.jobs.has(jobId)).toBe(true);
+			expect(jobService.repository.has(jobId)).toBe(true);
 
 			// Now set status to completed, querying it should clean it up
 			rawJob.status = 'completed';
-			const jobAfterComplete = jobService.getJob(jobId);
+			await jobService.repository.save(rawJob);
+			const jobAfterComplete = await jobService.getJob(jobId);
 			expect(jobAfterComplete).toBeNull();
-			expect(jobService.jobs.has(jobId)).toBe(false);
+			expect(jobService.repository.has(jobId)).toBe(false);
+		});
+	});
+
+	describe('Durable persistence', () => {
+		it('reads a completed job from Firestore after a service restart', async () => {
+			process.env.ENABLE_FIRESTORE_JOB_STORAGE = 'true';
+			tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValueOnce({
+				symbol: 'BINANCE:BTCUSDT',
+				price_data: { close: 65000, change_percent: 1.5 },
+				rsi: { value: 45 },
+			});
+
+			const metadata = await jobService.createJob('expanded-analysis', {
+				symbols: ['BINANCE:BTCUSDT'],
+			});
+
+			let job = await jobService.getJob(metadata.jobId);
+			let attempts = 0;
+			while (job.status !== 'completed' && attempts < 10) {
+				await delay(20);
+				job = await jobService.getJob(metadata.jobId);
+				attempts++;
+			}
+
+			JobRepository._resetForTesting();
+			const restartedService = new JobService();
+			const restored = await restartedService.getJob(metadata.jobId);
+
+			expect(restored).toMatchObject({
+				jobId: metadata.jobId,
+				type: 'expanded-analysis',
+				status: 'completed',
+			});
+			expect(restored.alertText).toContain('BTCUSDT');
+			expect(restored.results).toHaveLength(1);
 		});
 	});
 });

--- a/tests/unit/jobs-controller.test.js
+++ b/tests/unit/jobs-controller.test.js
@@ -22,7 +22,7 @@ describe('Jobs Controller Unit Tests', () => {
 	});
 
 	describe('postCreateJob', () => {
-		it('returns 400 if type is missing', () => {
+		it('returns 400 if type is missing', async () => {
 			const req = httpMocks.createRequest({
 				method: 'POST',
 				url: '/api/jobs/tradingview-analysis',
@@ -30,7 +30,7 @@ describe('Jobs Controller Unit Tests', () => {
 			});
 			const res = httpMocks.createResponse();
 
-			postCreateJob(null)(req, res);
+			await postCreateJob(null)(req, res);
 
 			expect(res.statusCode).toBe(400);
 			const data = res._getJSONData();
@@ -38,7 +38,7 @@ describe('Jobs Controller Unit Tests', () => {
 			expect(data.code).toBe('INVALID_REQUEST');
 		});
 
-		it('returns 201 and job metadata on successful creation', () => {
+		it('returns 201 and job metadata on successful creation', async () => {
 			const req = httpMocks.createRequest({
 				method: 'POST',
 				url: '/api/jobs/tradingview-analysis',
@@ -54,14 +54,14 @@ describe('Jobs Controller Unit Tests', () => {
 			};
 			jobService.createJob.mockReturnValueOnce(mockResult);
 
-			postCreateJob(null)(req, res);
+			await postCreateJob(null)(req, res);
 
 			expect(res.statusCode).toBe(201);
 			expect(res._getJSONData()).toEqual(mockResult);
 			expect(jobService.createJob).toHaveBeenCalledWith('expanded-analysis', req.body, null);
 		});
 
-		it('returns 404/400 if jobService.createJob throws a validation or feature error', () => {
+		it('returns 404/400 if jobService.createJob throws a validation or feature error', async () => {
 			const req = httpMocks.createRequest({
 				method: 'POST',
 				url: '/api/jobs/tradingview-analysis',
@@ -76,7 +76,7 @@ describe('Jobs Controller Unit Tests', () => {
 				throw error;
 			});
 
-			postCreateJob(null)(req, res);
+			await postCreateJob(null)(req, res);
 
 			expect(res.statusCode).toBe(404);
 			const data = res._getJSONData();
@@ -84,7 +84,7 @@ describe('Jobs Controller Unit Tests', () => {
 			expect(data.code).toBe('FEATURE_DISABLED');
 		});
 
-		it('returns 500 and records error to Sentry on unexpected throw', () => {
+		it('returns 500 and records error to Sentry on unexpected throw', async () => {
 			const req = httpMocks.createRequest({
 				method: 'POST',
 				url: '/api/jobs/tradingview-analysis',
@@ -96,7 +96,7 @@ describe('Jobs Controller Unit Tests', () => {
 				throw new Error('Unexpected DB error');
 			});
 
-			postCreateJob(null)(req, res);
+			await postCreateJob(null)(req, res);
 
 			expect(res.statusCode).toBe(500);
 			const data = res._getJSONData();
@@ -106,7 +106,7 @@ describe('Jobs Controller Unit Tests', () => {
 	});
 
 	describe('getJobStatus', () => {
-		it('returns 400 if jobId is missing', () => {
+		it('returns 400 if jobId is missing', async () => {
 			const req = httpMocks.createRequest({
 				method: 'GET',
 				url: '/api/jobs/',
@@ -114,13 +114,13 @@ describe('Jobs Controller Unit Tests', () => {
 			});
 			const res = httpMocks.createResponse();
 
-			getJobStatus(req, res);
+			await getJobStatus(req, res);
 
 			expect(res.statusCode).toBe(400);
 			expect(res._getJSONData().error).toBe('Missing jobId parameter');
 		});
 
-		it('returns 404 if job is not found', () => {
+		it('returns 404 if job is not found', async () => {
 			const req = httpMocks.createRequest({
 				method: 'GET',
 				url: '/api/jobs/missing-job-id',
@@ -130,7 +130,7 @@ describe('Jobs Controller Unit Tests', () => {
 
 			jobService.getJob.mockReturnValueOnce(null);
 
-			getJobStatus(req, res);
+			await getJobStatus(req, res);
 
 			expect(res.statusCode).toBe(404);
 			expect(res._getJSONData()).toEqual({
@@ -139,7 +139,7 @@ describe('Jobs Controller Unit Tests', () => {
 			});
 		});
 
-		it('returns 200 and job details if job exists', () => {
+		it('returns 200 and job details if job exists', async () => {
 			const req = httpMocks.createRequest({
 				method: 'GET',
 				url: '/api/jobs/existing-job-id',
@@ -156,7 +156,7 @@ describe('Jobs Controller Unit Tests', () => {
 			};
 			jobService.getJob.mockReturnValueOnce(mockJob);
 
-			getJobStatus(req, res);
+			await getJobStatus(req, res);
 
 			expect(res.statusCode).toBe(200);
 			expect(res._getJSONData()).toEqual({
@@ -165,7 +165,7 @@ describe('Jobs Controller Unit Tests', () => {
 			});
 		});
 
-		it('returns 500 and records error to Sentry on unexpected throw', () => {
+		it('returns 500 and records error to Sentry on unexpected throw', async () => {
 			const req = httpMocks.createRequest({
 				method: 'GET',
 				url: '/api/jobs/existing-job-id',
@@ -177,7 +177,7 @@ describe('Jobs Controller Unit Tests', () => {
 				throw new Error('Disk crash');
 			});
 
-			getJobStatus(req, res);
+			await getJobStatus(req, res);
 
 			expect(res.statusCode).toBe(500);
 			expect(sentryService.captureRuntimeError).toHaveBeenCalled();


### PR DESCRIPTION
# feat(jobs): persist tradingview jobs

## Summary

Adds durable async TradingView job persistence so job metadata, progress, final reports, and delivery results can survive process restarts when Firestore job storage is enabled.

## Key Changes

### :floppy_disk: Durable job storage

- Added `JobRepository` for sanitized job persistence.
- Stores jobs in memory by default and in Firestore collection `tradingviewJobs` when `ENABLE_FIRESTORE_JOB_STORAGE=true`.
- Persists job checkpoints during creation, processing, completion, failure, and timeout paths.

### :arrows_counterclockwise: Restart-safe reads

- Updated `JobService.createJob()` and `JobService.getJob()` to be async so Firestore writes and reads complete before API responses.
- Updated the jobs controller to await job creation and status reads.
- Preserved eviction behavior for completed/failed jobs older than 1 hour while keeping active old jobs readable.

## Technical Implementation

### Architecture changes

#### `src/services/jobs/JobRepository.js`

Provides the storage boundary for async job state. It writes sanitized job records to memory and optionally Firestore without storing runtime-only fields such as bot instances, payload references, or abort signals.

#### `src/services/jobs/JobService.js`

Persists state transitions through the repository and reloads missing memory records from Firestore on `getJob()`.

#### `src/services/storage/AlertStorageService.js`

Allows the shared Firestore Admin singleton to initialize for job storage via `ENABLE_FIRESTORE_JOB_STORAGE` without enabling alert read APIs.

## Testing infraestructure

### Test Suite

- **Job service unit tests** updated for async job persistence and durable restart reads.
- **Jobs controller unit tests** updated for async create/status behavior.
- **Jobs endpoint integration tests** continue to cover the API lifecycle.

### Test Files

- `tests/unit/job-service.test.js`: adds Firestore-backed restart recovery coverage.
- `tests/unit/jobs-controller.test.js`: awaits async controller handlers.
- `tests/integration/jobs-endpoint.test.js`: verifies existing API behavior remains intact.

## Configuration Updates

### Environment Variables

```bash
ENABLE_FIRESTORE_JOB_STORAGE=true
FIREBASE_SERVICE_ACCOUNT_JSON=<firebase-admin-service-account-json>
# or
GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
```

## Documentation Updates

- **README** Documents durable job storage and the `ENABLE_FIRESTORE_JOB_STORAGE` flag.
- **agents.md** Documents the new repository boundary and async service behavior.

## Testing

### Pre-merge Verification

- [ ] Run `pnpm test`
- [ ] Run focused ESLint on touched job/storage files
- [ ] Create an async job with Firestore enabled and verify it is readable after process restart

### Post-merge Verification

- [ ] Confirm `GET /api/jobs/:jobId` returns persisted completed jobs after deploy restart
- [ ] Confirm expired completed/failed jobs are evicted without deleting active jobs

---

**Review Checklist:**

- [ ] Code quality meets project standards
- [ ] All tests pass and coverage is maintained
- [ ] Documentation is complete and accurate
- [ ] Breaking change assessment completed


Closes #64
Linear: CB-24
