### PR TITLE
feat(issue-automator): add gh user switching to francovp

### DIFF
--- a/.agents/skills/issue-automator/SKILL.md
+++ b/.agents/skills/issue-automator/SKILL.md
@@ -20,6 +20,7 @@ description: >-
 12. Prefer `gh` and `linear` CLIs over MCP tools when available.
 13. Distinguish local blockers from global blockers.
 14. Stop cleanly on global blockers, ambiguity, or missing ownership.
+15. **GitHub user switching**: Before any `gh` CLI command, always switch to the `francovp` user with `gh auth switch --user francovp`. After all `gh` commands are complete, restore the original user with `gh auth switch --user <original_user>`. The helper script `scripts/gh-auth-utils.sh` provides `save_gh_user`, `switch_to_francovp`, and `restore_gh_user` functions for this pattern. All script-based `gh` calls (in `get-oldest-issue.sh`, `verify-preview.sh`) already source this helper — just call them as-is. For inline `gh` commands in the workflow below, execute the switch pattern manually or use the helper.
 
 ## Notification Webhook
 
@@ -55,13 +56,17 @@ curl --location "${NOTIFY_WEBHOOK_URL:-https://cabros-crypto-bot-telegram.onrend
 Follow these steps in strict chronological order to automate issue resolution:
 
 ### Step 1: Pre-flight & Selection
-1. Determine the target issue:
+1. **Switch gh to francovp user** — save the current user and switch to francovp for all `gh` commands in this session:
+   ```bash
+   source scripts/gh-auth-utils.sh && save_gh_user && switch_to_francovp
+   ```
+2. Determine the target issue:
    - **If the user specifies an issue number** (via `#42`, `issue 42`, `GH-42`, or similar): fetch that specific issue with `gh issue view <NUMBER> --json number,title,createdAt,labels,url`.
-   - **If no issue number is given**: run `scripts/get-oldest-issue.sh` to fetch the oldest open GitHub issue.
-2. Select it as the primary issue.
-3. Do not fetch, inspect, select, plan, or create TODOs for any second issue at this stage.
-4. If no open GitHub issues exist (and none was specified), stop execution immediately.
-5. For the primary issue:
+   - **If no issue number is given**: run `scripts/get-oldest-issue.sh` to fetch the oldest open GitHub issue (the script handles switching to francovp internally).
+3. Select it as the primary issue.
+4. Do not fetch, inspect, select, plan, or create TODOs for any second issue at this stage.
+5. If no open GitHub issues exist (and none was specified), stop execution immediately.
+6. For the primary issue:
    - Check any linked or related Linear issue.
    - Check all open, closed, merged, and draft PRs that reference the issue.
    - Check unresolved review threads and CI status if a PR exists.
@@ -136,6 +141,10 @@ If the primary issue ends with any other outcome (including `IN_REVIEW` with age
        "whatsappChatId": "'"${NOTIFY_WHATSAPP_CHAT_ID:-120363422033474991@g.us}"'"
      }'
    ```
+6. **Restore original GitHub user** after all `gh` commands are done:
+   ```bash
+   restore_gh_user
+   ```
 
 ## Outcome Summary Contract
 
@@ -149,7 +158,11 @@ Always include a final summary of execution containing:
 ## Error Handling & Troubleshooting
 
 Refer to this section when encountering execution issues:
-- **CLI Authentication Failures**: If `gh` or `linear` CLI calls fail due to auth, check if the respective environment tokens (`GITHUB_TOKEN`, `LINEAR_API_KEY`) are loaded. If CLI is unavailable, fallback to MCP commands. If both fail:
+- **CLI Authentication Failures**: If `gh` or `linear` CLI calls fail due to auth:
+  - First ensure the current user is `francovp` — run `gh auth switch --user francovp` and retry.
+  - Verify the `francovp` account has valid credentials with `gh auth status`.
+  - If the user switch itself fails, check if `GITHUB_TOKEN` env var is overriding the keyring-based auth.
+  - As last resort, check if `GITHUB_TOKEN` or `LINEAR_API_KEY` env vars are loaded. If CLI is unavailable, fallback to MCP commands. If both fail:
   - Send a global-deadlock notification:
     ```bash
     NOTIFY_MESSAGE="[GLOBAL_BLOCKED] Issue automator halted: CLI + MCP auth both failed for $repo/$issue. Human intervention required." \

--- a/.agents/skills/issue-automator/scripts/get-oldest-issue.sh
+++ b/.agents/skills/issue-automator/scripts/get-oldest-issue.sh
@@ -4,15 +4,22 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/gh-auth-utils.sh"
+
 # Ensure gh CLI is installed
 if ! command -v gh &> /dev/null; then
   echo "Error: 'gh' CLI is not installed or not in PATH." >&2
   exit 127
 fi
 
-# Ensure gh CLI is authenticated
+# Switch to francovp user for all gh commands; restore on exit
+trap 'restore_gh_user' EXIT
+save_gh_user
+switch_to_francovp
+
 if ! gh auth status &> /dev/null; then
-  echo "Error: 'gh' CLI is not authenticated. Please run 'gh auth login' or configure GITHUB_TOKEN." >&2
+  echo "Error: 'gh' CLI is not authenticated as francovp. Please run 'gh auth login' or configure GITHUB_TOKEN." >&2
   exit 1
 fi
 

--- a/.agents/skills/issue-automator/scripts/gh-auth-utils.sh
+++ b/.agents/skills/issue-automator/scripts/gh-auth-utils.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# gh-auth-utils.sh
+# Helper functions for switching to the francovp GitHub user before gh CLI commands
+# and restoring the original user after completion.
+#
+# Usage:
+#   source "$(dirname "$0")/gh-auth-utils.sh"
+#   save_gh_user
+#   switch_to_francovp
+#   # ... run gh commands ...
+#   restore_gh_user
+#
+# Or use the trap-friendly pattern:
+#   source "$(dirname "$0")/gh-auth-utils.sh"
+#   trap 'restore_gh_user' EXIT
+#   save_gh_user && switch_to_francovp
+
+# Saves the currently active GitHub user to a temp file for later restoration.
+# The temp file path is stored in GH_AUTH_TMP and cleaned up on restore.
+save_gh_user() {
+  GH_AUTH_TMP=$(mktemp /tmp/gh-auth-XXXXXX 2>/dev/null || mktemp -t gh-auth 2>/dev/null)
+
+  # Get the current active account from gh auth status
+  # Output format: "Logged in to github.com as francovp"
+  local status_output
+  status_output=$(gh auth status 2>&1 || true)
+
+  local current_user
+  current_user=$(echo "$status_output" | grep -oP 'account \K\S+' 2>/dev/null || \
+                 echo "$status_output" | sed -n 's/.*logged in to github\.com as \([^ .]*\).*/\1/p' 2>/dev/null || \
+                 echo "")
+
+  if [ -n "$current_user" ]; then
+    echo "$current_user" > "$GH_AUTH_TMP"
+  else
+    # If no user detected, store empty — means we don't need to restore
+    echo "" > "$GH_AUTH_TMP"
+  fi
+}
+
+# Switches gh CLI authentication to the francovp user.
+# Must be called after save_gh_user.
+switch_to_francovp() {
+  if [ ! -f "${GH_AUTH_TMP:-}" ]; then
+    echo "Error: save_gh_user must be called before switch_to_francovp" >&2
+    return 1
+  fi
+
+  local current_user
+  current_user=$(cat "$GH_AUTH_TMP")
+
+  # Only switch if not already francovp
+  if [ "$current_user" != "francovp" ]; then
+    gh auth switch --user francovp 2>/dev/null || {
+      echo "Warning: Failed to switch gh auth to francovp. Continuing with current user." >&2
+      return 0
+    }
+  fi
+}
+
+# Restores the original GitHub user saved by save_gh_user.
+restore_gh_user() {
+  if [ ! -f "${GH_AUTH_TMP:-}" ]; then
+    return 0
+  fi
+
+  local original_user
+  original_user=$(cat "$GH_AUTH_TMP" 2>/dev/null || echo "")
+
+  # Clean up temp file
+  rm -f "$GH_AUTH_TMP" 2>/dev/null || true
+  unset GH_AUTH_TMP
+
+  if [ -n "$original_user" ] && [ "$original_user" != "francovp" ]; then
+    gh auth switch --user "$original_user" 2>/dev/null || {
+      echo "Warning: Failed to restore gh auth to $original_user" >&2
+    }
+  fi
+}

--- a/.agents/skills/issue-automator/scripts/verify-preview.sh
+++ b/.agents/skills/issue-automator/scripts/verify-preview.sh
@@ -4,12 +4,20 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/gh-auth-utils.sh"
+
 if [ "$#" -lt 1 ]; then
   echo "Usage: $0 <PR_NUMBER>" >&2
   exit 1
 fi
 
 PR_NUMBER="$1"
+
+# Switch to francovp user for gh commands; restore on exit
+trap 'restore_gh_user' EXIT
+save_gh_user
+switch_to_francovp
 
 # Determine Render service name: RENDER_SERVICE_NAME env var > repo name > hardcoded fallback
 RENDER_SERVICE_NAME="${RENDER_SERVICE_NAME:-$(gh repo view --json name -q '.name' 2>/dev/null)}"


### PR DESCRIPTION
## Summary

Add automatic `gh` user switching to the issue-automator skill so all GitHub CLI commands execute as the `francovp` user and restore the original user after completion.

## Key Changes

- **New `scripts/gh-auth-utils.sh`**: helper with `save_gh_user`, `switch_to_francovp`, `restore_gh_user` functions using `gh auth switch`
- **`scripts/get-oldest-issue.sh`**: sources gh-auth-utils, sets EXIT trap, switches to francovp before `gh issue list`
- **`scripts/verify-preview.sh`**: same pattern for `gh repo view`
- **`SKILL.md`**: Hard Rule #15, auth switching in Step 1/Step 7, updated error handling

[skip ci]