### PR TITLE
feat: Add Firestore alert replay endpoint (CB-25)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -557,6 +557,96 @@
 							"path": ["api", "alerts", "{{alertId}}"]
 						}
 					}
+				},
+				{
+					"name": "POST Replay Alert (telegram)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{ "key": "Content-Type", "value": "application/json", "type": "text" },
+							{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" },
+							{ "key": "idempotency-key", "value": "{{replayIdempotencyKey}}", "type": "text" }
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"channels\": [\"telegram\"]\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/alerts/{{alertId}}/replay",
+							"host": ["{{baseUrl}}"],
+							"path": ["api", "alerts", "{{alertId}}", "replay"]
+						}
+					},
+					"response": [
+						{
+							"name": "Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{ "key": "Content-Type", "value": "application/json", "type": "text" },
+									{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" },
+									{ "key": "idempotency-key", "value": "{{replayIdempotencyKey}}", "type": "text" }
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"channels\": [\"telegram\"]\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/alerts/{{alertId}}/replay",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "alerts", "{{alertId}}", "replay"]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"body": "{\n  \"success\": true,\n  \"alertId\": \"alert-123\",\n  \"replayId\": \"alert-123_replay-key-1\",\n  \"results\": [\n    { \"channel\": \"telegram\", \"success\": true, \"messageId\": \"123\" }\n  ]\n}"
+						},
+						{
+							"name": "Missing idempotency key",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{ "key": "Content-Type", "value": "application/json", "type": "text" },
+									{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"channels\": [\"telegram\"]\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/alerts/{{alertId}}/replay",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "alerts", "{{alertId}}", "replay"]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"body": "{\n  \"error\": \"Replay requests require an idempotency-key header or idempotencyKey body field.\",\n  \"code\": \"INVALID_REQUEST\"\n}"
+						},
+						{
+							"name": "Invalid channel",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{ "key": "Content-Type", "value": "application/json", "type": "text" },
+									{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" },
+									{ "key": "idempotency-key", "value": "{{replayIdempotencyKey}}", "type": "text" }
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"channels\": [\"telegram\", \"discord\"]\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/alerts/{{alertId}}/replay",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "alerts", "{{alertId}}", "replay"]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"body": "{\n  \"error\": \"Unknown channel(s): discord. Valid channels: telegram, whatsapp.\",\n  \"code\": \"INVALID_REQUEST\"\n}"
+						}
+					]
 				}
 			]
 		},

--- a/agents.md
+++ b/agents.md
@@ -39,7 +39,7 @@ This project is a small Express + Telegraf (Telegram) bot service that exposes a
 - `src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js` — `POST /api/webhook/expanded-analysis-alert` handler that builds TradingView MCP analysis reports and sends them through notification channels.
 - `src/controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation.js` — `POST /api/webhook/volume-confirmation` handler that returns structured TradingView MCP volume-confirmation data.
 - `src/controllers/webhooks/handlers/jobs/jobs.js` — Job creation (`POST /api/jobs/tradingview-analysis`) and status polling (`GET /api/jobs/:jobId`) handler.
-- `src/controllers/alerts/alerts.js` — Stored alert read handlers for `GET /api/alerts` and `GET /api/alerts/:alertId`.
+- `src/controllers/alerts/alerts.js` — Stored alert read/replay handlers for `GET /api/alerts`, `GET /api/alerts/:alertId`, and `POST /api/alerts/:alertId/replay`.
 - `src/controllers/status.js` — Status handler that computes capabilities, feature flags, notification channels, and active dependencies status.
 - `src/controllers/webhooks/handlers/marketScanner/marketScanner.js` — Scanner webhook handler executing sequential gainers, losers, and breakouts scanner runs on TradingView MCP.
 - `src/services/jobs/JobService.js` — Manages in-memory job state, executes background TradingView analysis runs, and performs periodic expiration cleanup.
@@ -144,7 +144,7 @@ Implement the following security practices to safeguard endpoints and credential
 - Optional but relevant (non-exhaustive; see feature sections below for full config): `ENABLE_TELEGRAM_BOT`, `PORT`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID`, `ENABLE_WHATSAPP_ALERTS`, `ENABLE_GEMINI_GROUNDING`, `GEMINI_API_KEY`, `ENABLE_LANGFUSE_PROMPTS`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_PROMPT_LABEL`, `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`, `BRAVE_SEARCH_API_KEY`, `BRAVE_SEARCH_ENDPOINT`, `FORCE_BRAVE_SEARCH`, `MODEL_PROVIDER`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `ENABLE_NEWS_MONITOR`, `EXPANDED_ANALYSIS_ALERT_SYMBOLS`, `EXPANDED_ANALYSIS_ALERT_TIMEOUT_MS`, `TRADINGVIEW_MCP_URL`, `TRADINGVIEW_MCP_TIMEOUT_MS`, `TRADINGVIEW_MCP_MAX_RETRIES`, `TRADINGVIEW_MCP_DEFAULT_TIMEFRAME`, `ENABLE_TRADINGVIEW_VOLUME_CONFIRMATION`, `ENABLE_SENTRY`, `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_CONSOLE_LOG_LEVELS`, `LOG_LEVEL`, `SERVICE_NAME`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `ENABLE_FIRESTORE_ALERT_STORAGE`, `ENABLE_MARKET_SCANNER`, `ENABLE_MESSAGE_FOOTER_METADATA`, `FIREBASE_PROJECT_ID`, `FIREBASE_SERVICE_ACCOUNT_JSON`, `GOOGLE_APPLICATION_CREDENTIALS`, `GEMINI_MODEL_NAME_FALLBACK`, `RENDER`, `IS_PULL_REQUEST`, `RENDER_GIT_COMMIT`, `RENDER_GIT_REPO_SLUG`.
 - Bot startup is gated: bot is launched only when `ENABLE_TELEGRAM_BOT === 'true'` and not a preview environment (`RENDER==='true' && IS_PULL_REQUEST==='true'` disables it).
 - Routes under `/api` (e.g. `/api/webhook/alert`) are mounted regardless of bot launch; individual features and notification channels are gated via env flags and per-channel validation.
-- Stored alert read routes (`GET /api/alerts`, `GET /api/alerts/:alertId`) are also mounted under `/api`; they require `WEBHOOK_API_KEY` when configured, return `403 FEATURE_DISABLED` unless `ENABLE_FIRESTORE_ALERT_STORAGE=true`, and return `503 STORAGE_UNAVAILABLE` when Firestore is enabled but unreadable.
+- Stored alert read/replay routes (`GET /api/alerts`, `GET /api/alerts/:alertId`, `POST /api/alerts/:alertId/replay`) are also mounted under `/api`; they require `WEBHOOK_API_KEY` when configured, return `403 FEATURE_DISABLED` unless `ENABLE_FIRESTORE_ALERT_STORAGE=true`, and return `503 STORAGE_UNAVAILABLE` when Firestore is enabled but unreadable.
 
 ---
 
@@ -613,6 +613,7 @@ Every successful `POST /api/webhook/alert` request is persisted as a document in
 **Read API**:
 - `GET /api/alerts` returns stored alerts ordered by `receivedAt` descending with `limit`, `before`, `source`, and `enriched` query support.
 - `GET /api/alerts/:alertId` returns a single formatted alert document by Firestore document ID.
+- `POST /api/alerts/:alertId/replay` reloads an immutable stored alert, rebuilds the current notification payload, dispatches it to requested channels (`telegram`, `whatsapp`, or both by default), and records the replay attempt in the separate `alertReplays` Firestore collection. It requires API-key auth and an idempotency key (`idempotency-key` header or `idempotencyKey` body/query field).
 - `listAlerts()` and `getAlertById()` in `src/services/storage/AlertStorageService.js` format Firestore documents into API-safe JSON with the following fields:
   - `id`
   - `receivedAt`
@@ -625,6 +626,7 @@ Every successful `POST /api/webhook/alert` request is persisted as a document in
   - `useTradingViewData`
 - Read filtering for `source` and `enriched` is applied in memory after `receivedAt`-ordered batches to avoid introducing new composite Firestore index requirements.
 - Read endpoints must map Firestore initialization/read failures to `503 STORAGE_UNAVAILABLE` instead of a generic `500`.
+- Replay attempts must not mutate the original `alerts` document. Use `saveReplayAttempt()` to write an audit document with ID `${alertId}_${idempotencyKey}` in `alertReplays`.
 - When extending the alerts read API, preserve `receivedAt` as the primary sort key but encode `nextBefore` with a deterministic tie-breaker (document ID) so paginated reads do not skip same-timestamp alerts, and preserve API-key protection on both list and detail routes.
 
 **Alert Flow Integration** (`src/controllers/webhooks/handlers/alert/alert.js`):

--- a/src/controllers/alerts/alerts.js
+++ b/src/controllers/alerts/alerts.js
@@ -5,6 +5,7 @@ const sentryService = require('../../services/monitoring/SentryService');
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
+const VALID_CHANNELS = ['telegram', 'whatsapp'];
 
 function parseLimit(rawLimit) {
 	if (rawLimit === undefined) {
@@ -125,6 +126,116 @@ function getAlertById(req, res) {
 	});
 }
 
+function parseReplayChannels(rawChannels) {
+	if (rawChannels === undefined) {
+		return VALID_CHANNELS;
+	}
+
+	if (!Array.isArray(rawChannels) || rawChannels.length === 0) {
+		return null;
+	}
+
+	const channels = rawChannels
+		.filter(channel => typeof channel === 'string')
+		.map(channel => channel.trim().toLowerCase())
+		.filter(Boolean);
+	const uniqueChannels = Array.from(new Set(channels));
+	if (uniqueChannels.length !== rawChannels.length) {
+		return null;
+	}
+
+	return uniqueChannels;
+}
+
+function getIdempotencyKey(req) {
+	return req.headers['idempotency-key']
+		|| (req.body && (req.body.idempotencyKey || req.body.idempotency_key))
+		|| (req.query && (req.query.idempotencyKey || req.query.idempotency_key));
+}
+
+function replayAlert(botOrGetter) {
+	return function handleReplayAlert(req, res) {
+		return handleAsync(req, res, `/api/alerts/${req.params.alertId}/replay`, async () => {
+			if (!alertStorageService.isEnabled()) {
+				return res.status(403).json({
+					error: 'Alert storage feature is disabled. Set ENABLE_FIRESTORE_ALERT_STORAGE=true to enable.',
+					code: 'FEATURE_DISABLED',
+				});
+			}
+
+			const { alertId } = req.params;
+			if (!alertId) {
+				return res.status(400).json({
+					error: 'Missing alertId parameter',
+					code: 'INVALID_REQUEST',
+				});
+			}
+
+			const idempotencyKey = getIdempotencyKey(req);
+			if (!idempotencyKey || typeof idempotencyKey !== 'string' || !idempotencyKey.trim()) {
+				return res.status(400).json({
+					error: 'Replay requests require an idempotency-key header or idempotencyKey body field.',
+					code: 'INVALID_REQUEST',
+				});
+			}
+
+			const channels = parseReplayChannels(req.body && req.body.channels);
+			if (!channels) {
+				return res.status(400).json({
+					error: 'channels must be a non-empty array of channel names.',
+					code: 'INVALID_REQUEST',
+				});
+			}
+
+			const unknownChannels = channels.filter(channel => !VALID_CHANNELS.includes(channel));
+			if (unknownChannels.length > 0) {
+				return res.status(400).json({
+					error: `Unknown channel(s): ${unknownChannels.join(', ')}. Valid channels: ${VALID_CHANNELS.join(', ')}.`,
+					code: 'INVALID_REQUEST',
+				});
+			}
+
+			const storedAlert = await alertStorageService.getAlertById(alertId);
+			if (!storedAlert) {
+				return res.status(404).json({
+					error: 'Alert not found',
+					code: 'NOT_FOUND',
+				});
+			}
+
+			const { getNotificationManager, initializeNotificationServices } = require('../webhooks/handlers/alert/alert');
+			let notificationManager = getNotificationManager();
+			if (!notificationManager) {
+				const bot = typeof botOrGetter === 'function' ? botOrGetter() : botOrGetter || null;
+				notificationManager = await initializeNotificationServices(bot);
+			}
+
+			const replayPayload = {
+				text: storedAlert.text,
+				enriched: storedAlert.enrichmentData || undefined,
+				replay: {
+					originalAlertId: alertId,
+					idempotencyKey: idempotencyKey.trim(),
+				},
+			};
+			const results = await notificationManager.sendToChannels(replayPayload, channels);
+			const replayId = await alertStorageService.saveReplayAttempt({
+				alertId,
+				idempotencyKey: idempotencyKey.trim(),
+				channels,
+				deliveryResults: results,
+			});
+
+			return res.status(200).json({
+				success: true,
+				alertId,
+				replayId,
+				results,
+			});
+		});
+	};
+}
+
 function handleAsync(req, res, endpoint, handler) {
 	return Promise.resolve(handler()).catch((error) => {
 		console.error('[AlertsController] Request failed:', error.message);
@@ -156,4 +267,5 @@ function handleAsync(req, res, endpoint, handler) {
 module.exports = {
 	listAlerts,
 	getAlertById,
+	replayAlert,
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -13,7 +13,7 @@ const {
 } = require('../controllers/webhooks/handlers/scannerPresets/scannerPresets');
 const { postVolumeConfirmation } = require('../controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation');
 const { postCreateJob, getJobStatus } = require('../controllers/webhooks/handlers/jobs/jobs');
-const { listAlerts, getAlertById } = require('../controllers/alerts/alerts');
+const { listAlerts, getAlertById, replayAlert } = require('../controllers/alerts/alerts');
 const { validateApiKey } = require('../lib/auth');
 const { getApiStatus } = require('../controllers/status');
 const { idempotencyMiddleware } = require('../lib/idempotency');
@@ -26,6 +26,7 @@ function getRoutes(botOrGetter) {
 	router.post('/webhook/market-scanner-alert', validateApiKey, idempotencyMiddleware, postMarketScannerAlert(botOrGetter));
 	router.post('/webhook/volume-confirmation', validateApiKey, postVolumeConfirmation());
 	router.get('/alerts', validateApiKey, listAlerts);
+	router.post('/alerts/:alertId/replay', validateApiKey, idempotencyMiddleware, replayAlert(botOrGetter));
 	router.get('/alerts/:alertId', validateApiKey, getAlertById);
 	router.post('/scanner-presets', validateApiKey, postPreset);
 	router.get('/scanner-presets', validateApiKey, listPresets);

--- a/src/services/storage/AlertStorageService.js
+++ b/src/services/storage/AlertStorageService.js
@@ -28,6 +28,7 @@ const admin = require('firebase-admin');
 const { encodeAlertPaginationCursor, parseAlertPaginationCursor } = require('./alertPaginationCursor');
 
 const COLLECTION_NAME = 'alerts';
+const REPLAY_COLLECTION_NAME = 'alertReplays';
 const DEFAULT_PAGE_SIZE = 50;
 const MAX_PAGE_SIZE = 100;
 const STORAGE_UNAVAILABLE_CODE = 'STORAGE_UNAVAILABLE';
@@ -345,17 +346,54 @@ async function getAlertById(alertId) {
 	return formatAlertDocument(snapshot);
 }
 
+/**
+ * Persist a replay attempt separately from the immutable original alert.
+ *
+ * @param {Object} params
+ * @param {string} params.alertId
+ * @param {string} params.idempotencyKey
+ * @param {Array<string>} params.channels
+ * @param {Array} params.deliveryResults
+ * @returns {Promise<string|null>}
+ */
+async function saveReplayAttempt({ alertId, idempotencyKey, channels, deliveryResults }) {
+	const firestore = getFirestore();
+	if (!firestore) {
+		throw createStorageUnavailableError();
+	}
+
+	const replayId = `${alertId}_${idempotencyKey}`;
+	const document = {
+		alertId,
+		idempotencyKey,
+		channels: Array.isArray(channels) ? channels : [],
+		deliveryResults: Array.isArray(deliveryResults) ? deliveryResults : [],
+		replayedAt: admin.firestore.FieldValue.serverTimestamp(),
+		source: 'alert-replay',
+	};
+
+	try {
+		await firestore.collection(REPLAY_COLLECTION_NAME).doc(replayId).set(document, { merge: false });
+		return replayId;
+	} catch (error) {
+		console.warn('[AlertStorageService] Failed to store alert replay attempt:', error.message);
+		throw createStorageUnavailableError(error);
+	}
+}
+
 module.exports = {
 	isEnabled,
 	saveAlert,
 	listAlerts,
 	getAlertById,
+	saveReplayAttempt,
 	STORAGE_UNAVAILABLE_CODE,
 	INVALID_CURSOR_MESSAGE,
 	parseAlertPaginationCursor,
 	// Exported for testing
 	getFirestore,
 	COLLECTION_NAME,
+	REPLAY_COLLECTION_NAME,
 	// Reset the cached db singleton between tests without module reloading
 	_resetForTesting() {
 		db = null;

--- a/tests/integration/alerts-endpoint.test.js
+++ b/tests/integration/alerts-endpoint.test.js
@@ -4,19 +4,28 @@ jest.mock('../../src/services/storage/AlertStorageService', () => ({
 	isEnabled: jest.fn(),
 	listAlerts: jest.fn(),
 	getAlertById: jest.fn(),
+	saveReplayAttempt: jest.fn(),
 	STORAGE_UNAVAILABLE_CODE: 'STORAGE_UNAVAILABLE',
 	INVALID_CURSOR_MESSAGE: 'Invalid before cursor. Use an ISO-8601 timestamp or the nextBefore cursor from a previous response.',
 	parseAlertPaginationCursor: jest.fn(),
+}));
+
+jest.mock('../../src/controllers/webhooks/handlers/alert/alert', () => ({
+	postAlert: jest.fn(() => (_req, res) => res.status(501).json({ error: 'not mocked' })),
+	initializeNotificationServices: jest.fn(),
+	getNotificationManager: jest.fn(),
 }));
 
 const request = require('supertest');
 const app = require('../../app');
 const { getRoutes } = require('../../src/routes');
 const alertStorageService = require('../../src/services/storage/AlertStorageService');
+const alertHandler = require('../../src/controllers/webhooks/handlers/alert/alert');
 const { encodeAlertPaginationCursor } = require('../../src/services/storage/alertPaginationCursor');
 
 describe('Alerts API Integration Tests', () => {
 	const originalEnv = process.env;
+	let mockNotificationManager;
 
 	beforeEach(() => {
 		process.env = {
@@ -26,7 +35,13 @@ describe('Alerts API Integration Tests', () => {
 		};
 
 		jest.clearAllMocks();
+		mockNotificationManager = {
+			sendToChannels: jest.fn().mockResolvedValue([{ channel: 'telegram', success: true, messageId: 'tg-1' }]),
+		};
+		alertHandler.getNotificationManager.mockReturnValue(mockNotificationManager);
+		alertHandler.initializeNotificationServices.mockResolvedValue(mockNotificationManager);
 		alertStorageService.isEnabled.mockReturnValue(true);
+		alertStorageService.saveReplayAttempt.mockResolvedValue('replay-1');
 		alertStorageService.parseAlertPaginationCursor.mockImplementation((cursor) => {
 			if (!cursor) {
 				return null;
@@ -244,6 +259,75 @@ describe('Alerts API Integration Tests', () => {
 		expect(res.body).toEqual({
 			error: 'Alert storage is enabled but Firestore is unavailable. Check Firestore credentials and project configuration.',
 			code: 'STORAGE_UNAVAILABLE',
+		});
+	});
+
+	it('replays a stored alert to selected channels and records the replay attempt', async () => {
+		alertStorageService.getAlertById.mockResolvedValue({
+			id: 'alert-123',
+			receivedAt: '2026-06-06T12:34:56.000Z',
+			text: 'Replay me',
+			enriched: true,
+			enrichmentData: { sentiment: 'bullish' },
+			tokenUsage: { totalTokens: 42 },
+			deliveryResults: [{ channel: 'whatsapp', success: false }],
+			source: 'webhook',
+			useTradingViewData: false,
+		});
+
+		const res = await request(app)
+			.post('/api/alerts/alert-123/replay')
+			.set('x-api-key', 'test-key')
+			.set('idempotency-key', 'replay-key-1')
+			.send({ channels: ['telegram'] })
+			.expect(200);
+
+		expect(mockNotificationManager.sendToChannels).toHaveBeenCalledWith({
+			text: 'Replay me',
+			enriched: { sentiment: 'bullish' },
+			replay: {
+				originalAlertId: 'alert-123',
+				idempotencyKey: 'replay-key-1',
+			},
+		}, ['telegram']);
+		expect(alertStorageService.saveReplayAttempt).toHaveBeenCalledWith({
+			alertId: 'alert-123',
+			idempotencyKey: 'replay-key-1',
+			channels: ['telegram'],
+			deliveryResults: [{ channel: 'telegram', success: true, messageId: 'tg-1' }],
+		});
+		expect(res.body).toEqual({
+			success: true,
+			alertId: 'alert-123',
+			replayId: 'replay-1',
+			results: [{ channel: 'telegram', success: true, messageId: 'tg-1' }],
+		});
+	});
+
+	it('returns 400 when replay is missing an idempotency key', async () => {
+		const res = await request(app)
+			.post('/api/alerts/alert-123/replay')
+			.set('x-api-key', 'test-key')
+			.send({ channels: ['telegram'] })
+			.expect(400);
+
+		expect(res.body).toEqual({
+			error: 'Replay requests require an idempotency-key header or idempotencyKey body field.',
+			code: 'INVALID_REQUEST',
+		});
+	});
+
+	it('returns 400 when replay channels contain unsupported names', async () => {
+		const res = await request(app)
+			.post('/api/alerts/alert-123/replay')
+			.set('x-api-key', 'test-key')
+			.set('idempotency-key', 'replay-key-2')
+			.send({ channels: ['telegram', 'discord'] })
+			.expect(400);
+
+		expect(res.body).toEqual({
+			error: 'Unknown channel(s): discord. Valid channels: telegram, whatsapp.',
+			code: 'INVALID_REQUEST',
 		});
 	});
 });

--- a/tests/unit/alert-storage-service.test.js
+++ b/tests/unit/alert-storage-service.test.js
@@ -20,6 +20,7 @@ const {
 	__mockCollection: mockCollection,
 	__mockGet: mockGet,
 	__mockDocGet: mockDocGet,
+	__mockDocSet: mockDocSet,
 	__mockWhere: mockWhere,
 	__mockOrderBy: mockOrderBy,
 	__mockLimit: mockLimit,
@@ -517,6 +518,44 @@ describe('AlertStorageService', () => {
 			mockDocGet.mockRejectedValueOnce(new Error('Permission denied'));
 
 			await expect(AlertStorageService.getAlertById('alert-123')).rejects.toMatchObject({
+				code: 'STORAGE_UNAVAILABLE',
+			});
+		});
+	});
+
+	describe('saveReplayAttempt()', () => {
+		it('stores replay attempts in a separate collection using the idempotency key', async () => {
+			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+
+			const result = await AlertStorageService.saveReplayAttempt({
+				alertId: 'alert-123',
+				idempotencyKey: 'replay-key-1',
+				channels: ['telegram'],
+				deliveryResults: [{ channel: 'telegram', success: true }],
+			});
+
+			expect(result).toBe('alert-123_replay-key-1');
+			expect(mockCollection).toHaveBeenCalledWith('alertReplays');
+			expect(mockDocSet).toHaveBeenCalledWith({
+				alertId: 'alert-123',
+				idempotencyKey: 'replay-key-1',
+				channels: ['telegram'],
+				deliveryResults: [{ channel: 'telegram', success: true }],
+				replayedAt: expect.anything(),
+				source: 'alert-replay',
+			});
+		});
+
+		it('throws STORAGE_UNAVAILABLE when replay audit storage fails', async () => {
+			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+			mockDocSet.mockRejectedValueOnce(new Error('permission denied'));
+
+			await expect(AlertStorageService.saveReplayAttempt({
+				alertId: 'alert-123',
+				idempotencyKey: 'replay-key-2',
+				channels: ['telegram'],
+				deliveryResults: [],
+			})).rejects.toMatchObject({
 				code: 'STORAGE_UNAVAILABLE',
 			});
 		});


### PR DESCRIPTION
Add a protected stored-alert replay endpoint so operators can redeliver a previously persisted alert after downstream delivery problems without retriggering the original market signal.

## Summary

This branch implements `POST /api/alerts/:alertId/replay` for the existing Firestore-backed alert archive. The endpoint reloads an immutable stored alert, rebuilds the current notification payload, dispatches it to selected notification channels, and records an auditable replay attempt separately from the original alert document.

## Key Changes

- Adds `POST /api/alerts/:alertId/replay` under the existing `/api` router.
- Protects the replay endpoint with the same `validateApiKey` middleware used by stored alert read APIs.
- Requires an idempotency key via `idempotency-key`, `idempotencyKey`, or `idempotency_key`.
- Supports channel selection for `telegram`, `whatsapp`, or both by default.
- Stores replay audit records in the separate `alertReplays` Firestore collection using `${alertId}_${idempotencyKey}` as the replay document ID.
- Keeps original `alerts` documents immutable.
- Updates the Postman collection with valid and invalid replay examples.
- Updates agent documentation for future maintainers.

## Verification

- [x] `pnpm test -- tests/integration/alerts-endpoint.test.js --testTimeout=10000`
- [x] `pnpm test -- tests/unit/alert-storage-service.test.js --testTimeout=5000`
- [x] `pnpm test` reported `56 passed / 56`, `646 passed / 646`; later reruns hung after the green summary due to open handles and had to be interrupted.
- [x] GitHub Actions `Node.js CI / build`
- [x] Render preview `/healthcheck`

## References

Closes #66
Linear: CB-25
