### PR TITLE
feat(alerts): add analytics summary endpoint (CB-26)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -545,6 +545,60 @@
 					}
 				},
 				{
+					"name": "GET Alert Analytics Summary",
+					"request": {
+						"method": "GET",
+						"header": [
+							{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/alerts/summary?from=2026-06-06T00:00:00.000Z&to=2026-06-07T00:00:00.000Z&limit=500",
+							"host": ["{{baseUrl}}"],
+							"path": ["api", "alerts", "summary"],
+							"query": [
+								{ "key": "from", "value": "2026-06-06T00:00:00.000Z" },
+								{ "key": "to", "value": "2026-06-07T00:00:00.000Z" },
+								{ "key": "limit", "value": "500" }
+							]
+						},
+						"description": "Returns bounded JSON-only aggregates for stored alerts. Requires ENABLE_FIRESTORE_ALERT_STORAGE=true and a valid x-api-key."
+					},
+					"response": [
+						{
+							"name": "200 OK - Analytics summary",
+							"status": "OK",
+							"code": 200,
+							"body": "{\n  \"success\": true,\n  \"summary\": {\n    \"window\": {\n      \"from\": \"2026-06-06T00:00:00.000Z\",\n      \"to\": \"2026-06-07T00:00:00.000Z\",\n      \"limit\": 500,\n      \"maxDays\": 31\n    },\n    \"totalAlerts\": 2,\n    \"bySource\": { \"webhook\": 2 },\n    \"bySymbol\": { \"BTCUSDT\": 1, \"ETHUSDT\": 1 },\n    \"byFeatureFlag\": {\n      \"enriched\": 1,\n      \"plain\": 1,\n      \"tradingViewData\": 1,\n      \"withoutTradingViewData\": 1\n    },\n    \"enrichment\": {\n      \"enrichedAlerts\": 1,\n      \"plainAlerts\": 1,\n      \"tokenUsage\": {\n        \"inputTokens\": 10,\n        \"outputTokens\": 20,\n        \"totalTokens\": 30,\n        \"totalCost\": 0.001\n      }\n    },\n    \"delivery\": {\n      \"totalSuccess\": 2,\n      \"totalFailure\": 1,\n      \"byChannel\": {\n        \"telegram\": { \"total\": 2, \"success\": 1, \"failure\": 1 },\n        \"whatsapp\": { \"total\": 1, \"success\": 1, \"failure\": 0 }\n      }\n    },\n    \"latency\": {\n      \"averageProcessingMs\": 250,\n      \"averageDeliveryMs\": 150\n    }\n  }\n}"
+						}
+					]
+				},
+				{
+					"name": "GET Alert Analytics Summary (invalid window)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/alerts/summary?from=not-a-date",
+							"host": ["{{baseUrl}}"],
+							"path": ["api", "alerts", "summary"],
+							"query": [
+								{ "key": "from", "value": "not-a-date" }
+							]
+						},
+						"description": "Invalid input variant for summary timestamp validation."
+					},
+					"response": [
+						{
+							"name": "400 Bad Request - Invalid from timestamp",
+							"status": "Bad Request",
+							"code": 400,
+							"body": "{\n  \"error\": \"Invalid from timestamp. Use an ISO-8601 timestamp.\",\n  \"code\": \"INVALID_REQUEST\"\n}"
+						}
+					]
+				},
+				{
 					"name": "GET Get Alert by ID",
 					"request": {
 						"method": "GET",

--- a/README.md
+++ b/README.md
@@ -690,8 +690,8 @@ Set `ENABLE_FIRESTORE_JOB_STORAGE=true` plus the normal Firebase Admin credentia
 
 When `ENABLE_FIRESTORE_ALERT_STORAGE=true`, successful `POST /api/webhook/alert` requests are persisted to Firestore and can be inspected through the protected alerts read API.
 
-Both endpoints below require the same `x-api-key` header used by the webhook routes.
-If alert storage is enabled but Firestore credentials/project access are unavailable, both endpoints return `503 STORAGE_UNAVAILABLE` instead of a generic `500`.
+All endpoints below require the same `x-api-key` header used by the webhook routes.
+If alert storage is enabled but Firestore credentials/project access are unavailable, they return `503 STORAGE_UNAVAILABLE` instead of a generic `500`.
 
 #### GET /api/alerts
 
@@ -733,6 +733,76 @@ List stored alerts ordered by `receivedAt` descending.
     "hasMore": false,
     "limit": 50,
     "nextBefore": "eyJ2IjoxLCJyZWNlaXZlZEF0IjoiMjAyNi0wNi0wNlQxMjowMDowMC4wMDBaIiwiaWQiOiJhbGVydC0xIn0"
+  }
+}
+```
+
+#### GET /api/alerts/summary
+
+Return bounded JSON-only analytics for stored alerts without exposing raw alert text or credentials.
+
+**Query Parameters:**
+- `from` - Optional ISO-8601 lower bound; defaults to 24 hours before `to`
+- `to` - Optional ISO-8601 upper bound; defaults to request time
+- `limit` - Integer between `1` and `1000` (default: `500`)
+
+The service caps the queried window at 31 days to keep routine operator usage cheap.
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "summary": {
+    "window": {
+      "from": "2026-06-06T00:00:00.000Z",
+      "to": "2026-06-07T00:00:00.000Z",
+      "limit": 500,
+      "maxDays": 31
+    },
+    "totalAlerts": 2,
+    "bySource": {
+      "webhook": 2
+    },
+    "bySymbol": {
+      "BTCUSDT": 1,
+      "ETHUSDT": 1
+    },
+    "byFeatureFlag": {
+      "enriched": 1,
+      "plain": 1,
+      "tradingViewData": 1,
+      "withoutTradingViewData": 1
+    },
+    "enrichment": {
+      "enrichedAlerts": 1,
+      "plainAlerts": 1,
+      "tokenUsage": {
+        "inputTokens": 10,
+        "outputTokens": 20,
+        "totalTokens": 30,
+        "totalCost": 0.001
+      }
+    },
+    "delivery": {
+      "totalSuccess": 2,
+      "totalFailure": 1,
+      "byChannel": {
+        "telegram": {
+          "total": 2,
+          "success": 1,
+          "failure": 1
+        },
+        "whatsapp": {
+          "total": 1,
+          "success": 1,
+          "failure": 0
+        }
+      }
+    },
+    "latency": {
+      "averageProcessingMs": 250,
+      "averageDeliveryMs": 150
+    }
   }
 }
 ```

--- a/agents.md
+++ b/agents.md
@@ -39,7 +39,7 @@ This project is a small Express + Telegraf (Telegram) bot service that exposes a
 - `src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js` — `POST /api/webhook/expanded-analysis-alert` handler that builds TradingView MCP analysis reports and sends them through notification channels.
 - `src/controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation.js` — `POST /api/webhook/volume-confirmation` handler that returns structured TradingView MCP volume-confirmation data.
 - `src/controllers/webhooks/handlers/jobs/jobs.js` — Job creation (`POST /api/jobs/tradingview-analysis`) and status polling (`GET /api/jobs/:jobId`) handler.
-- `src/controllers/alerts/alerts.js` — Stored alert read/replay handlers for `GET /api/alerts`, `GET /api/alerts/:alertId`, and `POST /api/alerts/:alertId/replay`.
+- `src/controllers/alerts/alerts.js` — Stored alert read, analytics, and replay handlers for `GET /api/alerts`, `GET /api/alerts/summary`, `GET /api/alerts/:alertId`, and `POST /api/alerts/:alertId/replay`.
 - `src/controllers/status.js` — Status handler that computes capabilities, feature flags, notification channels, and active dependencies status.
 - `src/controllers/webhooks/handlers/marketScanner/marketScanner.js` — Scanner webhook handler executing sequential gainers, losers, and breakouts scanner runs on TradingView MCP.
 - `src/services/jobs/JobService.js` — Manages in-memory job state, executes background TradingView analysis runs, and performs periodic expiration cleanup.
@@ -144,7 +144,7 @@ Implement the following security practices to safeguard endpoints and credential
 - Optional but relevant (non-exhaustive; see feature sections below for full config): `ENABLE_TELEGRAM_BOT`, `PORT`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID`, `ENABLE_WHATSAPP_ALERTS`, `ENABLE_GEMINI_GROUNDING`, `GEMINI_API_KEY`, `ENABLE_LANGFUSE_PROMPTS`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_PROMPT_LABEL`, `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`, `BRAVE_SEARCH_API_KEY`, `BRAVE_SEARCH_ENDPOINT`, `FORCE_BRAVE_SEARCH`, `MODEL_PROVIDER`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `ENABLE_NEWS_MONITOR`, `EXPANDED_ANALYSIS_ALERT_SYMBOLS`, `EXPANDED_ANALYSIS_ALERT_TIMEOUT_MS`, `TRADINGVIEW_MCP_URL`, `TRADINGVIEW_MCP_TIMEOUT_MS`, `TRADINGVIEW_MCP_MAX_RETRIES`, `TRADINGVIEW_MCP_DEFAULT_TIMEFRAME`, `ENABLE_TRADINGVIEW_VOLUME_CONFIRMATION`, `ENABLE_SENTRY`, `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_CONSOLE_LOG_LEVELS`, `LOG_LEVEL`, `SERVICE_NAME`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `ENABLE_FIRESTORE_ALERT_STORAGE`, `ENABLE_MARKET_SCANNER`, `ENABLE_MESSAGE_FOOTER_METADATA`, `FIREBASE_PROJECT_ID`, `FIREBASE_SERVICE_ACCOUNT_JSON`, `GOOGLE_APPLICATION_CREDENTIALS`, `GEMINI_MODEL_NAME_FALLBACK`, `RENDER`, `IS_PULL_REQUEST`, `RENDER_GIT_COMMIT`, `RENDER_GIT_REPO_SLUG`.
 - Bot startup is gated: bot is launched only when `ENABLE_TELEGRAM_BOT === 'true'` and not a preview environment (`RENDER==='true' && IS_PULL_REQUEST==='true'` disables it).
 - Routes under `/api` (e.g. `/api/webhook/alert`) are mounted regardless of bot launch; individual features and notification channels are gated via env flags and per-channel validation.
-- Stored alert read/replay routes (`GET /api/alerts`, `GET /api/alerts/:alertId`, `POST /api/alerts/:alertId/replay`) are also mounted under `/api`; they require `WEBHOOK_API_KEY` when configured, return `403 FEATURE_DISABLED` unless `ENABLE_FIRESTORE_ALERT_STORAGE=true`, and return `503 STORAGE_UNAVAILABLE` when Firestore is enabled but unreadable.
+- Stored alert read, analytics, and replay routes (`GET /api/alerts`, `GET /api/alerts/summary`, `GET /api/alerts/:alertId`, `POST /api/alerts/:alertId/replay`) are also mounted under `/api`; they require `WEBHOOK_API_KEY` when configured, return `403 FEATURE_DISABLED` unless `ENABLE_FIRESTORE_ALERT_STORAGE=true`, and return `503 STORAGE_UNAVAILABLE` when Firestore is enabled but unreadable.
 
 ---
 
@@ -612,9 +612,10 @@ Every successful `POST /api/webhook/alert` request is persisted as a document in
 
 **Read API**:
 - `GET /api/alerts` returns stored alerts ordered by `receivedAt` descending with `limit`, `before`, `source`, and `enriched` query support.
+- `GET /api/alerts/summary` returns bounded JSON-only analytics for stored alerts, with `from`, `to`, and `limit` query support capped to a 31-day window and 1000 documents.
 - `GET /api/alerts/:alertId` returns a single formatted alert document by Firestore document ID.
 - `POST /api/alerts/:alertId/replay` reloads an immutable stored alert, rebuilds the current notification payload, dispatches it to requested channels (`telegram`, `whatsapp`, or both by default), and records the replay attempt in the separate `alertReplays` Firestore collection. It requires API-key auth and an idempotency key (`idempotency-key` header or `idempotencyKey` body/query field).
-- `listAlerts()` and `getAlertById()` in `src/services/storage/AlertStorageService.js` format Firestore documents into API-safe JSON with the following fields:
+- `listAlerts()`, `summarizeAlerts()`, and `getAlertById()` in `src/services/storage/AlertStorageService.js` format Firestore documents into API-safe JSON with the following fields:
   - `id`
   - `receivedAt`
   - `text`

--- a/src/controllers/alerts/alerts.js
+++ b/src/controllers/alerts/alerts.js
@@ -6,6 +6,8 @@ const sentryService = require('../../services/monitoring/SentryService');
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 const VALID_CHANNELS = ['telegram', 'whatsapp'];
+const DEFAULT_SUMMARY_LIMIT = 500;
+const MAX_SUMMARY_LIMIT = 1000;
 
 function parseLimit(rawLimit) {
 	if (rawLimit === undefined) {
@@ -34,6 +36,36 @@ function parseEnriched(rawEnriched) {
 	}
 
 	return null;
+}
+
+function parseSummaryLimit(rawLimit) {
+	if (rawLimit === undefined) {
+		return DEFAULT_SUMMARY_LIMIT;
+	}
+
+	const limit = Number.parseInt(rawLimit, 10);
+	if (!Number.isInteger(limit) || limit < 1 || limit > MAX_SUMMARY_LIMIT) {
+		return null;
+	}
+
+	return limit;
+}
+
+function parseOptionalTimestamp(rawValue, name) {
+	if (rawValue === undefined) {
+		return { value: undefined };
+	}
+
+	if (typeof rawValue !== 'string' || !rawValue.trim() || Number.isNaN(Date.parse(rawValue))) {
+		return {
+			error: {
+				error: `Invalid ${name} timestamp. Use an ISO-8601 timestamp.`,
+				code: 'INVALID_REQUEST',
+			},
+		};
+	}
+
+	return { value: new Date(rawValue).toISOString() };
 }
 
 function listAlerts(req, res) {
@@ -90,6 +122,46 @@ function listAlerts(req, res) {
 				limit,
 				nextBefore: result.nextBefore,
 			},
+		});
+	});
+}
+
+function summarizeAlerts(req, res) {
+	return handleAsync(req, res, '/api/alerts/summary', async () => {
+		if (!alertStorageService.isEnabled()) {
+			return res.status(403).json({
+				error: 'Alert storage feature is disabled. Set ENABLE_FIRESTORE_ALERT_STORAGE=true to enable.',
+				code: 'FEATURE_DISABLED',
+			});
+		}
+
+		const limit = parseSummaryLimit(req.query.limit);
+		if (limit === null) {
+			return res.status(400).json({
+				error: `Invalid limit. Use an integer between 1 and ${MAX_SUMMARY_LIMIT}.`,
+				code: 'INVALID_REQUEST',
+			});
+		}
+
+		const from = parseOptionalTimestamp(req.query.from, 'from');
+		if (from.error) {
+			return res.status(400).json(from.error);
+		}
+
+		const to = parseOptionalTimestamp(req.query.to, 'to');
+		if (to.error) {
+			return res.status(400).json(to.error);
+		}
+
+		const summary = await alertStorageService.summarizeAlerts({
+			from: from.value,
+			limit,
+			to: to.value,
+		});
+
+		return res.status(200).json({
+			success: true,
+			summary,
 		});
 	});
 }
@@ -239,7 +311,9 @@ function replayAlert(botOrGetter) {
 function handleAsync(req, res, endpoint, handler) {
 	return Promise.resolve(handler()).catch((error) => {
 		console.error('[AlertsController] Request failed:', error.message);
-		const statusCode = error.code === alertStorageService.STORAGE_UNAVAILABLE_CODE ? 503 : 500;
+		const statusCode = error.code === alertStorageService.STORAGE_UNAVAILABLE_CODE
+			? 503
+			: (error.code === 'INVALID_REQUEST' ? 400 : 500);
 		sentryService.captureRuntimeError({
 			channel: 'alerts-controller',
 			error,
@@ -257,6 +331,13 @@ function handleAsync(req, res, endpoint, handler) {
 			});
 		}
 
+		if (statusCode === 400) {
+			return res.status(400).json({
+				error: error.message,
+				code: 'INVALID_REQUEST',
+			});
+		}
+
 		return res.status(500).json({
 			error: 'Internal server error',
 			code: 'INTERNAL_ERROR',
@@ -268,4 +349,5 @@ module.exports = {
 	listAlerts,
 	getAlertById,
 	replayAlert,
+	summarizeAlerts,
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -13,7 +13,7 @@ const {
 } = require('../controllers/webhooks/handlers/scannerPresets/scannerPresets');
 const { postVolumeConfirmation } = require('../controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation');
 const { postCreateJob, getJobStatus } = require('../controllers/webhooks/handlers/jobs/jobs');
-const { listAlerts, getAlertById, replayAlert } = require('../controllers/alerts/alerts');
+const { listAlerts, getAlertById, replayAlert, summarizeAlerts } = require('../controllers/alerts/alerts');
 const { validateApiKey } = require('../lib/auth');
 const { getApiStatus } = require('../controllers/status');
 const { idempotencyMiddleware } = require('../lib/idempotency');
@@ -26,6 +26,7 @@ function getRoutes(botOrGetter) {
 	router.post('/webhook/market-scanner-alert', validateApiKey, idempotencyMiddleware, postMarketScannerAlert(botOrGetter));
 	router.post('/webhook/volume-confirmation', validateApiKey, postVolumeConfirmation());
 	router.get('/alerts', validateApiKey, listAlerts);
+	router.get('/alerts/summary', validateApiKey, summarizeAlerts);
 	router.post('/alerts/:alertId/replay', validateApiKey, idempotencyMiddleware, replayAlert(botOrGetter));
 	router.get('/alerts/:alertId', validateApiKey, getAlertById);
 	router.post('/scanner-presets', validateApiKey, postPreset);

--- a/src/services/storage/AlertStorageService.js
+++ b/src/services/storage/AlertStorageService.js
@@ -31,6 +31,9 @@ const COLLECTION_NAME = 'alerts';
 const REPLAY_COLLECTION_NAME = 'alertReplays';
 const DEFAULT_PAGE_SIZE = 50;
 const MAX_PAGE_SIZE = 100;
+const DEFAULT_SUMMARY_LIMIT = 500;
+const MAX_SUMMARY_LIMIT = 1000;
+const MAX_SUMMARY_WINDOW_DAYS = 31;
 const STORAGE_UNAVAILABLE_CODE = 'STORAGE_UNAVAILABLE';
 const INVALID_CURSOR_MESSAGE = 'Invalid before cursor. Use an ISO-8601 timestamp or the nextBefore cursor from a previous response.';
 
@@ -74,6 +77,118 @@ function formatAlertDocument(doc) {
 		source: typeof data.source === 'string' ? data.source : null,
 		useTradingViewData: Boolean(data.useTradingViewData),
 	};
+}
+
+function getNumericValue(value) {
+	const numeric = Number(value);
+	return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function incrementCounter(target, key) {
+	const normalizedKey = typeof key === 'string' && key.trim()
+		? key.trim()
+		: 'unknown';
+	target[normalizedKey] = (target[normalizedKey] || 0) + 1;
+}
+
+function extractAlertSymbol(data) {
+	const candidates = [
+		data.symbol,
+		data.ticker,
+		data.enrichmentData && data.enrichmentData.symbol,
+		data.enrichmentData && data.enrichmentData.ticker,
+		data.enrichmentData && data.enrichmentData.asset,
+		data.enrichmentData && data.enrichmentData.original_symbol,
+	];
+
+	const symbol = candidates.find((candidate) => typeof candidate === 'string' && candidate.trim());
+	return symbol ? symbol.trim().toUpperCase() : 'unknown';
+}
+
+function addTokenUsage(totals, tokenUsage) {
+	if (!tokenUsage || typeof tokenUsage !== 'object') {
+		return;
+	}
+
+	totals.inputTokens += getNumericValue(tokenUsage.inputTokens || tokenUsage.promptTokens);
+	totals.outputTokens += getNumericValue(tokenUsage.outputTokens || tokenUsage.completionTokens);
+	totals.totalTokens += getNumericValue(tokenUsage.totalTokens || tokenUsage.total);
+	totals.totalCost += getNumericValue(tokenUsage.totalCost);
+}
+
+function addDeliverySummary(summary, deliveryResults) {
+	if (!Array.isArray(deliveryResults)) {
+		return;
+	}
+
+	for (const result of deliveryResults) {
+		if (!result || typeof result !== 'object') {
+			continue;
+		}
+
+		const channel = typeof result.channel === 'string' && result.channel.trim()
+			? result.channel.trim()
+			: 'unknown';
+		if (!summary.byChannel[channel]) {
+			summary.byChannel[channel] = { total: 0, success: 0, failure: 0 };
+		}
+
+		summary.byChannel[channel].total += 1;
+		if (result.success) {
+			summary.byChannel[channel].success += 1;
+			summary.totalSuccess += 1;
+		} else {
+			summary.byChannel[channel].failure += 1;
+			summary.totalFailure += 1;
+		}
+	}
+}
+
+function collectLatency(samples, value) {
+	const numeric = Number(value);
+	if (Number.isFinite(numeric) && numeric >= 0) {
+		samples.push(numeric);
+	}
+}
+
+function averageLatency(samples) {
+	if (samples.length === 0) {
+		return null;
+	}
+
+	return Math.round(samples.reduce((sum, value) => sum + value, 0) / samples.length);
+}
+
+function buildSummaryWindow({ from, to, limit }) {
+	const now = new Date();
+	const parsedTo = to ? new Date(to) : now;
+	const maxWindowMs = MAX_SUMMARY_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+	let parsedFrom = from ? new Date(from) : new Date(parsedTo.getTime() - (24 * 60 * 60 * 1000));
+
+	if (parsedTo.getTime() - parsedFrom.getTime() > maxWindowMs) {
+		parsedFrom = new Date(parsedTo.getTime() - maxWindowMs);
+	}
+
+	if (parsedFrom.getTime() > parsedTo.getTime()) {
+		const error = new Error('Invalid summary window. from must be before or equal to to.');
+		error.code = 'INVALID_REQUEST';
+		throw error;
+	}
+
+	return {
+		from: parsedFrom.toISOString(),
+		to: parsedTo.toISOString(),
+		limit: clampSummaryLimit(limit),
+		maxDays: MAX_SUMMARY_WINDOW_DAYS,
+	};
+}
+
+function clampSummaryLimit(limit) {
+	if (!Number.isInteger(limit) || limit < 1) {
+		return DEFAULT_SUMMARY_LIMIT;
+	}
+
+	return Math.min(limit, MAX_SUMMARY_LIMIT);
 }
 
 function matchesFilters(alert, filters) {
@@ -381,11 +496,125 @@ async function saveReplayAttempt({ alertId, idempotencyKey, channels, deliveryRe
 	}
 }
 
+/**
+ * Build bounded aggregate metrics for stored alerts.
+ *
+ * The endpoint intentionally returns counts and totals only. Raw alert text,
+ * provider payloads, credentials, and error details stay out of the response.
+ *
+ * @param {Object} params
+ * @param {string|undefined} params.from ISO timestamp, defaults to 24h before to
+ * @param {string|undefined} params.to ISO timestamp, defaults to now
+ * @param {number|undefined} params.limit Maximum documents scanned, capped at 1000
+ * @returns {Promise<Object|null>}
+ */
+async function summarizeAlerts({ from, to, limit } = {}) {
+	if (!isEnabled()) {
+		return null;
+	}
+
+	const firestore = getFirestore();
+	if (!firestore) {
+		throw createStorageUnavailableError();
+	}
+
+	const window = buildSummaryWindow({ from, to, limit });
+	let snapshot;
+	try {
+		snapshot = await firestore
+			.collection(COLLECTION_NAME)
+			.where('receivedAt', '>=', admin.firestore.Timestamp.fromDate(new Date(window.from)))
+			.where('receivedAt', '<=', admin.firestore.Timestamp.fromDate(new Date(window.to)))
+			.orderBy('receivedAt', 'desc')
+			.limit(window.limit)
+			.get();
+	} catch (error) {
+		console.warn('[AlertStorageService] Failed to summarize alerts from Firestore:', error.message);
+		throw createStorageUnavailableError(error);
+	}
+
+	const summary = {
+		window,
+		totalAlerts: 0,
+		bySource: {},
+		bySymbol: {},
+		byFeatureFlag: {
+			enriched: 0,
+			plain: 0,
+			tradingViewData: 0,
+			withoutTradingViewData: 0,
+		},
+		enrichment: {
+			enrichedAlerts: 0,
+			plainAlerts: 0,
+			tokenUsage: {
+				inputTokens: 0,
+				outputTokens: 0,
+				totalTokens: 0,
+				totalCost: 0,
+			},
+		},
+		delivery: {
+			totalSuccess: 0,
+			totalFailure: 0,
+			byChannel: {},
+		},
+		latency: {
+			averageProcessingMs: null,
+			averageDeliveryMs: null,
+		},
+	};
+	const processingLatencySamples = [];
+	const deliveryLatencySamples = [];
+
+	const docs = snapshot && Array.isArray(snapshot.docs) ? snapshot.docs : [];
+	for (const doc of docs) {
+		const data = doc.data() || {};
+		const enriched = Boolean(data.enriched);
+		const useTradingViewData = Boolean(data.useTradingViewData);
+
+		summary.totalAlerts += 1;
+		incrementCounter(summary.bySource, data.source);
+		incrementCounter(summary.bySymbol, extractAlertSymbol(data));
+
+		if (enriched) {
+			summary.byFeatureFlag.enriched += 1;
+			summary.enrichment.enrichedAlerts += 1;
+		} else {
+			summary.byFeatureFlag.plain += 1;
+			summary.enrichment.plainAlerts += 1;
+		}
+
+		if (useTradingViewData) {
+			summary.byFeatureFlag.tradingViewData += 1;
+		} else {
+			summary.byFeatureFlag.withoutTradingViewData += 1;
+		}
+
+		addTokenUsage(summary.enrichment.tokenUsage, data.tokenUsage);
+		addDeliverySummary(summary.delivery, data.deliveryResults);
+		collectLatency(processingLatencySamples, data.processingTimeMs || data.processing_time_ms);
+
+		if (Array.isArray(data.deliveryResults)) {
+			for (const result of data.deliveryResults) {
+				collectLatency(deliveryLatencySamples, result && (result.latencyMs || result.deliveryLatencyMs || result.durationMs));
+			}
+		}
+	}
+
+	summary.enrichment.tokenUsage.totalCost = Number(summary.enrichment.tokenUsage.totalCost.toFixed(6));
+	summary.latency.averageProcessingMs = averageLatency(processingLatencySamples);
+	summary.latency.averageDeliveryMs = averageLatency(deliveryLatencySamples);
+
+	return summary;
+}
+
 module.exports = {
 	isEnabled,
 	saveAlert,
 	listAlerts,
 	getAlertById,
+	summarizeAlerts,
 	saveReplayAttempt,
 	STORAGE_UNAVAILABLE_CODE,
 	INVALID_CURSOR_MESSAGE,

--- a/tests/integration/alerts-endpoint.test.js
+++ b/tests/integration/alerts-endpoint.test.js
@@ -5,6 +5,7 @@ jest.mock('../../src/services/storage/AlertStorageService', () => ({
 	listAlerts: jest.fn(),
 	getAlertById: jest.fn(),
 	saveReplayAttempt: jest.fn(),
+	summarizeAlerts: jest.fn(),
 	STORAGE_UNAVAILABLE_CODE: 'STORAGE_UNAVAILABLE',
 	INVALID_CURSOR_MESSAGE: 'Invalid before cursor. Use an ISO-8601 timestamp or the nextBefore cursor from a previous response.',
 	parseAlertPaginationCursor: jest.fn(),
@@ -194,6 +195,130 @@ describe('Alerts API Integration Tests', () => {
 		expect(res.body).toEqual({
 			error: 'Alert storage is enabled but Firestore is unavailable. Check Firestore credentials and project configuration.',
 			code: 'STORAGE_UNAVAILABLE',
+		});
+	});
+
+	it('returns an alert analytics summary for a bounded time window', async () => {
+		alertStorageService.summarizeAlerts.mockResolvedValue({
+			window: {
+				from: '2026-06-06T00:00:00.000Z',
+				to: '2026-06-07T00:00:00.000Z',
+				limit: 200,
+				maxDays: 31,
+			},
+			totalAlerts: 2,
+			bySource: { webhook: 2 },
+			bySymbol: { BTCUSDT: 1, ETHUSDT: 1 },
+			byFeatureFlag: {
+				enriched: 1,
+				plain: 1,
+				tradingViewData: 1,
+				withoutTradingViewData: 1,
+			},
+			enrichment: {
+				enrichedAlerts: 1,
+				plainAlerts: 1,
+				tokenUsage: {
+					inputTokens: 10,
+					outputTokens: 20,
+					totalTokens: 30,
+					totalCost: 0.001,
+				},
+			},
+			delivery: {
+				totalSuccess: 2,
+				totalFailure: 1,
+				byChannel: {
+					telegram: { total: 2, success: 1, failure: 1 },
+					whatsapp: { total: 1, success: 1, failure: 0 },
+				},
+			},
+			latency: {
+				averageProcessingMs: null,
+				averageDeliveryMs: 125,
+			},
+		});
+
+		const res = await request(app)
+			.get('/api/alerts/summary?from=2026-06-06T00:00:00.000Z&to=2026-06-07T00:00:00.000Z&limit=200')
+			.set('x-api-key', 'test-key')
+			.expect(200);
+
+		expect(alertStorageService.summarizeAlerts).toHaveBeenCalledWith({
+			from: '2026-06-06T00:00:00.000Z',
+			limit: 200,
+			to: '2026-06-07T00:00:00.000Z',
+		});
+		expect(res.body).toEqual({
+			success: true,
+			summary: {
+				window: {
+					from: '2026-06-06T00:00:00.000Z',
+					to: '2026-06-07T00:00:00.000Z',
+					limit: 200,
+					maxDays: 31,
+				},
+				totalAlerts: 2,
+				bySource: { webhook: 2 },
+				bySymbol: { BTCUSDT: 1, ETHUSDT: 1 },
+				byFeatureFlag: {
+					enriched: 1,
+					plain: 1,
+					tradingViewData: 1,
+					withoutTradingViewData: 1,
+				},
+				enrichment: {
+					enrichedAlerts: 1,
+					plainAlerts: 1,
+					tokenUsage: {
+						inputTokens: 10,
+						outputTokens: 20,
+						totalTokens: 30,
+						totalCost: 0.001,
+					},
+				},
+				delivery: {
+					totalSuccess: 2,
+					totalFailure: 1,
+					byChannel: {
+						telegram: { total: 2, success: 1, failure: 1 },
+						whatsapp: { total: 1, success: 1, failure: 0 },
+					},
+				},
+				latency: {
+					averageProcessingMs: null,
+					averageDeliveryMs: 125,
+				},
+			},
+		});
+	});
+
+	it('returns 400 when the summary window is invalid', async () => {
+		const res = await request(app)
+			.get('/api/alerts/summary?from=not-a-date')
+			.set('x-api-key', 'test-key')
+			.expect(400);
+
+		expect(res.body).toEqual({
+			error: 'Invalid from timestamp. Use an ISO-8601 timestamp.',
+			code: 'INVALID_REQUEST',
+		});
+		expect(alertStorageService.summarizeAlerts).not.toHaveBeenCalled();
+	});
+
+	it('returns 400 when the summary service rejects an inverted time window', async () => {
+		const error = new Error('Invalid summary window. from must be before or equal to to.');
+		error.code = 'INVALID_REQUEST';
+		alertStorageService.summarizeAlerts.mockRejectedValue(error);
+
+		const res = await request(app)
+			.get('/api/alerts/summary?from=2026-06-07T00:00:00.000Z&to=2026-06-06T00:00:00.000Z')
+			.set('x-api-key', 'test-key')
+			.expect(400);
+
+		expect(res.body).toEqual({
+			error: 'Invalid summary window. from must be before or equal to to.',
+			code: 'INVALID_REQUEST',
 		});
 	});
 

--- a/tests/unit/alert-storage-service.test.js
+++ b/tests/unit/alert-storage-service.test.js
@@ -560,4 +560,98 @@ describe('AlertStorageService', () => {
 			});
 		});
 	});
+
+	describe('summarizeAlerts()', () => {
+		it('aggregates bounded alert analytics without exposing raw alert text', async () => {
+			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+			mockGet.mockResolvedValueOnce({
+				empty: false,
+				docs: [
+					buildQueryDoc('alert-1', {
+						receivedAt: buildTimestamp('2026-06-06T12:00:00.000Z'),
+						text: 'BTC raw alert text should not leak',
+						enriched: true,
+						enrichmentData: { symbol: 'BTCUSDT' },
+						tokenUsage: {
+							inputTokens: 10,
+							outputTokens: 20,
+							totalTokens: 30,
+							totalCost: 0.001,
+						},
+						deliveryResults: [
+							{ channel: 'telegram', success: true, latencyMs: 100 },
+							{ channel: 'whatsapp', success: true, latencyMs: 150 },
+						],
+						source: 'webhook',
+						useTradingViewData: true,
+						processingTimeMs: 250,
+					}),
+					buildQueryDoc('alert-2', {
+						receivedAt: buildTimestamp('2026-06-06T11:00:00.000Z'),
+						text: 'ETH raw alert text should not leak',
+						enriched: false,
+						enrichmentData: { symbol: 'ETHUSDT' },
+						tokenUsage: null,
+						deliveryResults: [
+							{ channel: 'telegram', success: false, latencyMs: 200 },
+						],
+						source: 'webhook',
+						useTradingViewData: false,
+					}),
+				],
+			});
+
+			const result = await AlertStorageService.summarizeAlerts({
+				from: '2026-06-06T00:00:00.000Z',
+				to: '2026-06-07T00:00:00.000Z',
+				limit: 200,
+			});
+
+			expect(mockCollection).toHaveBeenCalledWith('alerts');
+			expect(mockWhere).toHaveBeenCalledWith('receivedAt', '>=', expect.anything());
+			expect(mockWhere).toHaveBeenCalledWith('receivedAt', '<=', expect.anything());
+			expect(mockOrderBy).toHaveBeenCalledWith('receivedAt', 'desc');
+			expect(mockLimit).toHaveBeenCalledWith(200);
+			expect(result).toEqual({
+				window: {
+					from: '2026-06-06T00:00:00.000Z',
+					to: '2026-06-07T00:00:00.000Z',
+					limit: 200,
+					maxDays: 31,
+				},
+				totalAlerts: 2,
+				bySource: { webhook: 2 },
+				bySymbol: { BTCUSDT: 1, ETHUSDT: 1 },
+				byFeatureFlag: {
+					enriched: 1,
+					plain: 1,
+					tradingViewData: 1,
+					withoutTradingViewData: 1,
+				},
+				enrichment: {
+					enrichedAlerts: 1,
+					plainAlerts: 1,
+					tokenUsage: {
+						inputTokens: 10,
+						outputTokens: 20,
+						totalTokens: 30,
+						totalCost: 0.001,
+					},
+				},
+				delivery: {
+					totalSuccess: 2,
+					totalFailure: 1,
+					byChannel: {
+						telegram: { total: 2, success: 1, failure: 1 },
+						whatsapp: { total: 1, success: 1, failure: 0 },
+					},
+				},
+				latency: {
+					averageProcessingMs: 250,
+					averageDeliveryMs: 150,
+				},
+			});
+			expect(JSON.stringify(result)).not.toContain('raw alert text');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Add an API-key protected alert analytics summary endpoint for stored Firestore alerts.

## Key Changes

- Adds `GET /api/alerts/summary` before the dynamic alert detail route.
- Aggregates stored alert counts by source, symbol, enrichment/use-TradingView flags, token usage, delivery channel outcomes, and available latency samples.
- Keeps summary reads bounded with a 31-day maximum window and a 1000-document scan cap.
- Updates README, Postman collection, and agent context for the new API contract.

## Technical Implementation

- `src/controllers/alerts/alerts.js` validates `from`, `to`, and `limit` query params and maps invalid summary windows to `400 INVALID_REQUEST`.
- `src/services/storage/AlertStorageService.js` performs a bounded Firestore range query over `receivedAt` and returns aggregate-only JSON without raw alert text.
- `src/routes/index.js` mounts `/alerts/summary` before `/alerts/:alertId` to avoid route shadowing.

## Testing

- `pnpm test -- tests/integration/alerts-endpoint.test.js tests/unit/alert-storage-service.test.js --testTimeout=10000`
- `pnpm test`

## References

- Fixes #67
- Linear: https://linear.app/knil/issue/CB-26/gh-67-add-alert-analytics-summary-endpoint
