### PR TITLE
feat: add async job cancellation and retry endpoints (CB-27)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -704,6 +704,48 @@
 							"path": ["api", "jobs", "{{jobId}}"]
 						}
 					}
+				},
+				{
+					"name": "POST Cancel Job",
+					"request": {
+						"method": "POST",
+						"header": [
+							{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/jobs/{{jobId}}/cancel",
+							"host": ["{{baseUrl}}"],
+							"path": ["api", "jobs", "{{jobId}}", "cancel"]
+						}
+					}
+				},
+				{
+					"name": "POST Retry Job",
+					"request": {
+						"method": "POST",
+						"header": [
+							{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/jobs/{{jobId}}/retry",
+							"host": ["{{baseUrl}}"],
+							"path": ["api", "jobs", "{{jobId}}", "retry"]
+						}
+					}
+				},
+				{
+					"name": "POST Retry Failed Job",
+					"request": {
+						"method": "POST",
+						"header": [
+							{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/jobs/{{jobId}}/retry-failed",
+							"host": ["{{baseUrl}}"],
+							"path": ["api", "jobs", "{{jobId}}", "retry-failed"]
+						}
+					}
 				}
 			]
 		}

--- a/context/francovaleriop-cb-27-gh-71-job-cancel-retry.md
+++ b/context/francovaleriop-cb-27-gh-71-job-cancel-retry.md
@@ -1,0 +1,48 @@
+feat: add async job cancellation and retry endpoints (CB-27)
+
+## Summary
+
+Exposes protected job lifecycle actions (`cancel`, `retry`, and `retry-failed`) for long-running scan or analysis jobs under the `/api` routing namespace.
+
+## Key Changes
+
+### :wrench: Expose Job cancellation and retries
+
+- Exposes three new protected routes:
+  - `POST /api/jobs/:jobId/cancel` - Cancels an active/processing job by aborting its remote stream queries.
+  - `POST /api/jobs/:jobId/retry` - Retries a failed, timed-out, or cancelled job by starting a new job with the same request inputs.
+  - `POST /api/jobs/:jobId/retry-failed` - Retries only the subset of indicators or scans that failed or timed out during the original run.
+- Ensures all new endpoints validate the `x-api-key` header/param just like core webhook alert endpoints.
+- Avoids mutating completed or failed history by returning a brand new `jobId` for retries, providing clear traceability back to the `oldJobId`.
+- Preserves terminal statuses: `completed`, `failed`, `cancelled`, and `timed_out`.
+
+## Technical Implementation
+
+### Service Layer
+
+- Track active `AbortController` instances inside `JobService` using `this.activeControllers`.
+- Maintain sanitized request metadata (`requestMetadata`) on the stored job object upon job creation, avoiding leaks of any credentials or secrets.
+- Add cancellation checks inside loop iterations of `_executeExpandedAnalysis` and `_executeMarketScanner` to stop remote TradingView MCP requests instantly.
+- Protect `_persistJob` to prevent race conditions or state overwriting where a processing background thread could overwrite a terminal cancelled status.
+
+### Routes & Controllers
+
+- Add `postCancelJob`, `postRetryJob`, and `postRetryFailedJob` controllers under `src/controllers/webhooks/handlers/jobs/jobs.js`.
+- Mount routes and apply validation middleware in `src/routes/index.js`.
+- Update Postman Collection `CabrosBot.postman_collection.json` with the new endpoint contract examples.
+
+## Testing
+
+### Automated Tests
+
+- New unit tests added in `tests/unit/job-service.test.js` validating:
+  - Cancellation of active jobs and 409 responses for terminal states.
+  - Retry functionality with correct duplication of `requestMetadata`.
+  - Selective retry of only failed items.
+- New unit tests added in `tests/unit/jobs-controller.test.js` asserting status codes and Sentry monitoring.
+- Integration tests in `tests/integration/jobs-endpoint.test.js` checking end-to-end cancellation and retry lifecycle flow.
+
+## References
+
+- GitHub Issue: https://github.com/francovp/cabros-bot/issues/71
+- **Linear**: [CB-27](https://linear.app/knil/issue/CB-27/add-async-job-cancellation-and-retry-endpoints)

--- a/src/controllers/webhooks/handlers/jobs/jobs.js
+++ b/src/controllers/webhooks/handlers/jobs/jobs.js
@@ -91,7 +91,160 @@ async function getJobStatus(req, res) {
 	}
 }
 
+async function postCancelJob(req, res) {
+	const { jobId } = req.params;
+
+	if (!jobId) {
+		return res.status(400).json({
+			error: 'Missing jobId parameter',
+			code: 'INVALID_REQUEST',
+		});
+	}
+
+	try {
+		const result = await jobService.cancelJob(jobId);
+
+		if (!result) {
+			return res.status(404).json({
+				success: false,
+				error: 'Job not found',
+			});
+		}
+
+		if (!result.success) {
+			return res.status(409).json({
+				success: false,
+				error: result.message,
+				code: result.code,
+				status: result.status,
+			});
+		}
+
+		return res.status(200).json(result);
+	} catch (error) {
+		console.error('[JobsController] Failed to cancel job:', error.message);
+		sentryService.captureRuntimeError({
+			channel: 'jobs-controller',
+			error,
+			http: {
+				endpoint: `/api/jobs/${jobId}/cancel`,
+				method: 'POST',
+				statusCode: 500,
+			},
+		});
+
+		return res.status(500).json({
+			error: 'Internal server error',
+			code: 'INTERNAL_ERROR',
+		});
+	}
+}
+
+function postRetryJob(botOrGetter) {
+	return async (req, res) => {
+		const { jobId } = req.params;
+
+		if (!jobId) {
+			return res.status(400).json({
+				error: 'Missing jobId parameter',
+				code: 'INVALID_REQUEST',
+			});
+		}
+
+		try {
+			const result = await jobService.retryJob(jobId, botOrGetter);
+
+			if (!result) {
+				return res.status(404).json({
+					success: false,
+					error: 'Job not found',
+				});
+			}
+
+			if (!result.success) {
+				return res.status(409).json({
+					success: false,
+					error: result.message,
+					code: result.code,
+				});
+			}
+
+			return res.status(201).json(result);
+		} catch (error) {
+			console.error('[JobsController] Failed to retry job:', error.message);
+			sentryService.captureRuntimeError({
+				channel: 'jobs-controller',
+				error,
+				http: {
+					endpoint: `/api/jobs/${jobId}/retry`,
+					method: 'POST',
+					statusCode: 500,
+				},
+			});
+
+			return res.status(500).json({
+				error: 'Internal server error',
+				code: 'INTERNAL_ERROR',
+			});
+		}
+	};
+}
+
+function postRetryFailedJob(botOrGetter) {
+	return async (req, res) => {
+		const { jobId } = req.params;
+
+		if (!jobId) {
+			return res.status(400).json({
+				error: 'Missing jobId parameter',
+				code: 'INVALID_REQUEST',
+			});
+		}
+
+		try {
+			const result = await jobService.retryFailedJob(jobId, botOrGetter);
+
+			if (!result) {
+				return res.status(404).json({
+					success: false,
+					error: 'Job not found',
+				});
+			}
+
+			if (!result.success) {
+				const statusCode = result.code === 'NO_FAILED_ITEMS' ? 400 : 409;
+				return res.status(statusCode).json({
+					success: false,
+					error: result.message,
+					code: result.code,
+				});
+			}
+
+			return res.status(201).json(result);
+		} catch (error) {
+			console.error('[JobsController] Failed to retry failed job:', error.message);
+			sentryService.captureRuntimeError({
+				channel: 'jobs-controller',
+				error,
+				http: {
+					endpoint: `/api/jobs/${jobId}/retry-failed`,
+					method: 'POST',
+					statusCode: 500,
+				},
+			});
+
+			return res.status(500).json({
+				error: 'Internal server error',
+				code: 'INTERNAL_ERROR',
+			});
+		}
+	};
+}
+
 module.exports = {
 	postCreateJob,
 	getJobStatus,
+	postCancelJob,
+	postRetryJob,
+	postRetryFailedJob,
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -12,7 +12,13 @@ const {
 	postRunPreset,
 } = require('../controllers/webhooks/handlers/scannerPresets/scannerPresets');
 const { postVolumeConfirmation } = require('../controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation');
-const { postCreateJob, getJobStatus } = require('../controllers/webhooks/handlers/jobs/jobs');
+const {
+	postCreateJob,
+	getJobStatus,
+	postCancelJob,
+	postRetryJob,
+	postRetryFailedJob,
+} = require('../controllers/webhooks/handlers/jobs/jobs');
 const { listAlerts, getAlertById, replayAlert } = require('../controllers/alerts/alerts');
 const { validateApiKey } = require('../lib/auth');
 const { getApiStatus } = require('../controllers/status');
@@ -38,6 +44,9 @@ function getRoutes(botOrGetter) {
 	// Async job endpoints
 	router.post('/jobs/tradingview-analysis', validateApiKey, postCreateJob(botOrGetter));
 	router.get('/jobs/:jobId', validateApiKey, getJobStatus);
+	router.post('/jobs/:jobId/cancel', validateApiKey, postCancelJob);
+	router.post('/jobs/:jobId/retry', validateApiKey, postRetryJob(botOrGetter));
+	router.post('/jobs/:jobId/retry-failed', validateApiKey, postRetryFailedJob(botOrGetter));
 
 	const { getNewsMonitor } = require('../controllers/webhooks/handlers/newsMonitor/newsMonitor');
 	const newsMonitor = getNewsMonitor();

--- a/src/services/jobs/JobService.js
+++ b/src/services/jobs/JobService.js
@@ -24,6 +24,7 @@ class JobService {
 	constructor(repository = jobRepository) {
 		this.repository = repository;
 		this.jobs = repository;
+		this.activeControllers = new Map();
 	}
 
 	/**
@@ -153,11 +154,29 @@ class JobService {
 			validatedTimeoutMs = Math.min(timeoutVal, MAX_JOB_TIMEOUT_MS);
 		}
 
+		const requestMetadata = {
+			type,
+			timeoutMs: validatedTimeoutMs,
+			...(type === 'expanded-analysis' ? {
+				symbols: parsed.symbols.map((s) => s.raw),
+				timeframe: parsed.timeframe,
+				includeMultiTimeframe: parsed.includeMultiTimeframe,
+				analysisMode: parsed.analysisMode,
+			} : {
+				exchange: parsed.exchange,
+				timeframe: parsed.timeframe,
+				scans: parsed.scans,
+				limit: parsed.limit,
+				bbwThreshold: parsed.bbwThreshold,
+			}),
+		};
+
 		const jobId = uuidv4();
 		const job = {
 			jobId,
 			type,
 			status: 'processing',
+			requestMetadata,
 			progress: {
 				total: type === 'expanded-analysis' ? parsed.symbols.length : parsed.scans.length,
 				current: 0,
@@ -207,6 +226,8 @@ class JobService {
 		const timeoutMs = job.timeoutMs || DEFAULT_JOB_TIMEOUT_MS;
 
 		const controller = new AbortController();
+		this.activeControllers.set(jobId, controller);
+
 		const timeoutId = setTimeout(() => {
 			controller.abort(new Error(`Job timed out after ${timeoutMs}ms`));
 		}, timeoutMs);
@@ -221,9 +242,22 @@ class JobService {
 			}
 		} catch (error) {
 			console.error(`[JobService] Job ${jobId} failed:`, error.message);
-			job.status = 'failed';
+
+			const currentJob = await this.repository.get(jobId);
+			if (currentJob && currentJob.status === 'cancelled') {
+				return;
+			}
+
+			const isTimeout =
+				error.message.includes('timed out') ||
+				error.name === 'TimeoutError' ||
+				error.name === 'AbortError' ||
+				(job.fullResults && job.fullResults.some((r) => r.status === 'timeout')) ||
+				(job.fullScanResults && job.fullScanResults.some((r) => r.status === 'timeout'));
+
+			job.status = isTimeout ? 'timed_out' : 'failed';
 			job.error = error.message;
-			job.code = error.code || 'INTERNAL_ERROR';
+			job.code = error.code || (isTimeout ? 'JOB_TIMEOUT' : 'INTERNAL_ERROR');
 
 			sentryService.captureRuntimeError({
 				channel: 'job-service',
@@ -235,6 +269,16 @@ class JobService {
 			});
 		} finally {
 			clearTimeout(timeoutId);
+			this.activeControllers.delete(jobId);
+
+			const finalJob = await this.repository.get(jobId);
+			if (finalJob && finalJob.status === 'cancelled') {
+				finalJob.totalDurationMs = Date.now() - startTime;
+				finalJob.updatedAt = new Date().toISOString();
+				await this._persistJob(finalJob);
+				return;
+			}
+
 			job.totalDurationMs = Date.now() - startTime;
 			job.updatedAt = new Date().toISOString();
 			await this._persistJob(job);
@@ -246,6 +290,12 @@ class JobService {
 
 		for (let index = 0; index < symbols.length; index++) {
 			const input = symbols[index];
+
+			const currentJob = await this.repository.get(job.jobId);
+			if (currentJob && currentJob.status === 'cancelled') {
+				break;
+			}
+
 			job.progress.current = index;
 			job.progress.status = `Analyzing symbol ${input.raw} (${index + 1}/${symbols.length})`;
 			job.updatedAt = new Date().toISOString();
@@ -314,6 +364,11 @@ class JobService {
 			}
 		}
 
+		const currentJob = await this.repository.get(job.jobId);
+		if (currentJob && currentJob.status === 'cancelled') {
+			return;
+		}
+
 		job.progress.current = symbols.length;
 		job.progress.status = 'Completed analysis';
 		job.updatedAt = new Date().toISOString();
@@ -329,7 +384,7 @@ class JobService {
 			}));
 
 		if (analyzedItems.length === 0) {
-			job.status = 'failed';
+			job.status = timedOut ? 'timed_out' : 'failed';
 			job.error = timedOut
 				? 'Expanded analysis job timed out.'
 				: 'TradingView MCP failed for all requested symbols.';
@@ -358,6 +413,12 @@ class JobService {
 
 		for (let index = 0; index < scans.length; index++) {
 			const scanType = scans[index];
+
+			const currentJob = await this.repository.get(job.jobId);
+			if (currentJob && currentJob.status === 'cancelled') {
+				break;
+			}
+
 			job.progress.current = index;
 			job.progress.status = `Running scan ${scanType} (${index + 1}/${scans.length})`;
 			job.updatedAt = new Date().toISOString();
@@ -406,6 +467,11 @@ class JobService {
 			}
 		}
 
+		const currentJob = await this.repository.get(job.jobId);
+		if (currentJob && currentJob.status === 'cancelled') {
+			return;
+		}
+
 		job.progress.current = scans.length;
 		job.progress.status = 'Completed scans';
 		job.updatedAt = new Date().toISOString();
@@ -415,7 +481,7 @@ class JobService {
 		const successfulScans = job.fullScanResults.filter((r) => r.status === 'success');
 
 		if (successfulScans.length === 0) {
-			job.status = 'failed';
+			job.status = timedOut ? 'timed_out' : 'failed';
 			job.error = timedOut
 				? 'Market scanner job timed out.'
 				: 'TradingView MCP failed for all requested scans.';
@@ -444,6 +510,13 @@ class JobService {
 	}
 
 	async _persistJob(job) {
+		const current = await this.repository.get(job.jobId);
+		if (current) {
+			const terminalStatuses = new Set(['completed', 'failed', 'cancelled', 'timed_out']);
+			if (terminalStatuses.has(current.status) && job.status === 'processing') {
+				return;
+			}
+		}
 		await this.repository.save(job);
 	}
 
@@ -569,6 +642,138 @@ class JobService {
 		}
 
 		return fallback;
+	}
+
+	async cancelJob(jobId) {
+		const job = await this.repository.get(jobId);
+		if (!job) {
+			return null;
+		}
+
+		const terminalStatuses = new Set(['completed', 'failed', 'cancelled', 'timed_out']);
+		if (terminalStatuses.has(job.status)) {
+			return {
+				success: false,
+				code: 'TERMINAL_JOB',
+				message: 'Job is already in a terminal state.',
+				status: job.status,
+			};
+		}
+
+		job.status = 'cancelled';
+		job.error = 'Job cancelled by user';
+		job.code = 'USER_CANCELLED';
+		job.updatedAt = new Date().toISOString();
+		await this._persistJob(job);
+
+		const controller = this.activeControllers.get(jobId);
+		if (controller) {
+			controller.abort(new Error('Job cancelled by user'));
+			this.activeControllers.delete(jobId);
+		}
+
+		return {
+			success: true,
+			jobId,
+			status: job.status,
+		};
+	}
+
+	async retryJob(jobId, botOrGetter) {
+		const job = await this.repository.get(jobId);
+		if (!job) {
+			return null;
+		}
+
+		const retryableStatuses = new Set(['failed', 'timed_out', 'cancelled']);
+		if (!retryableStatuses.has(job.status)) {
+			return {
+				success: false,
+				code: 'NOT_RETRYABLE',
+				message: `Job cannot be retried. Current status: ${job.status}`,
+			};
+		}
+
+		if (!job.requestMetadata) {
+			return {
+				success: false,
+				code: 'MISSING_METADATA',
+				message: 'Missing job request metadata for retry.',
+			};
+		}
+
+		const result = await this.createJob(job.requestMetadata.type, job.requestMetadata, botOrGetter);
+		return {
+			success: true,
+			oldJobId: jobId,
+			newJobId: result.jobId,
+			status: result.status,
+		};
+	}
+
+	async retryFailedJob(jobId, botOrGetter) {
+		const job = await this.repository.get(jobId);
+		if (!job) {
+			return null;
+		}
+
+		if (job.status === 'processing') {
+			return {
+				success: false,
+				code: 'JOB_ACTIVE',
+				message: 'Cannot retry a currently processing job.',
+			};
+		}
+
+		if (!job.requestMetadata) {
+			return {
+				success: false,
+				code: 'MISSING_METADATA',
+				message: 'Missing job request metadata for retry.',
+			};
+		}
+
+		const type = job.requestMetadata.type;
+		let failedItems = [];
+
+		if (type === 'expanded-analysis') {
+			const results = job.fullResults || [];
+			const successfulSymbols = new Set(
+				results
+					.filter((r) => r.status === 'analyzed')
+					.map((r) => r.symbol)
+			);
+			failedItems = (job.requestMetadata.symbols || []).filter((sym) => !successfulSymbols.has(sym));
+		} else if (type === 'market-scanner') {
+			const results = job.fullScanResults || [];
+			const successfulScans = new Set(
+				results
+					.filter((r) => r.status === 'success')
+					.map((r) => r.scan)
+			);
+			failedItems = (job.requestMetadata.scans || []).filter((scan) => !successfulScans.has(scan));
+		}
+
+		if (failedItems.length === 0) {
+			return {
+				success: false,
+				code: 'NO_FAILED_ITEMS',
+				message: 'No failed or timed-out items found to retry in the original job.',
+			};
+		}
+
+		const retryPayload = {
+			...job.requestMetadata,
+			...(type === 'expanded-analysis' ? { symbols: failedItems } : { scans: failedItems }),
+		};
+
+		const result = await this.createJob(type, retryPayload, botOrGetter);
+		return {
+			success: true,
+			oldJobId: jobId,
+			newJobId: result.jobId,
+			status: result.status,
+		};
 	}
 
 	_resolveBot(botOrGetter) {

--- a/tests/integration/jobs-endpoint.test.js
+++ b/tests/integration/jobs-endpoint.test.js
@@ -132,4 +132,60 @@ describe('Jobs API Integration Tests', () => {
 		expect(res.body.success).toBe(false);
 		expect(res.body.error).toBe('Job not found');
 	});
+
+	it('supports cancellation and retry flow end-to-end', async () => {
+		// Mock with a longer delay so we can cancel it mid-flight
+		tradingViewMcpService.analyzeSymbolIdentifier.mockImplementation(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return {
+				symbol: 'BINANCE:BTCUSDT',
+				price_data: { close: 65000, change_percent: 1.5 },
+				rsi: { value: 45 },
+			};
+		});
+
+		// Create job
+		const createRes = await request(app)
+			.post('/api/jobs/tradingview-analysis')
+			.set('x-api-key', 'test-key')
+			.send({ type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] })
+			.expect(201);
+
+		const jobId = createRes.body.jobId;
+
+		// Cancel it immediately
+		const cancelRes = await request(app)
+			.post(`/api/jobs/${jobId}/cancel`)
+			.set('x-api-key', 'test-key')
+			.expect(200);
+
+		expect(cancelRes.body.success).toBe(true);
+		expect(cancelRes.body.status).toBe('cancelled');
+
+		// Poll status to verify it's cancelled and does not complete
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		const statusRes = await request(app)
+			.get(`/api/jobs/${jobId}`)
+			.set('x-api-key', 'test-key')
+			.expect(200);
+
+		expect(statusRes.body.status).toBe('cancelled');
+
+		// Attempt to cancel again (should return 409)
+		await request(app)
+			.post(`/api/jobs/${jobId}/cancel`)
+			.set('x-api-key', 'test-key')
+			.expect(409);
+
+		// Retry the cancelled job
+		const retryRes = await request(app)
+			.post(`/api/jobs/${jobId}/retry`)
+			.set('x-api-key', 'test-key')
+			.expect(201);
+
+		expect(retryRes.body.success).toBe(true);
+		expect(retryRes.body.oldJobId).toBe(jobId);
+		expect(retryRes.body.newJobId).toBeDefined();
+		expect(retryRes.body.status).toBe('processing');
+	});
 });

--- a/tests/unit/job-service.test.js
+++ b/tests/unit/job-service.test.js
@@ -281,4 +281,86 @@ describe('JobService Unit Tests', () => {
 			expect(restored.results).toHaveLength(1);
 		});
 	});
+
+	describe('Cancellation and retry operations', () => {
+		it('cancels a running job and returns 409 if already completed', async () => {
+			const metadata = await jobService.createJob('expanded-analysis', {
+				symbols: ['BINANCE:BTCUSDT'],
+			});
+			const jobId = metadata.jobId;
+
+			// Cancel it
+			const cancelResult = await jobService.cancelJob(jobId);
+			expect(cancelResult.success).toBe(true);
+			expect(cancelResult.status).toBe('cancelled');
+
+			// Re-cancelling should return terminal error
+			const cancelAgain = await jobService.cancelJob(jobId);
+			expect(cancelAgain.success).toBe(false);
+			expect(cancelAgain.code).toBe('TERMINAL_JOB');
+
+			// Check job state
+			const job = await jobService.getJob(jobId);
+			expect(job.status).toBe('cancelled');
+		});
+
+		it('retries a failed/cancelled job and creates a new one with requestMetadata', async () => {
+			const metadata = await jobService.createJob('expanded-analysis', {
+				symbols: ['BINANCE:BTCUSDT'],
+				timeframe: '1H',
+			});
+			const jobId = metadata.jobId;
+
+			// Cancel it so it is terminal and retryable
+			await jobService.cancelJob(jobId);
+
+			// Retry it
+			const retryResult = await jobService.retryJob(jobId);
+			expect(retryResult.success).toBe(true);
+			expect(retryResult.oldJobId).toBe(jobId);
+			expect(retryResult.newJobId).toBeDefined();
+			expect(retryResult.status).toBe('processing');
+
+			// Check that the new job has the same metadata
+			const newJob = await jobService.repository.get(retryResult.newJobId);
+			expect(newJob.requestMetadata).toEqual(
+				expect.objectContaining({
+					type: 'expanded-analysis',
+					symbols: ['BINANCE:BTCUSDT'],
+					timeframe: '1h',
+				})
+			);
+		});
+
+		it('retries only failed items via retryFailedJob', async () => {
+			// Save a job that is completed with mixed status
+			const jobId = 'mixed-job';
+			const rawJob = {
+				jobId,
+				type: 'expanded-analysis',
+				status: 'completed',
+				progress: { total: 3, current: 3, status: 'Completed' },
+				requestMetadata: {
+					type: 'expanded-analysis',
+					symbols: ['BINANCE:BTCUSDT', 'BINANCE:ETHUSDT', 'BINANCE:SOLUSDT'],
+					timeframe: '60',
+				},
+				fullResults: [
+					{ symbol: 'BINANCE:BTCUSDT', status: 'analyzed' },
+					{ symbol: 'BINANCE:ETHUSDT', status: 'error', error: 'MCP error' },
+					{ symbol: 'BINANCE:SOLUSDT', status: 'timeout', error: 'Timed out' },
+				],
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			};
+			await jobService.repository.save(rawJob);
+
+			const retryResult = await jobService.retryFailedJob(jobId);
+			expect(retryResult.success).toBe(true);
+			expect(retryResult.oldJobId).toBe(jobId);
+
+			const newJob = await jobService.repository.get(retryResult.newJobId);
+			expect(newJob.requestMetadata.symbols).toEqual(['BINANCE:ETHUSDT', 'BINANCE:SOLUSDT']);
+		});
+	});
 });

--- a/tests/unit/jobs-controller.test.js
+++ b/tests/unit/jobs-controller.test.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const httpMocks = require('node-mocks-http');
-const { postCreateJob, getJobStatus } = require('../../src/controllers/webhooks/handlers/jobs/jobs');
+const {
+	postCreateJob,
+	getJobStatus,
+	postCancelJob,
+	postRetryJob,
+	postRetryFailedJob,
+} = require('../../src/controllers/webhooks/handlers/jobs/jobs');
 const { jobService } = require('../../src/services/jobs/JobService');
 const sentryService = require('../../src/services/monitoring/SentryService');
 
@@ -9,6 +15,9 @@ jest.mock('../../src/services/jobs/JobService', () => ({
 	jobService: {
 		createJob: jest.fn(),
 		getJob: jest.fn(),
+		cancelJob: jest.fn(),
+		retryJob: jest.fn(),
+		retryFailedJob: jest.fn(),
 	},
 }));
 
@@ -181,6 +190,150 @@ describe('Jobs Controller Unit Tests', () => {
 
 			expect(res.statusCode).toBe(500);
 			expect(sentryService.captureRuntimeError).toHaveBeenCalled();
+		});
+	});
+
+	describe('postCancelJob', () => {
+		it('returns 400 if jobId is missing', async () => {
+			const req = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/jobs//cancel',
+				params: {},
+			});
+			const res = httpMocks.createResponse();
+
+			await postCancelJob(req, res);
+
+			expect(res.statusCode).toBe(400);
+			expect(res._getJSONData().error).toBe('Missing jobId parameter');
+		});
+
+		it('returns 404 if job is not found', async () => {
+			const req = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/jobs/missing-job-id/cancel',
+				params: { jobId: 'missing-job-id' },
+			});
+			const res = httpMocks.createResponse();
+
+			jobService.cancelJob.mockResolvedValueOnce(null);
+
+			await postCancelJob(req, res);
+
+			expect(res.statusCode).toBe(404);
+			expect(res._getJSONData().error).toBe('Job not found');
+		});
+
+		it('returns 409 if job is terminal', async () => {
+			const req = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/jobs/terminal-job-id/cancel',
+				params: { jobId: 'terminal-job-id' },
+			});
+			const res = httpMocks.createResponse();
+
+			const mockResult = {
+				success: false,
+				code: 'TERMINAL_JOB',
+				message: 'Job is already in a terminal state.',
+				status: 'completed',
+			};
+			jobService.cancelJob.mockResolvedValueOnce(mockResult);
+
+			await postCancelJob(req, res);
+
+			expect(res.statusCode).toBe(409);
+			expect(res._getJSONData().code).toBe('TERMINAL_JOB');
+		});
+
+		it('returns 200 on successful cancellation', async () => {
+			const req = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/jobs/running-job-id/cancel',
+				params: { jobId: 'running-job-id' },
+			});
+			const res = httpMocks.createResponse();
+
+			const mockResult = {
+				success: true,
+				jobId: 'running-job-id',
+				status: 'cancelled',
+			};
+			jobService.cancelJob.mockResolvedValueOnce(mockResult);
+
+			await postCancelJob(req, res);
+
+			expect(res.statusCode).toBe(200);
+			expect(res._getJSONData()).toEqual(mockResult);
+		});
+	});
+
+	describe('postRetryJob', () => {
+		it('returns 201 and new job details on success', async () => {
+			const req = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/jobs/failed-job-id/retry',
+				params: { jobId: 'failed-job-id' },
+			});
+			const res = httpMocks.createResponse();
+
+			const mockResult = {
+				success: true,
+				oldJobId: 'failed-job-id',
+				newJobId: 'new-job-id',
+				status: 'processing',
+			};
+			jobService.retryJob.mockResolvedValueOnce(mockResult);
+
+			await postRetryJob(null)(req, res);
+
+			expect(res.statusCode).toBe(201);
+			expect(res._getJSONData()).toEqual(mockResult);
+		});
+	});
+
+	describe('postRetryFailedJob', () => {
+		it('returns 201 on success', async () => {
+			const req = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/jobs/mixed-job-id/retry-failed',
+				params: { jobId: 'mixed-job-id' },
+			});
+			const res = httpMocks.createResponse();
+
+			const mockResult = {
+				success: true,
+				oldJobId: 'mixed-job-id',
+				newJobId: 'new-job-id',
+				status: 'processing',
+			};
+			jobService.retryFailedJob.mockResolvedValueOnce(mockResult);
+
+			await postRetryFailedJob(null)(req, res);
+
+			expect(res.statusCode).toBe(201);
+			expect(res._getJSONData()).toEqual(mockResult);
+		});
+
+		it('returns 400 if no failed items to retry', async () => {
+			const req = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/jobs/all-success-job-id/retry-failed',
+				params: { jobId: 'all-success-job-id' },
+			});
+			const res = httpMocks.createResponse();
+
+			const mockResult = {
+				success: false,
+				code: 'NO_FAILED_ITEMS',
+				message: 'No failed items to retry.',
+			};
+			jobService.retryFailedJob.mockResolvedValueOnce(mockResult);
+
+			await postRetryFailedJob(null)(req, res);
+
+			expect(res.statusCode).toBe(400);
+			expect(res._getJSONData().code).toBe('NO_FAILED_ITEMS');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Exposes protected job lifecycle actions (`cancel`, `retry`, and `retry-failed`) for long-running scan or analysis jobs under the `/api` routing namespace.

## Key Changes

### :wrench: Expose Job cancellation and retries

- Exposes three new protected routes:
  - `POST /api/jobs/:jobId/cancel` - Cancels an active/processing job by aborting its remote stream queries.
  - `POST /api/jobs/:jobId/retry` - Retries a failed, timed-out, or cancelled job by starting a new job with the same request inputs.
  - `POST /api/jobs/:jobId/retry-failed` - Retries only the subset of indicators or scans that failed or timed out during the original run.
- Ensures all new endpoints validate the `x-api-key` header/param just like core webhook alert endpoints.
- Avoids mutating completed or failed history by returning a brand new `jobId` for retries, providing clear traceability back to the `oldJobId`.
- Preserves terminal statuses: `completed`, `failed`, `cancelled`, and `timed_out`.

## Technical Implementation

### Service Layer

- Track active `AbortController` instances inside `JobService` using `this.activeControllers`.
- Maintain sanitized request metadata (`requestMetadata`) on the stored job object upon job creation, avoiding leaks of any credentials or secrets.
- Add cancellation checks inside loop iterations of `_executeExpandedAnalysis` and `_executeMarketScanner` to stop remote TradingView MCP requests instantly.
- Protect `_persistJob` to prevent race conditions or state overwriting where a processing background thread could overwrite a terminal cancelled status.

### Routes & Controllers

- Add `postCancelJob`, `postRetryJob`, and `postRetryFailedJob` controllers under `src/controllers/webhooks/handlers/jobs/jobs.js`.
- Mount routes and apply validation middleware in `src/routes/index.js`.
- Update Postman Collection `CabrosBot.postman_collection.json` with the new endpoint contract examples.

## Testing

### Automated Tests

- New unit tests added in `tests/unit/job-service.test.js` validating:
  - Cancellation of active jobs and 409 responses for terminal states.
  - Retry functionality with correct duplication of `requestMetadata`.
  - Selective retry of only failed items.
- New unit tests added in `tests/unit/jobs-controller.test.js` asserting status codes and Sentry monitoring.
- Integration tests in `tests/integration/jobs-endpoint.test.js` checking end-to-end cancellation and retry lifecycle flow.

## References

- GitHub Issue: https://github.com/francovp/cabros-bot/issues/71
- **Linear**: [CB-27](https://linear.app/knil/issue/CB-27/add-async-job-cancellation-and-retry-endpoints)
