### PR TITLE
feat: add stored alert export endpoint (CB-29)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -572,8 +572,8 @@
 						}
 					]
 				},
-				{
-					"name": "GET Alert Analytics Summary (invalid window)",
+    {
+      "name": "GET Alert Analytics Summary (invalid window)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -595,11 +595,168 @@
 							"status": "Bad Request",
 							"code": 400,
 							"body": "{\n  \"error\": \"Invalid from timestamp. Use an ISO-8601 timestamp.\",\n  \"code\": \"INVALID_REQUEST\"\n}"
-						}
-					]
-				},
-				{
-					"name": "GET Get Alert by ID",
+        }
+      ]
+    },
+    {
+      "name": "GET Export Alerts (JSONL)",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "x-api-key",
+            "value": "{{apiKey}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/alerts/export?format=jsonl&from=2026-06-06T00:00:00.000Z&to=2026-06-07T00:00:00.000Z&limit=500&source=webhook&enriched=true",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "alerts",
+            "export"
+          ],
+          "query": [
+            {
+              "key": "format",
+              "value": "jsonl"
+            },
+            {
+              "key": "from",
+              "value": "2026-06-06T00:00:00.000Z"
+            },
+            {
+              "key": "to",
+              "value": "2026-06-07T00:00:00.000Z"
+            },
+            {
+              "key": "limit",
+              "value": "500"
+            },
+            {
+              "key": "source",
+              "value": "webhook"
+            },
+            {
+              "key": "enriched",
+              "value": "true"
+            }
+          ]
+        },
+        "description": "Exports bounded stored alerts as JSON Lines. Requires from/to, validates x-api-key, and excludes raw text unless includeText=true."
+      },
+      "response": [
+        {
+          "name": "200 OK - JSONL export",
+          "status": "OK",
+          "code": 200,
+          "body": "{\"id\":\"alert-123\",\"receivedAt\":\"2026-06-06T12:00:00.000Z\",\"source\":\"webhook\",\"enriched\":true,\"useTradingViewData\":false,\"deliveryResults\":[{\"channel\":\"telegram\",\"success\":true,\"messageId\":\"123\",\"errorCode\":null,\"statusCode\":null}],\"tokenUsage\":{\"inputTokens\":10,\"outputTokens\":20,\"totalTokens\":30,\"totalCost\":0.001}}\n"
+        }
+      ]
+    },
+    {
+      "name": "GET Export Alerts (CSV with text)",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "x-api-key",
+            "value": "{{apiKey}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/alerts/export?format=csv&from=2026-06-06T00:00:00.000Z&to=2026-06-07T00:00:00.000Z&limit=100&includeText=true",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "alerts",
+            "export"
+          ],
+          "query": [
+            {
+              "key": "format",
+              "value": "csv"
+            },
+            {
+              "key": "from",
+              "value": "2026-06-06T00:00:00.000Z"
+            },
+            {
+              "key": "to",
+              "value": "2026-06-07T00:00:00.000Z"
+            },
+            {
+              "key": "limit",
+              "value": "100"
+            },
+            {
+              "key": "includeText",
+              "value": "true"
+            }
+          ]
+        },
+        "description": "Exports bounded stored alerts as CSV with optional truncated alert text included."
+      },
+      "response": [
+        {
+          "name": "200 OK - CSV export",
+          "status": "OK",
+          "code": 200,
+          "body": "id,receivedAt,source,enriched,useTradingViewData,deliveryResults,tokenUsage,text\nalert-123,2026-06-06T12:00:00.000Z,webhook,true,false,\"[{\"\"channel\"\":\"\"telegram\"\",\"\"success\"\":true,\"\"messageId\"\":\"\"123\"\",\"\"errorCode\"\":null,\"\"statusCode\"\":null}]\",\"{\"\"inputTokens\"\":10,\"\"outputTokens\"\":20,\"\"totalTokens\"\":30,\"\"totalCost\"\":0.001}\",BTC breakout\n"
+        }
+      ]
+    },
+    {
+      "name": "GET Export Alerts (missing bounds)",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "x-api-key",
+            "value": "{{apiKey}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/alerts/export?format=jsonl&from=2026-06-06T00:00:00.000Z",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "alerts",
+            "export"
+          ],
+          "query": [
+            {
+              "key": "format",
+              "value": "jsonl"
+            },
+            {
+              "key": "from",
+              "value": "2026-06-06T00:00:00.000Z"
+            }
+          ]
+        },
+        "description": "Invalid export variant. Both from and to are required so the endpoint never scans the full collection."
+      },
+      "response": [
+        {
+          "name": "400 Bad Request - Missing export bounds",
+          "status": "Bad Request",
+          "code": 400,
+          "body": "{\n  \"error\": \"Export requests require bounded from and to ISO-8601 timestamps.\",\n  \"code\": \"INVALID_REQUEST\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "GET Get Alert by ID",
 					"request": {
 						"method": "GET",
 						"header": [

--- a/agents.md
+++ b/agents.md
@@ -39,7 +39,7 @@ This project is a small Express + Telegraf (Telegram) bot service that exposes a
 - `src/controllers/webhooks/handlers/expandedAnalysisAlert/expandedAnalysisAlert.js` — `POST /api/webhook/expanded-analysis-alert` handler that builds TradingView MCP analysis reports and sends them through notification channels.
 - `src/controllers/webhooks/handlers/volumeConfirmation/volumeConfirmation.js` — `POST /api/webhook/volume-confirmation` handler that returns structured TradingView MCP volume-confirmation data.
 - `src/controllers/webhooks/handlers/jobs/jobs.js` — Job creation (`POST /api/jobs/tradingview-analysis`) and status polling (`GET /api/jobs/:jobId`) handler.
-- `src/controllers/alerts/alerts.js` — Stored alert read, analytics, and replay handlers for `GET /api/alerts`, `GET /api/alerts/summary`, `GET /api/alerts/:alertId`, and `POST /api/alerts/:alertId/replay`.
+- `src/controllers/alerts/alerts.js` — Stored alert read, export, analytics, and replay handlers for `GET /api/alerts`, `GET /api/alerts/export`, `GET /api/alerts/summary`, `GET /api/alerts/:alertId`, and `POST /api/alerts/:alertId/replay`.
 - `src/controllers/status.js` — Status handler that computes capabilities, feature flags, notification channels, and active dependencies status.
 - `src/controllers/webhooks/handlers/marketScanner/marketScanner.js` — Scanner webhook handler executing sequential gainers, losers, and breakouts scanner runs on TradingView MCP.
 - `src/services/jobs/JobService.js` — Manages in-memory job state, executes background TradingView analysis runs, and performs periodic expiration cleanup.
@@ -144,7 +144,7 @@ Implement the following security practices to safeguard endpoints and credential
 - Optional but relevant (non-exhaustive; see feature sections below for full config): `ENABLE_TELEGRAM_BOT`, `PORT`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID`, `ENABLE_WHATSAPP_ALERTS`, `ENABLE_GEMINI_GROUNDING`, `GEMINI_API_KEY`, `ENABLE_LANGFUSE_PROMPTS`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_PROMPT_LABEL`, `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`, `BRAVE_SEARCH_API_KEY`, `BRAVE_SEARCH_ENDPOINT`, `FORCE_BRAVE_SEARCH`, `MODEL_PROVIDER`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `ENABLE_NEWS_MONITOR`, `EXPANDED_ANALYSIS_ALERT_SYMBOLS`, `EXPANDED_ANALYSIS_ALERT_TIMEOUT_MS`, `TRADINGVIEW_MCP_URL`, `TRADINGVIEW_MCP_TIMEOUT_MS`, `TRADINGVIEW_MCP_MAX_RETRIES`, `TRADINGVIEW_MCP_DEFAULT_TIMEFRAME`, `ENABLE_TRADINGVIEW_VOLUME_CONFIRMATION`, `ENABLE_SENTRY`, `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_CONSOLE_LOG_LEVELS`, `LOG_LEVEL`, `SERVICE_NAME`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `ENABLE_FIRESTORE_ALERT_STORAGE`, `ENABLE_MARKET_SCANNER`, `ENABLE_MESSAGE_FOOTER_METADATA`, `FIREBASE_PROJECT_ID`, `FIREBASE_SERVICE_ACCOUNT_JSON`, `GOOGLE_APPLICATION_CREDENTIALS`, `GEMINI_MODEL_NAME_FALLBACK`, `RENDER`, `IS_PULL_REQUEST`, `RENDER_GIT_COMMIT`, `RENDER_GIT_REPO_SLUG`.
 - Bot startup is gated: bot is launched only when `ENABLE_TELEGRAM_BOT === 'true'` and not a preview environment (`RENDER==='true' && IS_PULL_REQUEST==='true'` disables it).
 - Routes under `/api` (e.g. `/api/webhook/alert`) are mounted regardless of bot launch; individual features and notification channels are gated via env flags and per-channel validation.
-- Stored alert read, analytics, and replay routes (`GET /api/alerts`, `GET /api/alerts/summary`, `GET /api/alerts/:alertId`, `POST /api/alerts/:alertId/replay`) are also mounted under `/api`; they require `WEBHOOK_API_KEY` when configured, return `403 FEATURE_DISABLED` unless `ENABLE_FIRESTORE_ALERT_STORAGE=true`, and return `503 STORAGE_UNAVAILABLE` when Firestore is enabled but unreadable.
+- Stored alert read, export, analytics, and replay routes (`GET /api/alerts`, `GET /api/alerts/export`, `GET /api/alerts/summary`, `GET /api/alerts/:alertId`, `POST /api/alerts/:alertId/replay`) are also mounted under `/api`; they require `WEBHOOK_API_KEY` when configured, return `403 FEATURE_DISABLED` unless `ENABLE_FIRESTORE_ALERT_STORAGE=true`, and return `503 STORAGE_UNAVAILABLE` when Firestore is enabled but unreadable.
 
 ---
 
@@ -581,8 +581,8 @@ The system provides an HTTP endpoint (`/api/news-monitor`) that analyzes financi
 Every successful `POST /api/webhook/alert` request is persisted as a document in the `alerts` Firestore collection after the HTTP response has been sent.
 
 **Core Components**:
-- `src/services/storage/AlertStorageService.js` — lazy `firebase-admin` singleton, `saveAlert()` wrapper, read helpers (`listAlerts()`, `getAlertById()`), fail-open write handling
-- `src/controllers/alerts/alerts.js` — HTTP controller for stored alert list/detail endpoints
+- `src/services/storage/AlertStorageService.js` — lazy `firebase-admin` singleton, `saveAlert()` wrapper, read/export helpers (`listAlerts()`, `exportAlerts()`, `getAlertById()`), fail-open write handling
+- `src/controllers/alerts/alerts.js` — HTTP controller for stored alert list/export/detail endpoints
 
 **Data Model** (collection: `alerts`, document ID: auto-generated):
 
@@ -613,10 +613,11 @@ Every successful `POST /api/webhook/alert` request is persisted as a document in
 
 **Read API**:
 - `GET /api/alerts` returns stored alerts ordered by `receivedAt` descending with `limit`, `before`, `source`, and `enriched` query support.
+- `GET /api/alerts/export` returns bounded JSONL or CSV (`format=jsonl|csv`) for stored alerts. It requires both `from` and `to`, caps `limit` at 1000, caps the window at 31 days, supports `source`, `enriched`, and `includeText=true`, and only includes safe export fields. Raw alert text is excluded by default and truncated to 1000 chars when included.
 - `GET /api/alerts/summary` returns bounded JSON-only analytics for stored alerts, with `from`, `to`, and `limit` query support capped to a 31-day window and 1000 documents.
 - `GET /api/alerts/:alertId` returns a single formatted alert document by Firestore document ID.
 - `POST /api/alerts/:alertId/replay` reloads an immutable stored alert, rebuilds the current notification payload, dispatches it to requested channels (`telegram`, `whatsapp`, or both by default), and records the replay attempt in the separate `alertReplays` Firestore collection. It requires API-key auth and an idempotency key (`idempotency-key` header or `idempotencyKey` body/query field).
-- `listAlerts()`, `summarizeAlerts()`, and `getAlertById()` in `src/services/storage/AlertStorageService.js` format Firestore documents into API-safe JSON with the following fields:
+- `listAlerts()`, `summarizeAlerts()`, `exportAlerts()`, and `getAlertById()` in `src/services/storage/AlertStorageService.js` format Firestore documents into API-safe JSON with the following fields:
   - `id`
   - `receivedAt`
   - `text`
@@ -629,6 +630,7 @@ Every successful `POST /api/webhook/alert` request is persisted as a document in
 - Read filtering for `source` and `enriched` is applied in memory after `receivedAt`-ordered batches to avoid introducing new composite Firestore index requirements.
 - Read endpoints must map Firestore initialization/read failures to `503 STORAGE_UNAVAILABLE` instead of a generic `500`.
 - Replay attempts must not mutate the original `alerts` document. Use `saveReplayAttempt()` to write an audit document with ID `${alertId}_${idempotencyKey}` in `alertReplays`.
+- Export responses must not expose API keys, service-account data, webhook secrets, raw provider credentials, full `enrichmentData`, or raw provider responses. Keep delivery status compact (`channel`, `success`, `messageId`, `errorCode`, `statusCode`) and token usage numeric-only.
 - When extending the alerts read API, preserve `receivedAt` as the primary sort key but encode `nextBefore` with a deterministic tie-breaker (document ID) so paginated reads do not skip same-timestamp alerts, and preserve API-key protection on both list and detail routes.
 
 **Alert Flow Integration** (`src/controllers/webhooks/handlers/alert/alert.js`):
@@ -638,8 +640,8 @@ Webhook → validate → enrich → sendToAll → res.json() → saveAlert() [fi
 Storage happens **after** the HTTP response; the caller is never blocked.
 
 **Where to look first when extending or debugging**:
-- `src/services/storage/AlertStorageService.js` — initialization, credential parsing, `saveAlert()`, `listAlerts()`, and `getAlertById()` logic
-- `src/controllers/alerts/alerts.js` — list/detail request validation and response shaping
+- `src/services/storage/AlertStorageService.js` — initialization, credential parsing, `saveAlert()`, `listAlerts()`, `exportAlerts()`, and `getAlertById()` logic
+- `src/controllers/alerts/alerts.js` — list/export/detail request validation and response shaping
 - `src/controllers/webhooks/handlers/alert/alert.js` — fire-and-forget call site (after `res.json()`)
 - Tests in `tests/unit/alert-storage-service.test.js` and `tests/integration/alerts-endpoint.test.js`
 - Firebase Console → Firestore → `alerts` collection for live document inspection

--- a/src/controllers/alerts/alerts.js
+++ b/src/controllers/alerts/alerts.js
@@ -8,6 +8,18 @@ const MAX_LIMIT = 100;
 const VALID_CHANNELS = ['telegram', 'whatsapp'];
 const DEFAULT_SUMMARY_LIMIT = 500;
 const MAX_SUMMARY_LIMIT = 1000;
+const DEFAULT_EXPORT_LIMIT = 500;
+const MAX_EXPORT_LIMIT = 1000;
+const EXPORT_FIELDS = [
+	'id',
+	'receivedAt',
+	'source',
+	'enriched',
+	'useTradingViewData',
+	'deliveryResults',
+	'tokenUsage',
+	'text',
+];
 
 function parseLimit(rawLimit) {
 	if (rawLimit === undefined) {
@@ -49,6 +61,40 @@ function parseSummaryLimit(rawLimit) {
 	}
 
 	return limit;
+}
+
+function parseExportLimit(rawLimit) {
+	if (rawLimit === undefined) {
+		return DEFAULT_EXPORT_LIMIT;
+	}
+
+	const limit = Number.parseInt(rawLimit, 10);
+	if (!Number.isInteger(limit) || limit < 1 || limit > MAX_EXPORT_LIMIT) {
+		return null;
+	}
+
+	return limit;
+}
+
+function parseBooleanFlag(rawValue, defaultValue = false) {
+	if (rawValue === undefined) {
+		return defaultValue;
+	}
+
+	if (rawValue === 'true' || rawValue === true) {
+		return true;
+	}
+
+	if (rawValue === 'false' || rawValue === false) {
+		return false;
+	}
+
+	return null;
+}
+
+function parseExportFormat(rawFormat) {
+	const format = rawFormat === undefined ? 'jsonl' : String(rawFormat).trim().toLowerCase();
+	return ['jsonl', 'csv'].includes(format) ? format : null;
 }
 
 function parseOptionalTimestamp(rawValue, name) {
@@ -163,6 +209,115 @@ function summarizeAlerts(req, res) {
 			success: true,
 			summary,
 		});
+	});
+}
+
+function escapeCsvValue(value) {
+	if (value === null || value === undefined) {
+		return '';
+	}
+
+	const serialized = typeof value === 'object'
+		? JSON.stringify(value)
+		: String(value);
+
+	if (/[",\n\r]/.test(serialized)) {
+		return `"${serialized.replace(/"/g, '""')}"`;
+	}
+
+	return serialized;
+}
+
+function buildCsv(alerts, includeText) {
+	const fields = includeText
+		? EXPORT_FIELDS
+		: EXPORT_FIELDS.filter(field => field !== 'text');
+	const rows = alerts.map(alert => fields.map(field => escapeCsvValue(alert[field])).join(','));
+	return [fields.join(','), ...rows].join('\n');
+}
+
+function exportAlerts(req, res) {
+	return handleAsync(req, res, '/api/alerts/export', async () => {
+		if (!alertStorageService.isEnabled()) {
+			return res.status(403).json({
+				error: 'Alert storage feature is disabled. Set ENABLE_FIRESTORE_ALERT_STORAGE=true to enable.',
+				code: 'FEATURE_DISABLED',
+			});
+		}
+
+		const format = parseExportFormat(req.query.format);
+		if (!format) {
+			return res.status(400).json({
+				error: 'Invalid export format. Use jsonl or csv.',
+				code: 'INVALID_REQUEST',
+			});
+		}
+
+		const limit = parseExportLimit(req.query.limit);
+		if (limit === null) {
+			return res.status(400).json({
+				error: `Invalid limit. Use an integer between 1 and ${MAX_EXPORT_LIMIT}.`,
+				code: 'INVALID_REQUEST',
+			});
+		}
+
+		const from = parseOptionalTimestamp(req.query.from, 'from');
+		if (from.error) {
+			return res.status(400).json(from.error);
+		}
+
+		const to = parseOptionalTimestamp(req.query.to, 'to');
+		if (to.error) {
+			return res.status(400).json(to.error);
+		}
+
+		if (!from.value || !to.value) {
+			return res.status(400).json({
+				error: 'Export requests require bounded from and to ISO-8601 timestamps.',
+				code: 'INVALID_REQUEST',
+			});
+		}
+
+		const enriched = parseEnriched(req.query.enriched);
+		if (enriched === null) {
+			return res.status(400).json({
+				error: 'Invalid enriched filter. Use true or false.',
+				code: 'INVALID_REQUEST',
+			});
+		}
+
+		const includeText = parseBooleanFlag(req.query.includeText, false);
+		if (includeText === null) {
+			return res.status(400).json({
+				error: 'Invalid includeText flag. Use true or false.',
+				code: 'INVALID_REQUEST',
+			});
+		}
+
+		const source = typeof req.query.source === 'string' && req.query.source.trim()
+			? req.query.source.trim()
+			: undefined;
+
+		const result = await alertStorageService.exportAlerts({
+			from: from.value,
+			to: to.value,
+			limit,
+			source,
+			enriched,
+			includeText,
+		});
+
+		const filename = `alerts-${from.value.substring(0, 10)}-${to.value.substring(0, 10)}.${format === 'csv' ? 'csv' : 'jsonl'}`;
+		res.set('Content-Disposition', `attachment; filename="${filename}"`);
+
+		if (format === 'csv') {
+			res.type('text/csv; charset=utf-8');
+			return res.status(200).send(`${buildCsv(result.alerts, includeText)}\n`);
+		}
+
+		res.type('application/x-ndjson; charset=utf-8');
+		const body = result.alerts.map(alert => JSON.stringify(alert)).join('\n');
+		return res.status(200).send(body ? `${body}\n` : '');
 	});
 }
 
@@ -350,4 +505,5 @@ module.exports = {
 	getAlertById,
 	replayAlert,
 	summarizeAlerts,
+	exportAlerts,
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -19,7 +19,7 @@ const {
 	postRetryJob,
 	postRetryFailedJob,
 } = require('../controllers/webhooks/handlers/jobs/jobs');
-const { listAlerts, getAlertById, replayAlert, summarizeAlerts } = require('../controllers/alerts/alerts');
+const { listAlerts, getAlertById, replayAlert, summarizeAlerts, exportAlerts } = require('../controllers/alerts/alerts');
 const { validateApiKey } = require('../lib/auth');
 const { getApiStatus } = require('../controllers/status');
 const { idempotencyMiddleware } = require('../lib/idempotency');
@@ -33,6 +33,7 @@ function getRoutes(botOrGetter) {
 	router.post('/webhook/volume-confirmation', validateApiKey, postVolumeConfirmation());
 	router.get('/alerts', validateApiKey, listAlerts);
 	router.get('/alerts/summary', validateApiKey, summarizeAlerts);
+	router.get('/alerts/export', validateApiKey, exportAlerts);
 	router.post('/alerts/:alertId/replay', validateApiKey, idempotencyMiddleware, replayAlert(botOrGetter));
 	router.get('/alerts/:alertId', validateApiKey, getAlertById);
 	router.post('/scanner-presets', validateApiKey, postPreset);

--- a/src/services/storage/AlertStorageService.js
+++ b/src/services/storage/AlertStorageService.js
@@ -34,6 +34,10 @@ const MAX_PAGE_SIZE = 100;
 const DEFAULT_SUMMARY_LIMIT = 500;
 const MAX_SUMMARY_LIMIT = 1000;
 const MAX_SUMMARY_WINDOW_DAYS = 31;
+const DEFAULT_EXPORT_LIMIT = 500;
+const MAX_EXPORT_LIMIT = 1000;
+const MAX_EXPORT_WINDOW_DAYS = 31;
+const MAX_EXPORT_TEXT_LENGTH = 1000;
 const STORAGE_UNAVAILABLE_CODE = 'STORAGE_UNAVAILABLE';
 const INVALID_CURSOR_MESSAGE = 'Invalid before cursor. Use an ISO-8601 timestamp or the nextBefore cursor from a previous response.';
 
@@ -144,6 +148,62 @@ function addDeliverySummary(summary, deliveryResults) {
 	}
 }
 
+function summarizeDeliveryResults(deliveryResults) {
+	if (!Array.isArray(deliveryResults)) {
+		return [];
+	}
+
+	return deliveryResults.map((result) => ({
+		channel: typeof result.channel === 'string' ? result.channel : null,
+		success: Boolean(result.success),
+		messageId: typeof result.messageId === 'string' ? result.messageId : null,
+		errorCode: typeof result.errorCode === 'string' ? result.errorCode : null,
+		statusCode: Number.isInteger(result.statusCode) ? result.statusCode : null,
+	})).filter(result => result.channel);
+}
+
+function summarizeTokenUsage(tokenUsage) {
+	if (!tokenUsage || typeof tokenUsage !== 'object') {
+		return null;
+	}
+
+	return {
+		inputTokens: getNumericValue(tokenUsage.inputTokens || tokenUsage.promptTokens),
+		outputTokens: getNumericValue(tokenUsage.outputTokens || tokenUsage.completionTokens),
+		totalTokens: getNumericValue(tokenUsage.totalTokens || tokenUsage.total),
+		totalCost: getNumericValue(tokenUsage.totalCost),
+	};
+}
+
+function truncateAlertText(text) {
+	if (typeof text !== 'string') {
+		return '';
+	}
+
+	return text.length > MAX_EXPORT_TEXT_LENGTH
+		? text.substring(0, MAX_EXPORT_TEXT_LENGTH)
+		: text;
+}
+
+function formatExportRecord(doc, { includeText }) {
+	const data = doc.data() || {};
+	const record = {
+		id: doc.id,
+		receivedAt: getDocTimestamp(data),
+		source: typeof data.source === 'string' ? data.source : null,
+		enriched: Boolean(data.enriched),
+		useTradingViewData: Boolean(data.useTradingViewData),
+		deliveryResults: summarizeDeliveryResults(data.deliveryResults),
+		tokenUsage: summarizeTokenUsage(data.tokenUsage),
+	};
+
+	if (includeText) {
+		record.text = truncateAlertText(data.text);
+	}
+
+	return record;
+}
+
 function collectLatency(samples, value) {
 	const numeric = Number(value);
 	if (Number.isFinite(numeric) && numeric >= 0) {
@@ -183,12 +243,51 @@ function buildSummaryWindow({ from, to, limit }) {
 	};
 }
 
+function buildExportWindow({ from, to, limit }) {
+	if (!from || !to) {
+		const error = new Error('Export requests require bounded from and to ISO-8601 timestamps.');
+		error.code = 'INVALID_REQUEST';
+		throw error;
+	}
+
+	const parsedFrom = new Date(from);
+	const parsedTo = new Date(to);
+	const maxWindowMs = MAX_EXPORT_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+	if (parsedFrom.getTime() > parsedTo.getTime()) {
+		const error = new Error('Invalid export window. from must be before or equal to to.');
+		error.code = 'INVALID_REQUEST';
+		throw error;
+	}
+
+	if (parsedTo.getTime() - parsedFrom.getTime() > maxWindowMs) {
+		const error = new Error(`Invalid export window. Maximum export window is ${MAX_EXPORT_WINDOW_DAYS} days.`);
+		error.code = 'INVALID_REQUEST';
+		throw error;
+	}
+
+	return {
+		from: parsedFrom.toISOString(),
+		to: parsedTo.toISOString(),
+		limit: clampExportLimit(limit),
+		maxDays: MAX_EXPORT_WINDOW_DAYS,
+	};
+}
+
 function clampSummaryLimit(limit) {
 	if (!Number.isInteger(limit) || limit < 1) {
 		return DEFAULT_SUMMARY_LIMIT;
 	}
 
 	return Math.min(limit, MAX_SUMMARY_LIMIT);
+}
+
+function clampExportLimit(limit) {
+	if (!Number.isInteger(limit) || limit < 1) {
+		return DEFAULT_EXPORT_LIMIT;
+	}
+
+	return Math.min(limit, MAX_EXPORT_LIMIT);
 }
 
 function matchesFilters(alert, filters) {
@@ -497,6 +596,54 @@ async function saveReplayAttempt({ alertId, idempotencyKey, channels, deliveryRe
 }
 
 /**
+ * Export a bounded set of stored alerts using safe, stable fields only.
+ *
+ * @param {Object} params
+ * @param {string} params.from ISO timestamp, required
+ * @param {string} params.to ISO timestamp, required
+ * @param {number|undefined} params.limit Maximum documents returned, capped at 1000
+ * @param {string|undefined} params.source Optional exact source filter
+ * @param {boolean|undefined} params.enriched Optional enriched/plain filter
+ * @param {boolean|undefined} params.includeText Include truncated alert text when true
+ * @returns {Promise<{window: Object, alerts: Array}>}
+ */
+async function exportAlerts({ from, to, limit, source, enriched, includeText = false } = {}) {
+	if (!isEnabled()) {
+		return null;
+	}
+
+	const firestore = getFirestore();
+	if (!firestore) {
+		throw createStorageUnavailableError();
+	}
+
+	const window = buildExportWindow({ from, to, limit });
+	let snapshot;
+	try {
+		snapshot = await firestore
+			.collection(COLLECTION_NAME)
+			.where('receivedAt', '>=', admin.firestore.Timestamp.fromDate(new Date(window.from)))
+			.where('receivedAt', '<=', admin.firestore.Timestamp.fromDate(new Date(window.to)))
+			.orderBy('receivedAt', 'desc')
+			.limit(window.limit)
+			.get();
+	} catch (error) {
+		console.warn('[AlertStorageService] Failed to export alerts from Firestore:', error.message);
+		throw createStorageUnavailableError(error);
+	}
+
+	const docs = snapshot && Array.isArray(snapshot.docs) ? snapshot.docs : [];
+	const alerts = docs
+		.map(doc => formatExportRecord(doc, { includeText }))
+		.filter(alert => matchesFilters(alert, { source, enriched }));
+
+	return {
+		window,
+		alerts,
+	};
+}
+
+/**
  * Build bounded aggregate metrics for stored alerts.
  *
  * The endpoint intentionally returns counts and totals only. Raw alert text,
@@ -615,6 +762,7 @@ module.exports = {
 	listAlerts,
 	getAlertById,
 	summarizeAlerts,
+	exportAlerts,
 	saveReplayAttempt,
 	STORAGE_UNAVAILABLE_CODE,
 	INVALID_CURSOR_MESSAGE,

--- a/tests/integration/alerts-endpoint.test.js
+++ b/tests/integration/alerts-endpoint.test.js
@@ -6,6 +6,7 @@ jest.mock('../../src/services/storage/AlertStorageService', () => ({
 	getAlertById: jest.fn(),
 	saveReplayAttempt: jest.fn(),
 	summarizeAlerts: jest.fn(),
+	exportAlerts: jest.fn(),
 	STORAGE_UNAVAILABLE_CODE: 'STORAGE_UNAVAILABLE',
 	INVALID_CURSOR_MESSAGE: 'Invalid before cursor. Use an ISO-8601 timestamp or the nextBefore cursor from a previous response.',
 	parseAlertPaginationCursor: jest.fn(),
@@ -320,6 +321,122 @@ describe('Alerts API Integration Tests', () => {
 			error: 'Invalid summary window. from must be before or equal to to.',
 			code: 'INVALID_REQUEST',
 		});
+	});
+
+	it('exports bounded stored alerts as JSONL without raw text by default', async () => {
+		alertStorageService.exportAlerts.mockResolvedValue({
+			window: {
+				from: '2026-06-06T00:00:00.000Z',
+				to: '2026-06-07T00:00:00.000Z',
+				limit: 2,
+				maxDays: 31,
+			},
+			alerts: [
+				{
+					id: 'alert-1',
+					receivedAt: '2026-06-06T12:00:00.000Z',
+					source: 'webhook',
+					enriched: true,
+					useTradingViewData: false,
+					deliveryResults: [{ channel: 'telegram', success: true, messageId: 'tg-1', errorCode: null, statusCode: null }],
+					tokenUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, totalCost: 0.001 },
+				},
+			],
+		});
+
+		const res = await request(app)
+			.get('/api/alerts/export?format=jsonl&from=2026-06-06T00:00:00.000Z&to=2026-06-07T00:00:00.000Z&limit=2&source=webhook&enriched=true')
+			.set('x-api-key', 'test-key')
+			.expect(200);
+
+		expect(alertStorageService.exportAlerts).toHaveBeenCalledWith({
+			from: '2026-06-06T00:00:00.000Z',
+			to: '2026-06-07T00:00:00.000Z',
+			limit: 2,
+			source: 'webhook',
+			enriched: true,
+			includeText: false,
+		});
+		expect(res.headers['content-type']).toContain('application/x-ndjson');
+		expect(res.text.trim().split('\n').map(line => JSON.parse(line))).toEqual([
+			{
+				id: 'alert-1',
+				receivedAt: '2026-06-06T12:00:00.000Z',
+				source: 'webhook',
+				enriched: true,
+				useTradingViewData: false,
+				deliveryResults: [{ channel: 'telegram', success: true, messageId: 'tg-1', errorCode: null, statusCode: null }],
+				tokenUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, totalCost: 0.001 },
+			},
+		]);
+		expect(res.text).not.toContain('raw secret text');
+	});
+
+	it('exports bounded stored alerts as CSV with optional text', async () => {
+		alertStorageService.exportAlerts.mockResolvedValue({
+			window: {
+				from: '2026-06-06T00:00:00.000Z',
+				to: '2026-06-07T00:00:00.000Z',
+				limit: 1,
+				maxDays: 31,
+			},
+			alerts: [
+				{
+					id: 'alert-1',
+					receivedAt: '2026-06-06T12:00:00.000Z',
+					source: 'webhook',
+					enriched: false,
+					useTradingViewData: true,
+					deliveryResults: [{ channel: 'whatsapp', success: false, messageId: null, errorCode: 'PROVIDER_LIMIT', statusCode: 429 }],
+					tokenUsage: null,
+					text: 'BTC, breakout',
+				},
+			],
+		});
+
+		const res = await request(app)
+			.get('/api/alerts/export?format=csv&from=2026-06-06T00:00:00.000Z&to=2026-06-07T00:00:00.000Z&limit=1&includeText=true')
+			.set('x-api-key', 'test-key')
+			.expect(200);
+
+		expect(alertStorageService.exportAlerts).toHaveBeenCalledWith({
+			from: '2026-06-06T00:00:00.000Z',
+			to: '2026-06-07T00:00:00.000Z',
+			limit: 1,
+			source: undefined,
+			enriched: undefined,
+			includeText: true,
+		});
+		expect(res.headers['content-type']).toContain('text/csv');
+		expect(res.text).toContain('id,receivedAt,source,enriched,useTradingViewData,deliveryResults,tokenUsage,text');
+		expect(res.text).toContain('"BTC, breakout"');
+		expect(res.text).toContain('PROVIDER_LIMIT');
+	});
+
+	it('returns 400 when export bounds are missing', async () => {
+		const res = await request(app)
+			.get('/api/alerts/export?format=jsonl&from=2026-06-06T00:00:00.000Z')
+			.set('x-api-key', 'test-key')
+			.expect(400);
+
+		expect(res.body).toEqual({
+			error: 'Export requests require bounded from and to ISO-8601 timestamps.',
+			code: 'INVALID_REQUEST',
+		});
+		expect(alertStorageService.exportAlerts).not.toHaveBeenCalled();
+	});
+
+	it('returns 400 when export format is invalid', async () => {
+		const res = await request(app)
+			.get('/api/alerts/export?format=xlsx&from=2026-06-06T00:00:00.000Z&to=2026-06-07T00:00:00.000Z')
+			.set('x-api-key', 'test-key')
+			.expect(400);
+
+		expect(res.body).toEqual({
+			error: 'Invalid export format. Use jsonl or csv.',
+			code: 'INVALID_REQUEST',
+		});
+		expect(alertStorageService.exportAlerts).not.toHaveBeenCalled();
 	});
 
 	it('returns a single stored alert by id', async () => {

--- a/tests/unit/alert-storage-service.test.js
+++ b/tests/unit/alert-storage-service.test.js
@@ -561,6 +561,146 @@ describe('AlertStorageService', () => {
 		});
 	});
 
+	describe('exportAlerts()', () => {
+		it('returns null when alert storage is disabled', async () => {
+			const result = await AlertStorageService.exportAlerts({
+				from: '2026-06-06T00:00:00.000Z',
+				to: '2026-06-07T00:00:00.000Z',
+			});
+
+			expect(result).toBeNull();
+			expect(mockGet).not.toHaveBeenCalled();
+		});
+
+		it('requires a bounded from/to window', async () => {
+			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+
+			await expect(AlertStorageService.exportAlerts({
+				from: '2026-06-06T00:00:00.000Z',
+			})).rejects.toMatchObject({
+				code: 'INVALID_REQUEST',
+				message: 'Export requests require bounded from and to ISO-8601 timestamps.',
+			});
+		});
+
+		it('rejects export windows over 31 days', async () => {
+			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+
+			await expect(AlertStorageService.exportAlerts({
+				from: '2026-05-01T00:00:00.000Z',
+				to: '2026-06-07T00:00:00.000Z',
+			})).rejects.toMatchObject({
+				code: 'INVALID_REQUEST',
+				message: 'Invalid export window. Maximum export window is 31 days.',
+			});
+		});
+
+		it('exports safe records with compact delivery and token fields', async () => {
+			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+			mockGet.mockResolvedValueOnce({
+				empty: false,
+				docs: [
+					buildQueryDoc('alert-1', {
+						receivedAt: buildTimestamp('2026-06-06T12:00:00.000Z'),
+						text: `BTC breakout ${'x'.repeat(1200)}`,
+						enriched: true,
+						enrichmentData: { providerSecret: 'must-not-export' },
+						tokenUsage: {
+							promptTokens: 10,
+							completionTokens: 20,
+							total: 30,
+							totalCost: 0.001,
+							apiKey: 'must-not-export',
+						},
+						deliveryResults: [
+							{
+								channel: 'telegram',
+								success: true,
+								messageId: 'tg-1',
+								requestHeaders: { authorization: 'Bearer secret' },
+							},
+							{
+								channel: 'whatsapp',
+								success: false,
+								errorCode: 'PROVIDER_LIMIT',
+								statusCode: 429,
+								rawProviderResponse: { token: 'secret' },
+							},
+						],
+						source: 'webhook',
+						useTradingViewData: true,
+					}),
+					buildQueryDoc('alert-2', {
+						receivedAt: buildTimestamp('2026-06-06T11:00:00.000Z'),
+						text: 'Plain alert',
+						enriched: false,
+						enrichmentData: null,
+						tokenUsage: null,
+						deliveryResults: [],
+						source: 'webhook',
+						useTradingViewData: false,
+					}),
+				],
+			});
+
+			const result = await AlertStorageService.exportAlerts({
+				from: '2026-06-06T00:00:00.000Z',
+				to: '2026-06-07T00:00:00.000Z',
+				limit: 2000,
+				source: 'webhook',
+				enriched: true,
+				includeText: true,
+			});
+
+			expect(mockCollection).toHaveBeenCalledWith('alerts');
+			expect(mockWhere).toHaveBeenCalledWith('receivedAt', '>=', expect.anything());
+			expect(mockWhere).toHaveBeenCalledWith('receivedAt', '<=', expect.anything());
+			expect(mockOrderBy).toHaveBeenCalledWith('receivedAt', 'desc');
+			expect(mockLimit).toHaveBeenCalledWith(1000);
+			expect(result.window).toEqual({
+				from: '2026-06-06T00:00:00.000Z',
+				to: '2026-06-07T00:00:00.000Z',
+				limit: 1000,
+				maxDays: 31,
+			});
+			expect(result.alerts).toHaveLength(1);
+			expect(result.alerts[0]).toEqual({
+				id: 'alert-1',
+				receivedAt: '2026-06-06T12:00:00.000Z',
+				source: 'webhook',
+				enriched: true,
+				useTradingViewData: true,
+				deliveryResults: [
+					{ channel: 'telegram', success: true, messageId: 'tg-1', errorCode: null, statusCode: null },
+					{ channel: 'whatsapp', success: false, messageId: null, errorCode: 'PROVIDER_LIMIT', statusCode: 429 },
+				],
+				tokenUsage: {
+					inputTokens: 10,
+					outputTokens: 20,
+					totalTokens: 30,
+					totalCost: 0.001,
+				},
+				text: expect.stringMatching(/^BTC breakout /),
+			});
+			expect(result.alerts[0].text.length).toBe(1000);
+			expect(JSON.stringify(result)).not.toContain('must-not-export');
+			expect(JSON.stringify(result)).not.toContain('authorization');
+			expect(JSON.stringify(result)).not.toContain('rawProviderResponse');
+		});
+
+		it('throws STORAGE_UNAVAILABLE when Firestore export reads fail', async () => {
+			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+			mockGet.mockRejectedValueOnce(new Error('Permission denied'));
+
+			await expect(AlertStorageService.exportAlerts({
+				from: '2026-06-06T00:00:00.000Z',
+				to: '2026-06-07T00:00:00.000Z',
+			})).rejects.toMatchObject({
+				code: 'STORAGE_UNAVAILABLE',
+			});
+		});
+	});
+
 	describe('summarizeAlerts()', () => {
 		it('aggregates bounded alert analytics without exposing raw alert text', async () => {
 			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';


### PR DESCRIPTION
## Summary
Adds a protected stored alert export endpoint for bounded JSONL and CSV exports from Firestore-backed alert records.

## Key Changes
- Added `GET /api/alerts/export` with `format=jsonl|csv`, required `from`/`to` bounds, optional `source`, `enriched`, `limit`, and `includeText` query params.
- Added Firestore export support that returns safe stable fields, compact delivery status, numeric token usage, and optional truncated alert text.
- Updated Postman coverage with valid JSONL/CSV examples and an invalid missing-bounds request.
- Updated `agents.md` with the new stored alert export contract.

## Technical Implementation
- Mounted `/alerts/export` before `/alerts/:alertId` to avoid route shadowing.
- Enforced API-key protection through the existing `validateApiKey` middleware.
- Capped export windows at 31 days and endpoint limits at 1000 records to avoid unbounded collection scans.
- Excluded raw provider payloads, credentials, full enrichment data, and raw alert text by default.

## Testing
- `pnpm test -- tests/unit/alert-storage-service.test.js --testTimeout=5000`
- `pnpm test -- tests/integration/alerts-endpoint.test.js --testTimeout=10000`
- `git diff --check`
- `pnpm test`

## References
- **GitHub Issue**: https://github.com/francovp/cabros-bot/issues/73
- **Linear**: [CB-29](https://linear.app/knil/issue/CB-29/gh-73-add-stored-alert-export-endpoint)