### PR TITLE
feat: publish OpenAPI docs (CB-30)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -35,10 +35,54 @@
 					"code": 200,
 					"body": "{\"uptime\":\"42.5\"}"
 				}
-			]
-		},
-		{
-			"name": "Get Status",
+				]
+			},
+			{
+				"name": "Get OpenAPI Contract",
+				"request": {
+					"method": "GET",
+					"header": [],
+					"description": "Public, read-only canonical OpenAPI contract. No API key is required.",
+					"url": {
+						"raw": "{{baseUrl}}/openapi.json",
+						"host": ["{{baseUrl}}"],
+						"path": ["openapi.json"]
+					}
+				},
+				"response": [
+					{
+						"name": "Success",
+						"status": "OK",
+						"code": 200,
+						"header": [{ "key": "Content-Type", "value": "application/json; charset=utf-8" }],
+						"body": "{\"openapi\":\"3.1.0\",\"info\":{\"title\":\"Cabros Bot API\",\"version\":\"0.1.0\"},\"paths\":{\"/api/status\":{\"get\":{\"security\":[{\"ApiKeyHeader\":[]},{\"ApiKeyQuery\":[]}]}}}}"
+					}
+				]
+			},
+			{
+				"name": "Open Interactive API Docs",
+				"request": {
+					"method": "GET",
+					"header": [],
+					"description": "Public Swagger UI backed by /openapi.json. Protected API calls still require authorization.",
+					"url": {
+						"raw": "{{baseUrl}}/docs",
+						"host": ["{{baseUrl}}"],
+						"path": ["docs"]
+					}
+				},
+				"response": [
+					{
+						"name": "Success",
+						"status": "OK",
+						"code": 200,
+						"header": [{ "key": "Content-Type", "value": "text/html; charset=UTF-8" }],
+						"body": "<!doctype html><html lang=\"en\"><head><title>Cabros Bot API</title></head><body><main id=\"swagger-ui\"></main></body></html>"
+					}
+				]
+			},
+			{
+				"name": "Get Status",
 			"request": {
 				"method": "GET",
 				"header": [

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ pnpm start
 
 ## API Endpoints
 
+The canonical API contract is served publicly at [`/openapi.json`](http://localhost:80/openapi.json), with interactive Swagger UI at [`/docs`](http://localhost:80/docs). Use those endpoints for request schemas, response shapes, examples, and the current route inventory. Protected `/api` operations still require `x-api-key`; the documentation endpoints never expose configured credentials.
+
 ### GET /healthcheck
 
 Health check endpoint.

--- a/agents.md
+++ b/agents.md
@@ -48,6 +48,8 @@ This project is a small Express + Telegraf (Telegram) bot service that exposes a
 - `src/controllers/helpers.js` — Small numeric helper (`round10`) used by price formatting.
 - `src/lib/logging.js` — Configures `console.*` levels via `LOG_LEVEL` and emits one-line structured JSON logs.
 - `src/lib/rateLimiter.js` — Global API rate limiting middleware (returns 429 when exceeded; configured via `RATE_LIMIT_WINDOW_MS`/`RATE_LIMIT_MAX`).
+- `src/openapi/openapi.json` — Canonical OpenAPI 3.1 contract for every mounted `/api` operation.
+- `src/openapi/docs.js` — Public, read-only `/openapi.json` and self-hosted Swagger UI `/docs` routes.
 
 ### External Integrations
 - **Binance**: Uses `binance` package `MainClient` and `getAvgPrice({ symbol })` with `beautifyResponses: true`.
@@ -143,6 +145,7 @@ Implement the following security practices to safeguard endpoints and credential
 - Optional but relevant (non-exhaustive; see feature sections below for full config): `ENABLE_TELEGRAM_BOT`, `PORT`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID`, `ENABLE_WHATSAPP_ALERTS`, `ENABLE_GEMINI_GROUNDING`, `GEMINI_API_KEY`, `ENABLE_LANGFUSE_PROMPTS`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_PROMPT_LABEL`, `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`, `BRAVE_SEARCH_API_KEY`, `BRAVE_SEARCH_ENDPOINT`, `FORCE_BRAVE_SEARCH`, `MODEL_PROVIDER`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `ENABLE_NEWS_MONITOR`, `EXPANDED_ANALYSIS_ALERT_SYMBOLS`, `EXPANDED_ANALYSIS_ALERT_TIMEOUT_MS`, `TRADINGVIEW_MCP_URL`, `TRADINGVIEW_MCP_TIMEOUT_MS`, `TRADINGVIEW_MCP_MAX_RETRIES`, `TRADINGVIEW_MCP_DEFAULT_TIMEFRAME`, `ENABLE_TRADINGVIEW_VOLUME_CONFIRMATION`, `ENABLE_SENTRY`, `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_CONSOLE_LOG_LEVELS`, `LOG_LEVEL`, `SERVICE_NAME`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `ENABLE_FIRESTORE_ALERT_STORAGE`, `ENABLE_MARKET_SCANNER`, `ENABLE_MESSAGE_FOOTER_METADATA`, `FIREBASE_PROJECT_ID`, `FIREBASE_SERVICE_ACCOUNT_JSON`, `GOOGLE_APPLICATION_CREDENTIALS`, `GEMINI_MODEL_NAME_FALLBACK`, `RENDER`, `IS_PULL_REQUEST`, `RENDER_GIT_COMMIT`, `RENDER_GIT_REPO_SLUG`.
 - Bot startup is gated: bot is launched only when `ENABLE_TELEGRAM_BOT === 'true'` and not a preview environment (`RENDER==='true' && IS_PULL_REQUEST==='true'` disables it).
 - Routes under `/api` (e.g. `/api/webhook/alert`) are mounted regardless of bot launch; individual features and notification channels are gated via env flags and per-channel validation.
+- API documentation is public and read-only at `/docs` and `/openapi.json`; protected `/api` operations remain guarded by `validateApiKey` and the contract documents both header and legacy query authentication.
 - Stored alert read, export, analytics, and replay routes (`GET /api/alerts`, `GET /api/alerts/export`, `GET /api/alerts/summary`, `GET /api/alerts/:alertId`, `POST /api/alerts/:alertId/replay`) are also mounted under `/api`; they require `WEBHOOK_API_KEY` when configured, return `403 FEATURE_DISABLED` unless `ENABLE_FIRESTORE_ALERT_STORAGE=true`, and return `503 STORAGE_UNAVAILABLE` when Firestore is enabled but unreadable.
 
 ---

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const express = require('express');
 const app = express();
 const cors = require('cors');
 const helmet = require('helmet');
+const { getOpenApiDocsRouter } = require('./src/openapi/docs');
 
 // Tell express to use body-parser's urlencoded parsing
 app.use(express.urlencoded({ extended: false }));
@@ -21,5 +22,7 @@ app.use('/healthcheck', require('express-healthcheck')());
 // Rate Limiter (must be after healthcheck to avoid limiting health checks)
 app.use(require('./src/lib/rateLimiter'));
 
-module.exports = app;
+// Public, read-only API contract and interactive documentation.
+app.use(getOpenApiDocsRouter());
 
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "express-healthcheck": "^0.1.0",
     "firebase-admin": "^9.8.0",
     "helmet": "^7.1.0",
+    "swagger-ui-dist": "^5.32.6",
     "telegraf": "^4.3.0",
     "uuid": "^11.1.1"
   },
@@ -39,6 +40,7 @@
     "@azure/core-sse": "^2.3.0"
   },
   "devDependencies": {
+    "@apidevtools/swagger-parser": "^12.1.0",
     "@babel/core": "^7.28.5",
     "@babel/preset-env": "^7.28.5",
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       helmet:
         specifier: ^7.1.0
         version: 7.2.0
+      swagger-ui-dist:
+        specifier: ^5.32.6
+        version: 5.32.6
       telegraf:
         specifier: ^4.3.0
         version: 4.16.3
@@ -45,6 +48,9 @@ importers:
         specifier: ^11.1.1
         version: 11.1.1
     devDependencies:
+      '@apidevtools/swagger-parser':
+        specifier: ^12.1.0
+        version: 12.1.0(openapi-types@12.1.3)
       '@babel/core':
         specifier: ^7.28.5
         version: 7.28.5
@@ -93,6 +99,22 @@ importers:
         version: 2.3.0
 
 packages:
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    resolution: {integrity: sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==}
+    engines: {node: '>= 16'}
+
+  '@apidevtools/openapi-schemas@2.1.0':
+    resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
+    engines: {node: '>=10'}
+
+  '@apidevtools/swagger-methods@3.0.2':
+    resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
+
+  '@apidevtools/swagger-parser@12.1.0':
+    resolution: {integrity: sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==}
+    peerDependencies:
+      openapi-types: '>=7'
 
   '@azure-rest/ai-inference@1.0.0-beta.6':
     resolution: {integrity: sha512-j5FrJDTHu2P2+zwFVe5j2edasOIhqkFj+VkDjbhGkQuOoIAByF0egRkgs0G1k03HyJ7bOOT9BkRF7MIgr/afhw==}
@@ -1258,6 +1280,9 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
+
   '@sentry/core@10.53.1':
     resolution: {integrity: sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==}
     engines: {node: '>=18'}
@@ -1690,6 +1715,14 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -1739,6 +1772,9 @@ packages:
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -1878,6 +1914,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -2869,6 +2908,10 @@ packages:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -3202,6 +3245,9 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3666,6 +3712,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-ui-dist@5.32.6:
+    resolution: {integrity: sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==}
+
   synckit@0.11.11:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -3993,6 +4042,25 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.2.0
+
+  '@apidevtools/openapi-schemas@2.1.0': {}
+
+  '@apidevtools/swagger-methods@3.0.2': {}
+
+  '@apidevtools/swagger-parser@12.1.0(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.0.1
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      ajv: 8.17.1
+      ajv-draft-04: 1.0.0(ajv@8.17.1)
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
 
   '@azure-rest/ai-inference@1.0.0-beta.6':
     dependencies:
@@ -5594,6 +5662,8 @@ snapshots:
   '@protobufjs/utf8@1.1.0':
     optional: true
 
+  '@scarf/scarf@1.4.0': {}
+
   '@sentry/core@10.53.1': {}
 
   '@sentry/node-core@10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
@@ -6084,6 +6154,10 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-draft-04@1.0.0(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
@@ -6108,7 +6182,6 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-    optional: true
 
   ansi-escapes@4.3.2:
     dependencies:
@@ -6134,6 +6207,8 @@ snapshots:
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
+
+  argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
 
@@ -6341,6 +6416,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
 
@@ -6792,8 +6869,7 @@ snapshots:
   fast-text-encoding@1.0.6:
     optional: true
 
-  fast-uri@3.1.0:
-    optional: true
+  fast-uri@3.1.0: {}
 
   fastest-levenshtein@1.0.16:
     optional: true
@@ -7622,6 +7698,10 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
@@ -7634,8 +7714,7 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
-  json-schema-traverse@1.0.0:
-    optional: true
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -7927,6 +8006,8 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  openapi-types@12.1.3: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -8188,8 +8269,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2:
-    optional: true
+  require-from-string@2.0.2: {}
 
   require-in-the-middle@8.0.1:
     dependencies:
@@ -8464,6 +8544,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swagger-ui-dist@5.32.6:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   synckit@0.11.11:
     dependencies:

--- a/src/openapi/docs.js
+++ b/src/openapi/docs.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const path = require('path');
+const express = require('express');
+const swaggerUiDist = require('swagger-ui-dist');
+const contract = require('./openapi.json');
+
+const docsHtmlPath = path.join(__dirname, 'index.html');
+const initializerPath = path.join(__dirname, 'swagger-initializer.js');
+
+function getOpenApiDocsRouter() {
+	const router = express.Router();
+
+	router.get('/openapi.json', (req, res) => {
+		res.set('Cache-Control', 'no-cache');
+		return res.json(contract);
+	});
+
+	router.get('/docs', (req, res) => {
+		res.set('Cache-Control', 'no-cache');
+		return res.sendFile(docsHtmlPath);
+	});
+
+	router.get('/docs/swagger-initializer.js', (req, res) => res.sendFile(initializerPath));
+	router.use('/docs', express.static(swaggerUiDist.getAbsoluteFSPath(), {
+		index: false,
+		immutable: true,
+		maxAge: '1d',
+	}));
+
+	return router;
+}
+
+module.exports = { getOpenApiDocsRouter };

--- a/src/openapi/index.html
+++ b/src/openapi/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Interactive OpenAPI documentation for Cabros Bot">
+  <title>Cabros Bot API</title>
+  <link rel="stylesheet" href="/docs/swagger-ui.css">
+</head>
+<body>
+  <main id="swagger-ui" aria-label="Cabros Bot API documentation"></main>
+  <script src="/docs/swagger-ui-bundle.js"></script>
+  <script src="/docs/swagger-ui-standalone-preset.js"></script>
+  <script src="/docs/swagger-initializer.js"></script>
+</body>
+</html>

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -1,0 +1,285 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Cabros Bot API",
+    "version": "0.1.0",
+    "description": "Protected alerting and market-analysis APIs. Use the x-api-key header; the api-key query parameter exists only for legacy client compatibility and may leak through logs."
+  },
+  "servers": [{ "url": "/", "description": "Current deployment" }],
+  "tags": [
+    { "name": "Webhooks" },
+    { "name": "Alerts" },
+    { "name": "Scanner presets" },
+    { "name": "Jobs" },
+    { "name": "News" },
+    { "name": "Operations" }
+  ],
+  "paths": {
+    "/api/webhook/alert": {
+      "post": {
+        "tags": ["Webhooks"], "summary": "Deliver an alert", "operationId": "postAlert",
+        "parameters": [{ "$ref": "#/components/parameters/DryRun" }, { "$ref": "#/components/parameters/UseTradingViewData" }],
+        "requestBody": { "$ref": "#/components/requestBodies/Alert" },
+        "responses": { "200": { "$ref": "#/components/responses/DeliveryResult" }, "400": { "$ref": "#/components/responses/Error" }, "401": { "$ref": "#/components/responses/Unauthorized" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/webhook/message": {
+      "post": {
+        "tags": ["Webhooks"], "summary": "Deliver a generic message", "operationId": "postMessage",
+        "requestBody": { "$ref": "#/components/requestBodies/Message" },
+        "responses": { "200": { "$ref": "#/components/responses/DeliveryResult" }, "400": { "$ref": "#/components/responses/Error" }, "401": { "$ref": "#/components/responses/Unauthorized" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/webhook/expanded-analysis-alert": {
+      "post": {
+        "tags": ["Webhooks"], "summary": "Build and deliver expanded TradingView analysis", "operationId": "postExpandedAnalysisAlert",
+        "parameters": [{ "$ref": "#/components/parameters/DryRun" }],
+        "requestBody": { "$ref": "#/components/requestBodies/ExpandedAnalysis" },
+        "responses": { "200": { "$ref": "#/components/responses/AnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "502": { "$ref": "#/components/responses/Error" }, "504": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/webhook/market-scanner-alert": {
+      "post": {
+        "tags": ["Webhooks"], "summary": "Run market scanners and deliver a report", "operationId": "postMarketScannerAlert",
+        "parameters": [{ "$ref": "#/components/parameters/DryRun" }],
+        "requestBody": { "$ref": "#/components/requestBodies/MarketScanner" },
+        "responses": { "200": { "$ref": "#/components/responses/AnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" }, "502": { "$ref": "#/components/responses/Error" }, "504": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/webhook/volume-confirmation": {
+      "post": {
+        "tags": ["Webhooks"], "summary": "Check TradingView volume confirmation", "operationId": "postVolumeConfirmation",
+        "requestBody": { "$ref": "#/components/requestBodies/VolumeConfirmation" },
+        "responses": { "200": { "$ref": "#/components/responses/AnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "502": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/alerts": {
+      "get": {
+        "tags": ["Alerts"], "summary": "List stored alerts", "operationId": "listAlerts",
+        "parameters": [{ "$ref": "#/components/parameters/AlertListLimit" }, { "$ref": "#/components/parameters/Cursor" }, { "$ref": "#/components/parameters/Source" }, { "$ref": "#/components/parameters/Enriched" }],
+        "responses": { "200": { "$ref": "#/components/responses/AlertList" }, "403": { "$ref": "#/components/responses/Error" }, "503": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/alerts/summary": {
+      "get": {
+        "tags": ["Alerts"], "summary": "Summarize stored alert analytics", "operationId": "summarizeAlerts",
+        "parameters": [{ "$ref": "#/components/parameters/From" }, { "$ref": "#/components/parameters/To" }, { "$ref": "#/components/parameters/SummaryLimit" }, { "$ref": "#/components/parameters/Source" }, { "$ref": "#/components/parameters/Enriched" }],
+        "responses": { "200": { "$ref": "#/components/responses/JsonResult" }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" }, "503": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/alerts/export": {
+      "get": {
+        "tags": ["Alerts"], "summary": "Export a bounded alert window", "operationId": "exportAlerts",
+        "parameters": [{ "$ref": "#/components/parameters/FromRequired" }, { "$ref": "#/components/parameters/ToRequired" }, { "$ref": "#/components/parameters/ExportFormat" }, { "$ref": "#/components/parameters/ExportLimit" }, { "$ref": "#/components/parameters/Source" }, { "$ref": "#/components/parameters/Enriched" }, { "$ref": "#/components/parameters/IncludeText" }],
+        "responses": { "200": { "description": "JSON Lines or CSV export", "content": { "application/x-ndjson": { "schema": { "type": "string" } }, "text/csv": { "schema": { "type": "string" } } } }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" }, "503": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/alerts/{alertId}": {
+      "get": {
+        "tags": ["Alerts"], "summary": "Get a stored alert", "operationId": "getAlertById",
+        "parameters": [{ "$ref": "#/components/parameters/AlertId" }],
+        "responses": { "200": { "$ref": "#/components/responses/JsonResult" }, "404": { "$ref": "#/components/responses/Error" }, "503": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/alerts/{alertId}/replay": {
+      "post": {
+        "tags": ["Alerts"], "summary": "Replay a stored alert", "operationId": "replayAlert",
+        "parameters": [{ "$ref": "#/components/parameters/AlertId" }, { "$ref": "#/components/parameters/DryRun" }],
+        "requestBody": { "$ref": "#/components/requestBodies/Replay" },
+        "responses": { "200": { "$ref": "#/components/responses/DeliveryResult" }, "400": { "$ref": "#/components/responses/Error" }, "404": { "$ref": "#/components/responses/Error" }, "503": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/scanner-presets": {
+      "get": {
+        "tags": ["Scanner presets"], "summary": "List scanner presets", "operationId": "listScannerPresets",
+        "responses": { "200": { "$ref": "#/components/responses/JsonResult" }, "500": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      },
+      "post": {
+        "tags": ["Scanner presets"], "summary": "Create a scanner preset", "operationId": "createScannerPreset",
+        "requestBody": { "$ref": "#/components/requestBodies/ScannerPreset" },
+        "responses": { "201": { "$ref": "#/components/responses/JsonResult" }, "400": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/scanner-presets/{id}": {
+      "get": {
+        "tags": ["Scanner presets"], "summary": "Get a scanner preset", "operationId": "getScannerPreset",
+        "parameters": [{ "$ref": "#/components/parameters/PresetId" }],
+        "responses": { "200": { "$ref": "#/components/responses/JsonResult" }, "404": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      },
+      "put": {
+        "tags": ["Scanner presets"], "summary": "Update a scanner preset", "operationId": "updateScannerPreset",
+        "parameters": [{ "$ref": "#/components/parameters/PresetId" }],
+        "requestBody": { "$ref": "#/components/requestBodies/ScannerPreset" },
+        "responses": { "200": { "$ref": "#/components/responses/JsonResult" }, "400": { "$ref": "#/components/responses/Error" }, "404": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      },
+      "delete": {
+        "tags": ["Scanner presets"], "summary": "Delete a scanner preset", "operationId": "deleteScannerPreset",
+        "parameters": [{ "$ref": "#/components/parameters/PresetId" }],
+        "responses": { "200": { "$ref": "#/components/responses/JsonResult" }, "404": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/scanner-presets/{id}/run": {
+      "post": {
+        "tags": ["Scanner presets"], "summary": "Run a scanner preset", "operationId": "runScannerPreset",
+        "parameters": [{ "$ref": "#/components/parameters/PresetId" }, { "$ref": "#/components/parameters/DryRun" }],
+        "responses": { "200": { "$ref": "#/components/responses/AnalysisResult" }, "404": { "$ref": "#/components/responses/Error" }, "502": { "$ref": "#/components/responses/Error" }, "504": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/jobs/tradingview-analysis": {
+      "post": {
+        "tags": ["Jobs"], "summary": "Create an asynchronous TradingView job", "operationId": "createTradingViewJob",
+        "requestBody": { "$ref": "#/components/requestBodies/TradingViewJob" },
+        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/jobs/{jobId}": {
+      "get": {
+        "tags": ["Jobs"], "summary": "Get asynchronous job status", "operationId": "getJobStatus",
+        "parameters": [{ "$ref": "#/components/parameters/JobId" }],
+        "responses": { "200": { "$ref": "#/components/responses/JobResult" }, "404": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/jobs/{jobId}/cancel": {
+      "post": {
+        "tags": ["Jobs"], "summary": "Cancel an asynchronous job", "operationId": "cancelJob",
+        "parameters": [{ "$ref": "#/components/parameters/JobId" }],
+        "responses": { "200": { "$ref": "#/components/responses/JobResult" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/jobs/{jobId}/retry": {
+      "post": {
+        "tags": ["Jobs"], "summary": "Retry a failed job", "operationId": "retryJob",
+        "parameters": [{ "$ref": "#/components/parameters/JobId" }],
+        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/jobs/{jobId}/retry-failed": {
+      "post": {
+        "tags": ["Jobs"], "summary": "Retry failed items in a completed job", "operationId": "retryFailedJobItems",
+        "parameters": [{ "$ref": "#/components/parameters/JobId" }],
+        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/news-monitor": {
+      "get": {
+        "tags": ["News"], "summary": "Analyze configured or queried market symbols", "operationId": "getNewsMonitor",
+        "parameters": [{ "$ref": "#/components/parameters/CryptoSymbols" }, { "$ref": "#/components/parameters/StockSymbols" }],
+        "responses": { "200": { "$ref": "#/components/responses/AnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      },
+      "post": {
+        "tags": ["News"], "summary": "Analyze market symbols from a JSON request", "operationId": "postNewsMonitor",
+        "requestBody": { "$ref": "#/components/requestBodies/NewsMonitor" },
+        "responses": { "200": { "$ref": "#/components/responses/AnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/status": {
+      "get": {
+        "tags": ["Operations"], "summary": "Get runtime capabilities and dependency readiness", "operationId": "getStatus",
+        "responses": { "200": { "$ref": "#/components/responses/StatusResult" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    },
+    "/api/capabilities": {
+      "get": {
+        "tags": ["Operations"], "summary": "Alias for runtime status", "operationId": "getCapabilities",
+        "responses": { "200": { "$ref": "#/components/responses/StatusResult" } },
+        "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyHeader": { "type": "apiKey", "in": "header", "name": "x-api-key" },
+      "ApiKeyQuery": { "type": "apiKey", "in": "query", "name": "api-key", "description": "Legacy compatibility only. Prefer x-api-key because query strings may be logged." }
+    },
+    "parameters": {
+      "AlertId": { "name": "alertId", "in": "path", "required": true, "schema": { "type": "string" }, "example": "alert-123" },
+      "PresetId": { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } },
+      "JobId": { "name": "jobId", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } },
+      "DryRun": { "name": "dryRun", "in": "query", "schema": { "type": "boolean", "default": false } },
+      "UseTradingViewData": { "name": "useTradingViewData", "in": "query", "schema": { "type": "boolean", "default": false } },
+      "AlertListLimit": { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 } },
+      "SummaryLimit": { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 1000, "default": 500 } },
+      "ExportLimit": { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 1000, "default": 500 } },
+      "Cursor": { "name": "cursor", "in": "query", "schema": { "type": "string" }, "description": "Opaque pagination cursor returned by the previous page." },
+      "Source": { "name": "source", "in": "query", "schema": { "type": "string" }, "example": "webhook" },
+      "Enriched": { "name": "enriched", "in": "query", "schema": { "type": "boolean" } },
+      "IncludeText": { "name": "includeText", "in": "query", "schema": { "type": "boolean", "default": false } },
+      "From": { "name": "from", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+      "To": { "name": "to", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+      "FromRequired": { "name": "from", "in": "query", "required": true, "schema": { "type": "string", "format": "date-time" } },
+      "ToRequired": { "name": "to", "in": "query", "required": true, "schema": { "type": "string", "format": "date-time" } },
+      "ExportFormat": { "name": "format", "in": "query", "schema": { "type": "string", "enum": ["jsonl", "csv"], "default": "jsonl" } },
+      "CryptoSymbols": { "name": "crypto", "in": "query", "schema": { "type": "string" }, "example": "BTCUSDT,ETHUSD" },
+      "StockSymbols": { "name": "stocks", "in": "query", "schema": { "type": "string" }, "example": "NVDA,MSFT" }
+    },
+    "requestBodies": {
+      "Alert": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AlertRequest" }, "example": { "text": "BTCUSDT broke resistance with strong volume" } }, "text/plain": { "schema": { "type": "string" }, "example": "BTCUSDT broke resistance" } } },
+      "Message": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/MessageRequest" }, "example": { "message": "Deployment completed", "channels": ["telegram", "whatsapp"] } } } },
+      "ExpandedAnalysis": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ExpandedAnalysisRequest" }, "example": { "symbols": ["BINANCE:BTCUSDT", "NASDAQ:NVDA"], "timeframe": "1D", "analysisMode": "standard", "includeMultiTimeframe": false } } } },
+      "MarketScanner": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/MarketScannerRequest" }, "example": { "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers", "top_losers", "volume_breakout_scanner"], "limit": 5 } } } },
+      "VolumeConfirmation": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/VolumeConfirmationRequest" }, "example": { "symbol": "BINANCE:BTCUSDT", "timeframe": "1h" } } } },
+      "Replay": { "content": { "application/json": { "schema": { "type": "object", "properties": { "channels": { "type": "array", "items": { "type": "string", "enum": ["telegram", "whatsapp"] } } } }, "example": { "channels": ["telegram"] } } } },
+      "ScannerPreset": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ScannerPresetRequest" }, "example": { "name": "Daily Scan", "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers"], "limit": 5 } } } },
+      "TradingViewJob": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TradingViewJobRequest" }, "examples": { "expandedAnalysis": { "value": { "type": "expanded-analysis", "symbols": ["BINANCE:BTCUSDT"], "timeframe": "1D" } }, "marketScanner": { "value": { "type": "market-scanner", "exchange": "BINANCE", "timeframe": "4h" } } } } } },
+      "NewsMonitor": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NewsMonitorRequest" }, "example": { "crypto": ["BTCUSDT", "ETHUSD"], "stocks": ["NVDA"] } } } }
+    },
+    "responses": {
+      "Unauthorized": { "description": "API key rejected", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Unauthorized", "code": "UNAUTHORIZED" } } } },
+      "Error": { "description": "Request or service error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Invalid request", "code": "INVALID_REQUEST" } } } },
+      "JsonResult": { "description": "Successful JSON response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonObject" } } } },
+      "DeliveryResult": { "description": "Per-channel delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DeliveryResult" }, "example": { "success": true, "results": [{ "channel": "telegram", "success": true }] } } } },
+      "AnalysisResult": { "description": "Analysis and delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonObject" } } } },
+      "AlertList": { "description": "Stored alert page", "content": { "application/json": { "schema": { "type": "object", "properties": { "alerts": { "type": "array", "items": { "$ref": "#/components/schemas/JsonObject" } }, "nextCursor": { "type": ["string", "null"] } } } } } },
+      "JobResult": { "description": "Asynchronous job state", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Job" } } } },
+      "StatusResult": { "description": "Non-sensitive runtime readiness", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Status" } } } }
+    },
+    "schemas": {
+      "JsonObject": { "type": "object", "additionalProperties": true },
+      "Error": { "type": "object", "required": ["error"], "properties": { "error": { "type": "string" }, "code": { "type": "string" } } },
+      "AlertRequest": { "type": "object", "required": ["text"], "properties": { "text": { "type": "string", "minLength": 1 } } },
+      "MessageRequest": { "type": "object", "required": ["message", "channels"], "properties": { "message": { "type": "string", "minLength": 1 }, "channels": { "type": "array", "minItems": 1, "items": { "type": "string", "enum": ["telegram", "whatsapp"] } }, "telegramChatId": { "type": "string", "minLength": 1 }, "whatsappChatId": { "type": "string", "minLength": 1 } } },
+      "ExpandedAnalysisRequest": { "type": "object", "properties": { "symbols": { "type": "array", "maxItems": 50, "items": { "type": "string", "pattern": "^[A-Z0-9_]+:[A-Z0-9._-]+$" } }, "timeframe": { "type": "string", "enum": ["5m", "15m", "1h", "4h", "1D", "1W", "1M"] }, "analysisMode": { "type": "string", "enum": ["standard", "combined"], "default": "standard" }, "includeMultiTimeframe": { "type": "boolean", "default": false } } },
+      "MarketScannerRequest": {
+        "type": "object",
+        "properties": {
+          "exchange": { "type": "string", "default": "BINANCE" },
+          "timeframe": { "type": "string", "default": "4h" },
+          "scans": { "type": "array", "items": { "type": "string", "enum": ["top_gainers", "top_losers", "volume_breakout_scanner", "smart_volume_scanner", "bollinger_scan"] } },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 20, "default": 5 },
+          "bbw_threshold": { "type": "number", "default": 0.05 }
+        }
+      },
+      "VolumeConfirmationRequest": { "type": "object", "required": ["symbol"], "properties": { "symbol": { "type": "string", "pattern": "^[A-Z0-9_]+:[A-Z0-9._-]+$" }, "timeframe": { "type": "string" } } },
+      "ScannerPresetRequest": { "type": "object", "required": ["name"], "properties": { "name": { "type": "string", "minLength": 1 }, "exchange": { "type": "string" }, "timeframe": { "type": "string" }, "scans": { "type": "array", "items": { "type": "string" } }, "limit": { "type": "integer", "minimum": 1, "maximum": 20 }, "bbw_threshold": { "type": "number" } } },
+      "TradingViewJobRequest": { "oneOf": [{ "allOf": [{ "type": "object", "required": ["type"], "properties": { "type": { "const": "expanded-analysis" } } }, { "$ref": "#/components/schemas/ExpandedAnalysisRequest" }] }, { "allOf": [{ "type": "object", "required": ["type"], "properties": { "type": { "const": "market-scanner" } } }, { "$ref": "#/components/schemas/MarketScannerRequest" }] }] },
+      "NewsMonitorRequest": { "type": "object", "properties": { "crypto": { "type": "array", "items": { "type": "string" } }, "stocks": { "type": "array", "items": { "type": "string" } } } },
+      "DeliveryResult": { "type": "object", "properties": { "success": { "type": "boolean" }, "results": { "type": "array", "items": { "type": "object", "properties": { "channel": { "type": "string" }, "success": { "type": "boolean" }, "error": { "type": "string" } } } }, "enriched": { "type": "boolean" }, "tokenUsage": { "$ref": "#/components/schemas/JsonObject" } } },
+      "Job": { "type": "object", "properties": { "success": { "type": "boolean" }, "jobId": { "type": "string", "format": "uuid" }, "status": { "type": "string", "enum": ["pending", "processing", "completed", "failed", "canceled"] }, "progress": { "$ref": "#/components/schemas/JsonObject" }, "result": { "$ref": "#/components/schemas/JsonObject" } } },
+      "Status": { "type": "object", "properties": { "service": { "$ref": "#/components/schemas/JsonObject" }, "featureFlags": { "$ref": "#/components/schemas/JsonObject" }, "deliveryChannels": { "$ref": "#/components/schemas/JsonObject" }, "dependencies": { "$ref": "#/components/schemas/JsonObject" } } }
+    }
+  }
+}

--- a/src/openapi/swagger-initializer.js
+++ b/src/openapi/swagger-initializer.js
@@ -1,0 +1,13 @@
+'use strict';
+
+window.addEventListener('load', () => {
+	window.ui = SwaggerUIBundle({
+		url: '/openapi.json',
+		dom_id: '#swagger-ui',
+		deepLinking: true,
+		displayRequestDuration: true,
+		presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+		layout: 'StandaloneLayout',
+		persistAuthorization: false,
+	});
+});

--- a/tests/integration/openapi-docs.test.js
+++ b/tests/integration/openapi-docs.test.js
@@ -1,0 +1,41 @@
+const request = require('supertest');
+
+describe('public OpenAPI documentation', () => {
+	let app;
+
+	beforeAll(() => {
+		process.env.WEBHOOK_API_KEY = 'must-not-appear-in-docs';
+		app = require('../../app');
+	});
+
+	afterAll(() => {
+		delete process.env.WEBHOOK_API_KEY;
+	});
+
+	it('serves the raw contract without API-key authentication', async () => {
+		const response = await request(app).get('/openapi.json');
+
+		expect(response.status).toBe(200);
+		expect(response.headers['content-type']).toMatch(/application\/json/);
+		expect(response.body.openapi).toMatch(/^3\./);
+		expect(response.body.components.securitySchemes.ApiKeyHeader).toEqual({
+			type: 'apiKey',
+			in: 'header',
+			name: 'x-api-key',
+		});
+		expect(response.text).not.toContain(process.env.WEBHOOK_API_KEY);
+	});
+
+	it('renders self-hosted Swagger UI without API-key authentication', async () => {
+		const page = await request(app).get('/docs');
+		const stylesheet = await request(app).get('/docs/swagger-ui.css');
+
+		expect(page.status).toBe(200);
+		expect(page.headers['content-type']).toMatch(/text\/html/);
+		expect(page.text).toContain('Cabros Bot API');
+		expect(page.text).toContain('/docs/swagger-ui-bundle.js');
+		expect(page.text).not.toContain(process.env.WEBHOOK_API_KEY);
+		expect(stylesheet.status).toBe(200);
+		expect(stylesheet.headers['content-type']).toMatch(/text\/css/);
+	});
+});

--- a/tests/unit/openapi-contract.test.js
+++ b/tests/unit/openapi-contract.test.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const SwaggerParser = require('@apidevtools/swagger-parser');
+const { getRoutes } = require('../../src/routes');
+
+const contractPath = path.join(__dirname, '../../src/openapi/openapi.json');
+
+function normalizeExpressPath(routePath) {
+	return `/api${routePath}`.replace(/:([A-Za-z0-9_]+)/g, '{$1}');
+}
+
+function getMountedApiOperations() {
+	return getRoutes(null).stack
+		.filter((layer) => layer.route)
+		.flatMap((layer) => Object.keys(layer.route.methods)
+			.filter((method) => layer.route.methods[method])
+			.map((method) => `${method.toUpperCase()} ${normalizeExpressPath(layer.route.path)}`))
+		.sort();
+}
+
+function getDocumentedApiOperations(contract) {
+	return Object.entries(contract.paths)
+		.flatMap(([routePath, pathItem]) => Object.keys(pathItem)
+			.filter((key) => ['get', 'post', 'put', 'patch', 'delete'].includes(key))
+			.map((method) => `${method.toUpperCase()} ${routePath}`))
+		.filter((operation) => operation.includes(' /api/'))
+		.sort();
+}
+
+describe('OpenAPI contract', () => {
+	it('exists as the canonical JSON source', () => {
+		expect(fs.existsSync(contractPath)).toBe(true);
+	});
+
+	it('documents every mounted API operation without stale operations', () => {
+		if (!fs.existsSync(contractPath)) return;
+		const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
+
+		expect(getDocumentedApiOperations(contract)).toEqual(getMountedApiOperations());
+	});
+
+	it('is a valid OpenAPI document', async () => {
+		if (!fs.existsSync(contractPath)) return;
+
+		await expect(SwaggerParser.validate(contractPath)).resolves.toBeDefined();
+	});
+
+	it('requires the documented API-key schemes on every protected operation', () => {
+		if (!fs.existsSync(contractPath)) return;
+		const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
+		const operations = Object.entries(contract.paths)
+			.filter(([routePath]) => routePath.startsWith('/api/'))
+			.flatMap(([, pathItem]) => Object.values(pathItem))
+			.filter((operation) => operation && operation.responses);
+
+		for (const operation of operations) {
+			expect(operation.security).toEqual([
+				{ ApiKeyHeader: [] },
+				{ ApiKeyQuery: [] },
+			]);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Publishes a canonical OpenAPI 3.1 contract and public, read-only Swagger UI for all protected Cabros Bot API operations.

## Key Changes

- Adds `/openapi.json` as the canonical machine-readable contract.
- Adds `/docs` with self-hosted Swagger UI assets and no runtime CDN dependency.
- Documents all 25 mounted `/api` operations, request examples, response shapes, and `x-api-key` authentication.
- Adds CI coverage that validates OpenAPI syntax and detects drift against Express routes.
- Updates Postman, README, and developer documentation.

## Technical Implementation

- Mounts the documentation router after Helmet and the global rate limiter.
- Keeps docs public while every `/api` operation retains `validateApiKey` protection.
- Avoids inline scripts and configured-secret interpolation in documentation responses.

## Testing

- `pnpm test -- tests/integration/openapi-docs.test.js tests/unit/openapi-contract.test.js --runInBand`
- `pnpm test`
- `git diff --check`
- `jq empty CabrosBot.postman_collection.json`

## References

- Closes #74
- **Linear**: [CB-30](https://linear.app/knil/issue/CB-30/gh-74-publish-openapi-contract-and-docs-ui)