### PR TITLE
fix: normalize idempotency fingerprint to ignore transport keys (CB-31)

### DIFF
--- a/context/fix/idempotency-conflicts-cb-31.md
+++ b/context/fix/idempotency-conflicts-cb-31.md
@@ -1,0 +1,24 @@
+fix: normalize idempotency fingerprint to ignore transport keys (CB-31)
+
+## Summary
+
+Normalize the request fingerprint used for idempotency hashing to exclude key transport fields (`idempotencyKey` and `idempotency_key`) from request body and query. This prevents false 409 IDEMPOTENCY_CONFLICT responses when retries supply the same key via different supported locations.
+
+## Key Changes
+
+- Exclude `idempotencyKey` and `idempotency_key` fields from `body` and `query` when constructing the request fingerprint in `buildRequestFingerprint()`.
+- Add comprehensive unit and regression tests in `tests/unit/idempotency.test.js` covering location transitions (header-to-body, body-to-header, query-to-header) and actual payload/query flag mismatch conflict checks.
+
+## Technical Implementation
+
+- Updated `buildRequestFingerprint` in `src/lib/idempotency.js` to create shallow copies of `req.body` and `req.query` and delete the `idempotencyKey` and `idempotency_key` keys if present, ensuring the resulting hash only reflects the business payloads.
+
+## Testing
+
+- Verified all unit and integration tests pass locally.
+- Added 5 new regression test cases verifying successful location transitions and correct mismatch conflict detection.
+
+## References
+
+- **GitHub**: Closes #90
+- **Linear**: [CB-31](https://linear.app/knil/issue/CB-31/fix-idempotency-conflicts-when-key-moves-between-supported-locations)

--- a/src/lib/idempotency.js
+++ b/src/lib/idempotency.js
@@ -19,11 +19,25 @@ function getRequestPath(req) {
 }
 
 function buildRequestFingerprint(req) {
+	let body = req.body || {};
+	if (body && typeof body === 'object') {
+		body = { ...body };
+		delete body.idempotencyKey;
+		delete body.idempotency_key;
+	}
+
+	let query = req.query || {};
+	if (query && typeof query === 'object') {
+		query = { ...query };
+		delete query.idempotencyKey;
+		delete query.idempotency_key;
+	}
+
 	return {
 		method: req.method || 'GET',
 		path: getRequestPath(req),
-		body: req.body || {},
-		query: req.query || {},
+		body,
+		query,
 	};
 }
 

--- a/tests/unit/idempotency.test.js
+++ b/tests/unit/idempotency.test.js
@@ -458,5 +458,146 @@ describe('Idempotency Service & Middleware', () => {
 				idempotencyService.maxKeys = originalMaxKeys;
 			}
 		});
+
+		test('should normalize fingerprint and succeed for header-to-body location transition', () => {
+			const key = 'test-header-to-body';
+			req.headers['idempotency-key'] = key;
+			req.body = { text: 'my business alert' };
+
+			idempotencyMiddleware(req, res, next);
+			res.status(200).json({ success: true, details: 'header request processed' });
+
+			const req2 = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/webhook/alert',
+				body: { text: 'my business alert', idempotencyKey: key },
+			});
+			const res2 = httpMocks.createResponse();
+			const next2 = jest.fn();
+
+			idempotencyMiddleware(req2, res2, next2);
+
+			expect(next2).not.toHaveBeenCalled();
+			expect(res2.statusCode).toBe(200);
+			expect(res2.getHeader('Idempotency-Replay')).toBe('true');
+			expect(JSON.parse(res2._getData())).toEqual({
+				success: true,
+				details: 'header request processed',
+				idempotencyReplayed: true,
+			});
+		});
+
+		test('should normalize fingerprint and succeed for body-to-header location transition', () => {
+			const key = 'test-body-to-header';
+			req.body = { text: 'my business alert', idempotencyKey: key };
+
+			idempotencyMiddleware(req, res, next);
+			res.status(200).json({ success: true, details: 'body request processed' });
+
+			const req2 = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/webhook/alert',
+				headers: { 'idempotency-key': key },
+				body: { text: 'my business alert' },
+			});
+			const res2 = httpMocks.createResponse();
+			const next2 = jest.fn();
+
+			idempotencyMiddleware(req2, res2, next2);
+
+			expect(next2).not.toHaveBeenCalled();
+			expect(res2.statusCode).toBe(200);
+			expect(res2.getHeader('Idempotency-Replay')).toBe('true');
+			expect(JSON.parse(res2._getData())).toEqual({
+				success: true,
+				details: 'body request processed',
+				idempotencyReplayed: true,
+			});
+		});
+
+		test('should normalize fingerprint and succeed for query-to-header location transition', () => {
+			const key = 'test-query-to-header';
+			req.query = { idempotency_key: key };
+			req.body = { text: 'my business alert' };
+
+			idempotencyMiddleware(req, res, next);
+			res.status(200).json({ success: true, details: 'query request processed' });
+
+			const req2 = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/webhook/alert',
+				headers: { 'idempotency-key': key },
+				body: { text: 'my business alert' },
+			});
+			const res2 = httpMocks.createResponse();
+			const next2 = jest.fn();
+
+			idempotencyMiddleware(req2, res2, next2);
+
+			expect(next2).not.toHaveBeenCalled();
+			expect(res2.statusCode).toBe(200);
+			expect(res2.getHeader('Idempotency-Replay')).toBe('true');
+			expect(JSON.parse(res2._getData())).toEqual({
+				success: true,
+				details: 'query request processed',
+				idempotencyReplayed: true,
+			});
+		});
+
+		test('should return 409 Conflict if business text payload changes for the same key', () => {
+			const key = 'test-payload-mismatch';
+			req.headers['idempotency-key'] = key;
+			req.body = { text: 'alert-a' };
+
+			idempotencyMiddleware(req, res, next);
+			res.status(200).json({ success: true });
+
+			const req2 = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/webhook/alert',
+				headers: { 'idempotency-key': key },
+				body: { text: 'alert-b' },
+			});
+			const res2 = httpMocks.createResponse();
+			const next2 = jest.fn();
+
+			idempotencyMiddleware(req2, res2, next2);
+
+			expect(next2).not.toHaveBeenCalled();
+			expect(res2.statusCode).toBe(409);
+			expect(JSON.parse(res2._getData())).toEqual({
+				error: 'Idempotency key was reused with a different payload',
+				code: 'IDEMPOTENCY_CONFLICT',
+			});
+		});
+
+		test('should return 409 Conflict if business query flags change for the same key', () => {
+			const key = 'test-query-mismatch';
+			req.headers['idempotency-key'] = key;
+			req.body = { text: 'alert-same' };
+			req.query = { useTradingViewData: 'true' };
+
+			idempotencyMiddleware(req, res, next);
+			res.status(200).json({ success: true });
+
+			const req2 = httpMocks.createRequest({
+				method: 'POST',
+				url: '/api/webhook/alert',
+				headers: { 'idempotency-key': key },
+				body: { text: 'alert-same' },
+				query: { useTradingViewData: 'false' },
+			});
+			const res2 = httpMocks.createResponse();
+			const next2 = jest.fn();
+
+			idempotencyMiddleware(req2, res2, next2);
+
+			expect(next2).not.toHaveBeenCalled();
+			expect(res2.statusCode).toBe(409);
+			expect(JSON.parse(res2._getData())).toEqual({
+				error: 'Idempotency key was reused with a different payload',
+				code: 'IDEMPOTENCY_CONFLICT',
+			});
+		});
 	});
 });


### PR DESCRIPTION
fix: normalize idempotency fingerprint to ignore transport keys (CB-31)

## Summary

Normalize the request fingerprint used for idempotency hashing to exclude key transport fields (`idempotencyKey` and `idempotency_key`) from request body and query. This prevents false 409 IDEMPOTENCY_CONFLICT responses when retries supply the same key via different supported locations.

## Key Changes

- Exclude `idempotencyKey` and `idempotency_key` fields from `body` and `query` when constructing the request fingerprint in `buildRequestFingerprint()`.
- Add comprehensive unit and regression tests in `tests/unit/idempotency.test.js` covering location transitions (header-to-body, body-to-header, query-to-header) and actual payload/query flag mismatch conflict checks.

## Technical Implementation

- Updated `buildRequestFingerprint` in `src/lib/idempotency.js` to create shallow copies of `req.body` and `req.query` and delete the `idempotencyKey` and `idempotency_key` keys if present, ensuring the resulting hash only reflects the business payloads.

## Testing

- Verified all unit and integration tests pass locally.
- Added 5 new regression test cases verifying successful location transitions and correct mismatch conflict detection.

## References

- **GitHub**: Closes #90
- **Linear**: [CB-31](https://linear.app/knil/issue/CB-31/fix-idempotency-conflicts-when-key-moves-between-supported-locations)
