### PR TITLE
fix: page admin on delivery failures (CB-33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 
 #### Admin Notifications
 
-- `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID` - Chat ID for admin notifications and deployment alerts
+- `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID` - Chat ID for deployment alerts and fail-open notification-channel failure pages
 
 #### Server Configuration
 

--- a/agents.md
+++ b/agents.md
@@ -857,6 +857,12 @@ ENABLE_FIRESTORE_ALERT_STORAGE (006)
 - Logging: Use existing `console.*` methods; the centralized logger formats every emitted log as structured JSON.
 - Admin notifications: Optional `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID` for failures
 
+### Notification delivery failure paging
+
+- `NotificationManager.sendToAll()` and `sendToChannels()` send one compact failure page to `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID` after any requested channel exhausts delivery retries.
+- The page lists failed/succeeded channels, provider errors, status/attempt metadata when available, and the request/correlation ID when present on the alert.
+- Admin paging calls `TelegramService.send()` directly instead of re-entering `NotificationManager`, so Telegram/admin delivery failures are logged but cannot recurse or change the original delivery results.
+
 **To extend**:
 1. **Discord integration**: Add in `src/services/notification/DiscordService.js`
 2. **Error aggregation**: Track error rates in memory for metrics

--- a/src/services/notification/NotificationManager.js
+++ b/src/services/notification/NotificationManager.js
@@ -207,7 +207,9 @@ class NotificationManager {
 			}
 		}
 
-		await this.notifyAdminOfFailures(alert, formattedResults);
+		void this.notifyAdminOfFailures(alert, formattedResults).catch((error) => {
+			console.error('[NotificationManager] Unexpected admin notification failure:', error.message);
+		});
 
 		console.info('[NotificationManager] Delivery results:', JSON.stringify(formattedResults.map(r => ({
 			channel: r.channel,
@@ -307,7 +309,9 @@ class NotificationManager {
 			}
 		}
 
-		await this.notifyAdminOfFailures(alert, formattedResults);
+		void this.notifyAdminOfFailures(alert, formattedResults).catch((error) => {
+			console.error('[NotificationManager] Unexpected admin notification failure:', error.message);
+		});
 
 		console.info('[NotificationManager] Delivery results:', JSON.stringify(formattedResults.map(r => ({
 			channel: r.channel,

--- a/src/services/notification/NotificationManager.js
+++ b/src/services/notification/NotificationManager.js
@@ -49,6 +49,55 @@ class NotificationManager {
 			.map((ch) => ch.name);
 	}
 
+	async notifyAdminOfFailures(alert, results) {
+		const failures = results.filter(result => !result.success);
+		if (failures.length === 0) {
+			return;
+		}
+
+		const adminChatId = process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID;
+		const telegramService = this.channels.get('telegram');
+		if (!adminChatId) {
+			console.warn('[NotificationManager] Admin chat is not configured; delivery failure notification skipped');
+			return;
+		}
+		if (!telegramService || !telegramService.isEnabled()) {
+			console.warn('[NotificationManager] Telegram is disabled; delivery failure notification skipped');
+			return;
+		}
+
+		const succeededChannels = results.filter(result => result.success).map(result => result.channel);
+		const failureDetails = failures.map((result) => {
+			const metadata = [
+				result.statusCode ? `status ${result.statusCode}` : null,
+				result.attemptCount ? `attempts ${result.attemptCount}` : null,
+			].filter(Boolean);
+			return `- ${result.channel}: ${result.error || 'Unknown error'}${metadata.length ? ` (${metadata.join(', ')})` : ''}`;
+		});
+		const requestId = alert && (alert.requestId || alert.correlationId);
+		const message = [
+			'Notification delivery failure',
+			`Failed channels: ${failures.map(result => result.channel).join(', ')}`,
+			`Succeeded channels: ${succeededChannels.length ? succeededChannels.join(', ') : 'none'}`,
+			...failureDetails,
+			...(requestId ? [`Request ID: ${requestId}`] : []),
+		].join('\n');
+
+		try {
+			const adminResult = await telegramService.send({
+				text: message,
+				telegramChatId: adminChatId,
+			});
+			if (adminResult && adminResult.success) {
+				console.info('[NotificationManager] Admin delivery failure notification sent');
+			} else {
+				console.error('[NotificationManager] Admin delivery failure notification failed:', adminResult && adminResult.error);
+			}
+		} catch (error) {
+			console.error('[NotificationManager] Admin delivery failure notification failed:', error.message);
+		}
+	}
+
 	/**
     * Send alert to specific channels by name, in parallel
     * @param {Object} alert - Alert object with text and optional enriched content
@@ -158,6 +207,8 @@ class NotificationManager {
 			}
 		}
 
+		await this.notifyAdminOfFailures(alert, formattedResults);
+
 		console.info('[NotificationManager] Delivery results:', JSON.stringify(formattedResults.map(r => ({
 			channel: r.channel,
 			success: r.success,
@@ -255,6 +306,8 @@ class NotificationManager {
 				});
 			}
 		}
+
+		await this.notifyAdminOfFailures(alert, formattedResults);
 
 		console.info('[NotificationManager] Delivery results:', JSON.stringify(formattedResults.map(r => ({
 			channel: r.channel,

--- a/tests/integration/alert-dual-channel.test.js
+++ b/tests/integration/alert-dual-channel.test.js
@@ -87,7 +87,12 @@ describe('Dual-Channel Alert Integration', () => {
 			expect(results.length).toBe(2);
 			expect(results[0].success).toBe(true); // Telegram succeeded
 			expect(results[1].success).toBe(false); // WhatsApp failed
-			expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+			expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(2);
+			expect(mockBot.telegram.sendMessage).toHaveBeenLastCalledWith(
+				process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID,
+				expect.stringContaining('Failed channels: whatsapp'),
+				expect.objectContaining({ parse_mode: 'MarkdownV2' }),
+			);
 		});
 
 		it('should return response with both channels regardless of success', async () => {

--- a/tests/integration/generic-message-webhook.test.js
+++ b/tests/integration/generic-message-webhook.test.js
@@ -337,7 +337,12 @@ describe('POST /api/webhook/message - Generic message webhook', () => {
 		// Overall success is still true (fail-open pattern)
 		expect(res.body.success).toBe(true);
 
-		expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+		expect(mockBot.telegram.sendMessage).toHaveBeenCalledTimes(2);
+		expect(mockBot.telegram.sendMessage).toHaveBeenLastCalledWith(
+			process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID,
+			expect.stringContaining('Failed channels: whatsapp'),
+			expect.objectContaining({ parse_mode: 'MarkdownV2' }),
+		);
 		// fetch is called multiple times due to WhatsApp retry logic
 		expect(global.fetch).toHaveBeenCalled();
 	});

--- a/tests/unit/notification-manager.test.js
+++ b/tests/unit/notification-manager.test.js
@@ -1,0 +1,114 @@
+const NotificationManager = require('../../src/services/notification/NotificationManager');
+
+describe('NotificationManager admin failure notifications', () => {
+	const originalAdminChatId = process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID;
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+		if (originalAdminChatId === undefined) {
+			delete process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID;
+		} else {
+			process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID = originalAdminChatId;
+		}
+	});
+
+	it('notifies the Telegram admin once when WhatsApp delivery fails', async () => {
+		process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID = '-100-admin';
+		const telegramService = {
+			name: 'telegram',
+			isEnabled: jest.fn(() => true),
+			send: jest.fn()
+				.mockResolvedValueOnce({ success: true, channel: 'telegram', messageId: 'alert-1' })
+				.mockResolvedValueOnce({ success: true, channel: 'telegram', messageId: 'admin-1' }),
+		};
+		const whatsappService = {
+			name: 'whatsapp',
+			isEnabled: jest.fn(() => true),
+			send: jest.fn().mockResolvedValue({
+				success: false,
+				channel: 'whatsapp',
+				error: 'GreenAPI 503: unavailable',
+				statusCode: 503,
+				attemptCount: 3,
+			}),
+		};
+		const manager = new NotificationManager(telegramService, whatsappService);
+
+		const results = await manager.sendToAll({ text: 'BTC alert', requestId: 'req-103' });
+
+		expect(results).toEqual([
+			{ success: true, channel: 'telegram', messageId: 'alert-1' },
+			{
+				success: false,
+				channel: 'whatsapp',
+				error: 'GreenAPI 503: unavailable',
+				statusCode: 503,
+				attemptCount: 3,
+			},
+		]);
+		expect(telegramService.send).toHaveBeenCalledTimes(2);
+		expect(telegramService.send).toHaveBeenLastCalledWith(expect.objectContaining({
+			telegramChatId: '-100-admin',
+			text: expect.stringContaining('Failed channels: whatsapp'),
+		}));
+		expect(telegramService.send.mock.calls[1][0].text).toContain('Succeeded channels: telegram');
+		expect(telegramService.send.mock.calls[1][0].text).toContain('Request ID: req-103');
+		expect(telegramService.send.mock.calls[1][0].text).toContain('status 503, attempts 3');
+	});
+
+	it('does not recurse or reject when Telegram and its admin notification fail', async () => {
+		process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID = '-100-admin';
+		jest.spyOn(console, 'error').mockImplementation(() => {});
+		const telegramService = {
+			name: 'telegram',
+			isEnabled: jest.fn(() => true),
+			send: jest.fn().mockResolvedValue({
+				success: false,
+				channel: 'telegram',
+				error: 'Telegram unavailable',
+			}),
+		};
+		const whatsappService = {
+			name: 'whatsapp',
+			isEnabled: jest.fn(() => true),
+			send: jest.fn().mockResolvedValue({ success: true, channel: 'whatsapp', messageId: 'wa-1' }),
+		};
+		const manager = new NotificationManager(telegramService, whatsappService);
+
+		await expect(manager.sendToAll({ text: 'BTC alert' })).resolves.toEqual([
+			{ success: false, channel: 'telegram', error: 'Telegram unavailable' },
+			{ success: true, channel: 'whatsapp', messageId: 'wa-1' },
+		]);
+		expect(telegramService.send).toHaveBeenCalledTimes(2);
+	});
+
+	it('notifies the Telegram admin when a selectively routed channel fails', async () => {
+		process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID = '-100-admin';
+		const telegramService = {
+			name: 'telegram',
+			isEnabled: jest.fn(() => true),
+			send: jest.fn().mockResolvedValue({ success: true, channel: 'telegram', messageId: 'admin-1' }),
+		};
+		const whatsappService = {
+			name: 'whatsapp',
+			isEnabled: jest.fn(() => true),
+			send: jest.fn().mockResolvedValue({
+				success: false,
+				channel: 'whatsapp',
+				error: 'GreenAPI unavailable',
+			}),
+		};
+		const manager = new NotificationManager(telegramService, whatsappService);
+
+		const results = await manager.sendToChannels({ text: 'BTC alert' }, ['whatsapp']);
+
+		expect(results).toEqual([
+			{ success: false, channel: 'whatsapp', error: 'GreenAPI unavailable' },
+		]);
+		expect(telegramService.send).toHaveBeenCalledTimes(1);
+		expect(telegramService.send).toHaveBeenCalledWith(expect.objectContaining({
+			telegramChatId: '-100-admin',
+			text: expect.stringContaining('Failed channels: whatsapp'),
+		}));
+	});
+});

--- a/tests/unit/notification-manager.test.js
+++ b/tests/unit/notification-manager.test.js
@@ -111,4 +111,41 @@ describe('NotificationManager admin failure notifications', () => {
 			text: expect.stringContaining('Failed channels: whatsapp'),
 		}));
 	});
+
+	it('returns delivery results without waiting for the admin notification', async () => {
+		process.env.TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID = '-100-admin';
+		let resolveAdminNotification;
+		const adminNotification = new Promise((resolve) => {
+			resolveAdminNotification = resolve;
+		});
+		const telegramService = {
+			name: 'telegram',
+			isEnabled: jest.fn(() => true),
+			send: jest.fn()
+				.mockResolvedValueOnce({ success: true, channel: 'telegram', messageId: 'alert-1' })
+				.mockReturnValueOnce(adminNotification),
+		};
+		const whatsappService = {
+			name: 'whatsapp',
+			isEnabled: jest.fn(() => true),
+			send: jest.fn().mockResolvedValue({
+				success: false,
+				channel: 'whatsapp',
+				error: 'GreenAPI unavailable',
+			}),
+		};
+		const manager = new NotificationManager(telegramService, whatsappService);
+		let deliverySettled = false;
+
+		const delivery = manager.sendToAll({ text: 'BTC alert' }).then((results) => {
+			deliverySettled = true;
+			return results;
+		});
+		await new Promise(setImmediate);
+		const settledBeforeAdmin = deliverySettled;
+		resolveAdminNotification({ success: true, channel: 'telegram', messageId: 'admin-1' });
+		await delivery;
+
+		expect(settledBeforeAdmin).toBe(true);
+	});
 });


### PR DESCRIPTION
## Summary

Notify the configured Telegram admin chat when a notification channel exhausts delivery retries, while preserving the original fail-open delivery results.

## Key Changes

- Page `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID` for failures from both broadcast and selectively routed deliveries.
- Include failed and successful channels, provider error details, status/attempt metadata, and request correlation when available.
- Call `TelegramService` directly so a failed admin page cannot recurse through `NotificationManager`.
- Dispatch admin paging asynchronously so a slow Telegram API cannot delay the fail-open webhook response.

## Technical Implementation

- Add centralized failure-page construction and dispatch in `NotificationManager`.
- Keep Sentry reporting and existing webhook response behavior unchanged.
- Log missing admin configuration, disabled Telegram, and admin delivery failures without throwing.
- Catch background admin paging failures to prevent unhandled promise rejections.

## Testing

- `pnpm test -- tests/unit/notification-manager.test.js tests/integration/graceful-degradation.test.js tests/integration/alert-dual-channel.test.js --runInBand --testTimeout=10000`
- `pnpm test`
- Regression coverage verifies delivery results settle while an admin notification remains pending.

## References

- **GitHub**: Closes #103
- **Linear**: [CB-33](https://linear.app/knil/issue/CB-33/notify-admin-chat-after-channel-delivery-failure)