### PR TITLE
fix: handle Gemini quota exhaustion in news monitor (CB-34)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,16 @@ NEWS_CACHE_TTL_HOURS=6
 # Each symbol has up to this long to complete analysis
 NEWS_TIMEOUT_MS=30000
 
+# Optional max concurrent Gemini-backed symbol analyses.
+# Leave unset to preserve legacy parallel fan-out.
+# NEWS_GEMINI_CONCURRENCY=3
+
+# Per-symbol retries for Gemini 429 RESOURCE_EXHAUSTED errors (default: 2)
+NEWS_GEMINI_QUOTA_MAX_RETRIES=2
+
+# Base exponential backoff in ms when Gemini does not provide retry metadata (default: 1000)
+NEWS_GEMINI_QUOTA_RETRY_BASE_MS=1000
+
 # ============================================================================
 # OPTIONAL: Binance Price Integration (News Monitoring)
 # ============================================================================

--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -535,7 +535,57 @@
 							"host": ["{{baseUrl}}"],
 							"path": ["api", "news-monitor"]
 						}
-					}
+					},
+					"response": [
+						{
+							"name": "200 OK - Analysis summary",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{ "key": "Content-Type", "value": "application/json", "type": "text" },
+									{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"crypto\": [\"BTCUSDT\", \"ETHUSD\"],\n  \"stocks\": [\"NVDA\", \"MSFT\"],\n  \"channels\": [\"telegram\"]\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/news-monitor",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "news-monitor"]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [{ "key": "Content-Type", "value": "application/json" }],
+							"body": "{\n  \"success\": true,\n  \"results\": [\n    {\n      \"symbol\": \"BTCUSDT\",\n      \"status\": \"analyzed\",\n      \"alert\": null,\n      \"cached\": false,\n      \"requestId\": \"req-abc123\",\n      \"totalDurationMs\": 800\n    }\n  ],\n  \"summary\": {\n    \"total\": 1,\n    \"analyzed\": 1,\n    \"cached\": 0,\n    \"timeout\": 0,\n    \"error\": 0,\n    \"quota_exhausted\": 0,\n    \"alerts_sent\": 0\n  },\n  \"requestedChannels\": [\"telegram\"],\n  \"deliveredChannels\": [],\n  \"totalDurationMs\": 850,\n  \"requestId\": \"req-abc123\",\n  \"tokenUsage\": {\n    \"inputTokens\": 10,\n    \"outputTokens\": 20,\n    \"totalTokens\": 30\n  }\n}"
+						},
+						{
+							"name": "200 OK - Partial quota exhaustion",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{ "key": "Content-Type", "value": "application/json", "type": "text" },
+									{ "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"crypto\": [\"BTCUSDT\", \"ETHUSD\"]\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/news-monitor",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "news-monitor"]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [{ "key": "Content-Type", "value": "application/json" }],
+							"body": "{\n  \"success\": true,\n  \"partial_success\": true,\n  \"results\": [\n    {\n      \"symbol\": \"BTCUSDT\",\n      \"status\": \"error\",\n      \"error\": {\n        \"code\": \"GEMINI_QUOTA_EXHAUSTED\",\n        \"message\": \"429 RESOURCE_EXHAUSTED: quota exceeded\"\n      },\n      \"cached\": false,\n      \"requestId\": \"req-quota123\",\n      \"totalDurationMs\": 0\n    },\n    {\n      \"symbol\": \"ETHUSD\",\n      \"status\": \"analyzed\",\n      \"alert\": null,\n      \"cached\": false,\n      \"requestId\": \"req-quota123\",\n      \"totalDurationMs\": 900\n    }\n  ],\n  \"summary\": {\n    \"total\": 2,\n    \"analyzed\": 1,\n    \"cached\": 0,\n    \"timeout\": 0,\n    \"error\": 1,\n    \"quota_exhausted\": 1,\n    \"alerts_sent\": 0\n  },\n  \"requestedChannels\": [\"telegram\", \"whatsapp\"],\n  \"deliveredChannels\": [],\n  \"totalDurationMs\": 950,\n  \"requestId\": \"req-quota123\",\n  \"tokenUsage\": {}\n}"
+						}
+					]
 				},
 				{
 					"name": "GET News Monitor",

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 - `NEWS_ALERT_THRESHOLD` - Confidence score threshold for sending alerts (default: `0.7`, range 0.0-1.0)
 - `NEWS_CACHE_TTL_HOURS` - Cache time-to-live for deduplication (default: `6` hours)
 - `NEWS_TIMEOUT_MS` - Per-symbol analysis timeout (default: `30000` ms)
+- `NEWS_GEMINI_CONCURRENCY` - Optional max concurrent Gemini-backed symbol analyses. Unset keeps legacy parallel fan-out.
+- `NEWS_GEMINI_QUOTA_MAX_RETRIES` - Max per-symbol retries for Gemini `429 RESOURCE_EXHAUSTED` errors (default: `2`)
+- `NEWS_GEMINI_QUOTA_RETRY_BASE_MS` - Base exponential backoff when Gemini does not provide retry delay metadata (default: `1000` ms)
 - `ENABLE_BINANCE_PRICE_CHECK` - Enable Binance crypto price fetching (`true` or `false`, default: `false`)
 - `ENABLE_LLM_ALERT_ENRICHMENT` - Enable optional secondary LLM enrichment (`true` or `false`, default: `false`)
 - `AZURE_LLM_ENDPOINT` - Azure AI Inference endpoint URL (required if enrichment enabled)
@@ -375,16 +378,12 @@ GET /api/news-monitor?crypto=BTCUSDT,ETHUSD&stocks=NVDA,MSFT
     {
       "symbol": "BTCUSDT",
       "status": "analyzed",
-      "alerts": [
-        {
-          "eventCategory": "price_surge",
-          "headline": "Bitcoin breaks $45,000 on positive market sentiment",
-          "confidence": 0.85,
-          "sentiment": 0.8,
-          "sources": ["Reuters", "CoinDesk"],
-          "message": "BTCUSDT: Price surge detected (+8.5%) with positive market sentiment (confidence: 0.85). Sources: Reuters, CoinDesk"
-        }
-      ],
+      "alert": {
+        "eventCategory": "price_surge",
+        "headline": "Bitcoin breaks $45,000 on positive market sentiment",
+        "confidence": 0.85,
+        "sources": ["Reuters", "CoinDesk"]
+      },
       "deliveryResults": [
         {
           "channel": "telegram",
@@ -399,23 +398,33 @@ GET /api/news-monitor?crypto=BTCUSDT,ETHUSD&stocks=NVDA,MSFT
       ],
       "totalDurationMs": 2847,
       "cached": false,
-      "enrichment": {
-        "applied": true,
-        "originalConfidence": 0.80,
-        "enrichedConfidence": 0.85,
-        "reasoning": "Secondary LLM confirms price surge with bullish indicators"
-      }
+      "requestId": "req-abc123def456"
     },
     {
       "symbol": "NVDA",
       "status": "cached",
-      "alerts": [],
+      "alert": null,
       "cached": true,
-      "cacheHitTime": "2025-10-31T15:30:00Z"
+      "requestId": "req-abc123def456"
     }
   ],
+  "summary": {
+    "total": 2,
+    "analyzed": 1,
+    "cached": 1,
+    "timeout": 0,
+    "error": 0,
+    "quota_exhausted": 0,
+    "alerts_sent": 1
+  },
+  "requestedChannels": ["telegram", "whatsapp"],
+  "deliveredChannels": ["telegram", "whatsapp"],
   "totalDurationMs": 5234,
-  "partialSuccess": false
+  "tokenUsage": {
+    "inputTokens": 120,
+    "outputTokens": 80,
+    "totalTokens": 200
+  }
 }
 ```
 
@@ -429,7 +438,7 @@ GET /api/news-monitor?crypto=BTCUSDT,ETHUSD&stocks=NVDA,MSFT
 - `analyzed` - Symbol successfully analyzed, alerts generated/filtered
 - `cached` - Result returned from cache (within TTL for same event category)
 - `timeout` - Analysis exceeded per-symbol timeout (30s default)
-- `error` - API failure (Binance, Gemini, or other service error)
+- `error` - API failure (Binance, Gemini, or other service error). Gemini quota exhaustion is reported as `error.code = "GEMINI_QUOTA_EXHAUSTED"` and counted in `summary.quota_exhausted`.
 
 ### POST /api/webhook/expanded-analysis-alert
 

--- a/agents.md
+++ b/agents.md
@@ -512,14 +512,14 @@ The system provides an HTTP endpoint (`/api/news-monitor`) that analyzes financi
 
 **Alert Flow**:
 1. Endpoint receives request with crypto and stock symbol arrays (or defaults from `NEWS_SYMBOLS_CRYPTO`/`NEWS_SYMBOLS_STOCKS` env vars)
-2. Symbols analyzed in parallel; each symbol has 30s timeout budget
+2. Symbols analyzed in parallel; each symbol has 30s timeout budget. `NEWS_GEMINI_CONCURRENCY` can cap concurrent Gemini-backed symbol analyses to reduce provider quota bursts; unset preserves legacy full fan-out.
 3. Gemini extracts market context and sentiment; confidence score calculated: `confidence = (0.6 × event_significance + 0.4 × |sentiment|)`
 4. Optional LLM enrichment (if `ENABLE_LLM_ALERT_ENRICHMENT=true`) refines confidence using conservative strategy: `min(gemini_confidence, llm_confidence)`
 5. Alerts filtered by `NEWS_ALERT_THRESHOLD` (default: 0.7)
 6. Deduplicated: cache key is `(symbol, event_category)`. Same category within TTL prevents duplicate alerts; different categories generate separate alerts
 7. **URL shortening applied to WhatsApp citations** (if `URL_SHORTENER_SERVICE` configured): Uses prettylink for supported services, direct API calls for unsupported; falls back to title-only if shortening fails
 8. Filtered alerts sent to all enabled channels (Telegram, WhatsApp) via existing NotificationManager in parallel
-9. Returns 200 OK with per-symbol results: status (analyzed/cached/timeout/error), detected alerts, delivery results, metadata (totalDurationMs, cached, requestId)
+9. Returns 200 OK with per-symbol results: status (analyzed/cached/timeout/error), detected alerts, delivery results, metadata (totalDurationMs, cached, requestId), and summary counters including `quota_exhausted` for exhausted Gemini 429 retries.
 
 **Configuration**:
 - `ENABLE_NEWS_MONITOR` — Feature flag (default: false for safe rollout)
@@ -528,6 +528,9 @@ The system provides an HTTP endpoint (`/api/news-monitor`) that analyzes financi
 - `NEWS_ALERT_THRESHOLD` — Confidence score threshold (default: 0.7, range 0.0-1.0)
 - `NEWS_CACHE_TTL_HOURS` — Cache time-to-live (default: 6 hours)
 - `NEWS_TIMEOUT_MS` — Per-symbol analysis timeout (default: 30000 ms)
+- `NEWS_GEMINI_CONCURRENCY` — Optional max concurrent Gemini-backed symbol analyses. Leave unset to preserve legacy full fan-out.
+- `NEWS_GEMINI_QUOTA_MAX_RETRIES` — Per-symbol retry count for Gemini `429 RESOURCE_EXHAUSTED` errors (default: 2)
+- `NEWS_GEMINI_QUOTA_RETRY_BASE_MS` — Base exponential backoff in milliseconds when provider retry metadata is absent (default: 1000)
 - `ENABLE_BINANCE_PRICE_CHECK` — Enable Binance crypto price fetching (default: false)
 - `ENABLE_LLM_ALERT_ENRICHMENT` — Enable optional secondary LLM enrichment (default: false)
 - `URL_SHORTENER_SERVICE` — URL shortening service for WhatsApp citations (default: 'bitly', options: 'bitly', 'tinyurl', 'picsee', 'reurl', 'cuttly', 'pixnet0rz.tw')
@@ -542,9 +545,9 @@ The system provides an HTTP endpoint (`/api/news-monitor`) that analyzes financi
 - Per-symbol total: 30s (accounts for worst-case retry scenarios with exponential backoff)
 - Batch response: waits up to 30s total; returns partial results if some symbols timeout
 
-**Retry Logic** (reuses `src/lib/retryHelper.js`):
+**Retry Logic**:
 - Binance: 3 retries with exponential backoff (1s, 2s, 4s) + ±10% jitter
-- Gemini: 3 retries with exponential backoff
+- Gemini news analysis: retries `429 RESOURCE_EXHAUSTED` per symbol inside `NEWS_TIMEOUT_MS`, honoring provider retry delay metadata when present and returning `GEMINI_QUOTA_EXHAUSTED` when exhausted
 - Optional LLM enrichment: 3 retries (independent from analysis; failure doesn't block alert)
 - URL shortening: 3 retries with exponential backoff (independent; failure falls back to title-only)
 - Telegram/WhatsApp: 3 retries (reuse existing notification retry logic)
@@ -700,7 +703,7 @@ See `/specs/TERMINOLOGY_GUIDE.md` for extended discussion and examples.
 - 001-gemini-grounding-alert (improvements with PR #21, #20, #19): Added Gemini GoogleSearch grounding integration for alert enrichment; added Brave Search fallback/override; introduced provider routing (Gemini/Azure/OpenRouter); added token usage + cost estimation surfaced in notifications; graceful degradation on API failure; single grounding call reused across channels.
 - 002-whatsapp-alerts: Added multi-channel notification system with TelegramService, WhatsAppService, NotificationManager; exponential backoff retry logic; MarkdownV2 and WhatsApp markdown formatters; comprehensive integration tests for parallel delivery, config validation, graceful degradation.
 - issue #91 / branch `codex/fix-91-whatsapp-truncation`: WhatsApp delivery now splits GreenAPI payloads above the provider limit into sequential chunks instead of silently truncating with an ellipsis; regression coverage added for long alert payloads.
-- 003-news-monitor (improvement with PR #18): Added `/api/news-monitor` endpoint for financial news analysis and sentiment-based alerts; Gemini GoogleSearch integration for market context; optional secondary LLM enrichment via Azure AI Inference (migrated to `@azure-rest/ai-inference`); in-memory deduplication cache; optional Binance price integration; parallel symbol analysis with timeout management; configurable event detection; URL shortening for WhatsApp citations.
+- 003-news-monitor (improvement with PR #18; CB-34): Added `/api/news-monitor` endpoint for financial news analysis and sentiment-based alerts; Gemini GoogleSearch integration for market context; optional secondary LLM enrichment via Azure AI Inference (migrated to `@azure-rest/ai-inference`); in-memory deduplication cache; optional Binance price integration; parallel symbol analysis with timeout management; configurable Gemini concurrency and quota-exhaustion retries; configurable event detection; URL shortening for WhatsApp citations.
 - 004-enrich-alert-output: Enriched `/api/webhook/alert` output with structured fields (sentiment, insights, technical levels) using the existing grounding pipeline; Telegram/WhatsApp formatters render structured enrichment when present.
 - 005-sentry-runtime-errors (PR #16): Added runtime error monitoring via `SentryService` + early initialization in `instrument.js`, plus Express error handler wiring; monitoring is gated by `ENABLE_SENTRY` + `SENTRY_DSN`.
 - 006-firestore-alert-storage: Added Cloud Firestore persistence for every `/api/webhook/alert` payload; `firebase-admin` singleton initialized from `FIREBASE_SERVICE_ACCOUNT_JSON` or `GOOGLE_APPLICATION_CREDENTIALS`; fire-and-forget after `res.json()` so storage never blocks delivery (fail-open).

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -160,13 +160,14 @@ class NewsAnalyzer {
 		const limit = Math.min(this.geminiConcurrency, symbols.length);
 		const results = [];
 		let nextIndex = 0;
+		const batchStartedAt = Date.now();
 
 		const runNext = async () => {
 			while (nextIndex < symbols.length) {
 				const currentIndex = nextIndex;
 				nextIndex += 1;
 				const symbol = symbols[currentIndex];
-				results[currentIndex] = await this.analyzeSymbol(symbol, requestId, tokenUsage, routing).catch(error => ({
+				results[currentIndex] = await this.analyzeSymbol(symbol, requestId, tokenUsage, routing, batchStartedAt).catch(error => ({
 					symbol,
 					status: AnalysisStatus.ERROR,
 					error: {
@@ -241,8 +242,8 @@ class NewsAnalyzer {
    * @param {string} requestId - Correlation ID
    * @returns {Promise<Object>} AnalysisResult object
    */
-	async analyzeSymbol(symbol, requestId, tokenUsage, routing = {}) {
-		const startTime = Date.now();
+	async analyzeSymbol(symbol, requestId, tokenUsage, routing = {}, startedAt = Date.now()) {
+		const startTime = startedAt;
 		const analysis = {
 			symbol,
 			status: AnalysisStatus.ANALYZED,
@@ -509,6 +510,7 @@ class NewsAnalyzer {
 			const priceSearchPromise = genaiClient.search({
 				query: priceQuery,
 				maxResults: 3,
+				rethrowQuotaErrors: true,
 			});
 
 			const priceSearchResult = await Promise.race([priceSearchPromise, timeoutPromise]);

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -113,14 +113,14 @@ function getQuotaRetryDelayMs(error, attempt, baseDelayMs) {
 	}
 
 	const message = String((error && error.message) || '');
-	const retryDelayMatch = message.match(/retry(?:\s|-)?delay[:=]?\s*(\d+(?:\.\d+)?)\s*(ms|s)?/i);
+	const retryDelayMatch = message.match(/"?retry(?:\s|-)?delay"?\s*[:=]?\s*"?(\d+(?:\.\d+)?)(ms|s)?"?/i);
 	if (retryDelayMatch) {
 		const value = Number.parseFloat(retryDelayMatch[1]);
 		const unit = (retryDelayMatch[2] || 'ms').toLowerCase();
 		return unit === 's' ? value * 1000 : value;
 	}
 
-	const retryAfterMatch = message.match(/retry-after[:=]?\s*(\d+(?:\.\d+)?)\s*(ms|s)?/i);
+	const retryAfterMatch = message.match(/"?retry-after"?\s*[:=]?\s*"?(\d+(?:\.\d+)?)(ms|s)?"?/i);
 	if (retryAfterMatch) {
 		const value = Number.parseFloat(retryAfterMatch[1]);
 		const unit = (retryAfterMatch[2] || 's').toLowerCase();

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -89,6 +89,51 @@ function shouldRedeliverCachedAlertForRequest(notificationMgr, cachedEntry = {},
 	return shouldRedeliverCachedAlert(notificationMgr, cachedEntry.deliveryResults, routing);
 }
 
+function parsePositiveInteger(value, fallback) {
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isGeminiQuotaError(error) {
+	const status = Number(error && (error.status || error.statusCode || error.code));
+	if (status === 429) {
+		return true;
+	}
+
+	const message = String((error && error.message) || '').toUpperCase();
+	return message.includes('429') ||
+		message.includes('RESOURCE_EXHAUSTED') ||
+		message.includes('QUOTA');
+}
+
+function getQuotaRetryDelayMs(error, attempt, baseDelayMs) {
+	const retryDelay = error && (error.retryDelay || error.retryAfter || error.retryDelayMs);
+	if (typeof retryDelay === 'number' && retryDelay >= 0) {
+		return retryDelay;
+	}
+
+	const message = String((error && error.message) || '');
+	const retryDelayMatch = message.match(/retry(?:\s|-)?delay[:=]?\s*(\d+(?:\.\d+)?)\s*(ms|s)?/i);
+	if (retryDelayMatch) {
+		const value = Number.parseFloat(retryDelayMatch[1]);
+		const unit = (retryDelayMatch[2] || 'ms').toLowerCase();
+		return unit === 's' ? value * 1000 : value;
+	}
+
+	const retryAfterMatch = message.match(/retry-after[:=]?\s*(\d+(?:\.\d+)?)\s*(ms|s)?/i);
+	if (retryAfterMatch) {
+		const value = Number.parseFloat(retryAfterMatch[1]);
+		const unit = (retryAfterMatch[2] || 's').toLowerCase();
+		return unit === 'ms' ? value : value * 1000;
+	}
+
+	return baseDelayMs * (2 ** Math.max(0, attempt - 1));
+}
+
+function sleep(ms) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 class NewsAnalyzer {
 	constructor() {
 		this.cache = getCacheInstance();
@@ -99,6 +144,9 @@ class NewsAnalyzer {
 		this.timeout = parseInt(process.env.NEWS_TIMEOUT_MS || 60000);
 		this.alertThreshold = parseFloat(process.env.NEWS_ALERT_THRESHOLD || 0.7);
 		this.enableBinance = process.env.ENABLE_BINANCE_PRICE_CHECK === 'true';
+		this.geminiConcurrency = parsePositiveInteger(process.env.NEWS_GEMINI_CONCURRENCY, Infinity);
+		this.geminiQuotaMaxRetries = parsePositiveInteger(process.env.NEWS_GEMINI_QUOTA_MAX_RETRIES, 2);
+		this.geminiQuotaRetryBaseMs = parsePositiveInteger(process.env.NEWS_GEMINI_QUOTA_RETRY_BASE_MS, 1000);
 	}
 
 	/**
@@ -109,39 +157,81 @@ class NewsAnalyzer {
    * @returns {Promise<Object[]>} Array of AnalysisResult objects
    */
 	async analyzeSymbols(symbols, requestId, tokenUsage, routing = {}) {
-		const analysisPromises = symbols.map(symbol =>
-			this.analyzeSymbol(symbol, requestId, tokenUsage, routing).catch(error => ({
-				symbol,
-				status: AnalysisStatus.ERROR,
-				error: {
-					code: 'ANALYSIS_ERROR',
-					message: error.message,
-				},
-				totalDurationMs: 0,
-				cached: false,
-				requestId,
-			})),
-		);
+		const limit = Math.min(this.geminiConcurrency, symbols.length);
+		const results = [];
+		let nextIndex = 0;
 
-		// Use Promise.allSettled to continue even if some fail
-		const results = await Promise.allSettled(analysisPromises);
-
-		return results.map(result => {
-			if (result.status === 'fulfilled') {
-				return result.value;
+		const runNext = async () => {
+			while (nextIndex < symbols.length) {
+				const currentIndex = nextIndex;
+				nextIndex += 1;
+				const symbol = symbols[currentIndex];
+				results[currentIndex] = await this.analyzeSymbol(symbol, requestId, tokenUsage, routing).catch(error => ({
+					symbol,
+					status: AnalysisStatus.ERROR,
+					error: {
+						code: isGeminiQuotaError(error) ? 'GEMINI_QUOTA_EXHAUSTED' : 'ANALYSIS_ERROR',
+						message: error.message,
+					},
+					totalDurationMs: 0,
+					cached: false,
+					requestId,
+				}));
 			}
-			// Should not happen due to catch above, but handle just in case
-			return {
-				status: AnalysisStatus.ERROR,
-				error: {
-					code: 'UNKNOWN_ERROR',
-					message: (result.reason && result.reason.message) || 'Unknown error',
-				},
-				totalDurationMs: 0,
-				cached: false,
-				requestId,
-			};
-		});
+		};
+
+		await Promise.all(Array.from({ length: limit }, runNext));
+
+		return results;
+	}
+
+	async runSymbolAnalysisWithRetry(symbol, requestId, tokenUsage, routing, startedAt) {
+		let attempt = 0;
+		let lastQuotaError = null;
+
+		while (attempt <= this.geminiQuotaMaxRetries) {
+			let timeoutHandle;
+			const elapsedMs = Date.now() - startedAt;
+			const remainingMs = this.timeout - elapsedMs;
+			if (remainingMs <= 0) {
+				throw new Error('TIMEOUT');
+			}
+
+			try {
+				const timeoutPromise = new Promise((_, reject) => {
+					timeoutHandle = setTimeout(() => reject(new Error('TIMEOUT')), remainingMs);
+				});
+				return await Promise.race([
+					this.analyzeSymbolInternal(symbol, requestId, tokenUsage, routing),
+					timeoutPromise,
+				]);
+			} catch (error) {
+				if (!isGeminiQuotaError(error) || attempt >= this.geminiQuotaMaxRetries) {
+					throw error;
+				}
+
+				lastQuotaError = error;
+				attempt += 1;
+				const delayMs = getQuotaRetryDelayMs(error, attempt, this.geminiQuotaRetryBaseMs);
+				const remainingAfterAttemptMs = this.timeout - (Date.now() - startedAt);
+				if (delayMs >= remainingAfterAttemptMs) {
+					console.warn('[Analyzer] Gemini quota retry skipped; delay exceeds remaining budget:', symbol);
+					throw lastQuotaError;
+				}
+
+				console.warn('[Analyzer] Gemini quota exhausted, retrying symbol analysis:', {
+					symbol,
+					attempt,
+					delayMs,
+					remainingMs: remainingAfterAttemptMs,
+				});
+				await sleep(delayMs);
+			} finally {
+				clearTimeout(timeoutHandle);
+			}
+		}
+
+		throw lastQuotaError;
 	}
 
 	/**
@@ -163,10 +253,7 @@ class NewsAnalyzer {
 
 		try {
 			// Attempt to run analysis with timeout
-			const result = await Promise.race([
-				this.analyzeSymbolInternal(symbol, requestId, tokenUsage, routing),
-				this.timeoutPromise(this.timeout),
-			]);
+			const result = await this.runSymbolAnalysisWithRetry(symbol, requestId, tokenUsage, routing, startTime);
 
 			return {
 				...analysis,

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -429,6 +429,9 @@ class NewsAnalyzer {
 		try {
 			return await this.fetchGeminiPrice(symbol, tokenUsage);
 		} catch (error) {
+			if (isGeminiQuotaError(error)) {
+				throw error;
+			}
 			console.warn('[Analyzer] Price context fetch failed:', error.message);
 			return null;
 		}
@@ -488,11 +491,11 @@ class NewsAnalyzer {
 
 		const genaiClient = require('../../../../services/grounding/genaiClient');
 		let { price, change24h } = { price: null, change24h: null };
+		let timeoutHandle;
 
 		try {
 			// Timeout wrapper (~20s for Gemini)
 			const timeoutMs = 30000;
-			let timeoutHandle;
 			const timeoutPromise = new Promise((_, reject) => {
 				timeoutHandle = setTimeout(() => reject(new Error('Gemini fetch timeout')), timeoutMs);
 			});
@@ -554,8 +557,13 @@ class NewsAnalyzer {
 				sources: priceSearchResultParsed.sources || [],
 			};
 		} catch (error) {
+			if (isGeminiQuotaError(error)) {
+				throw error;
+			}
 			console.warn(`[Analyzer] Gemini price fetch failed for ${symbol}: ${error.message}`);
 			return null;
+		} finally {
+			clearTimeout(timeoutHandle);
 		}
 	}
 

--- a/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/newsMonitor.js
@@ -104,13 +104,18 @@ class NewsMonitorHandler {
 			});
 
 			let results;
+			let summary;
 			try {
 				results = await this.analyzer.analyzeSymbols(symbolsToAnalyze, requestId, tokenUsage, routing);
+				summary = this.generateSummary(results);
+				if (analysisSpan && typeof analysisSpan.setAttribute === 'function') {
+					analysisSpan.setAttribute('news.quota_exhausted', summary.quota_exhausted);
+					analysisSpan.setAttribute('news.error_count', summary.error);
+				}
 			} finally {
 				sentryService.endSpan(analysisSpan);
 			}
 
-			const summary = this.generateSummary(results);
 			const notificationManagerForResponse = getNotificationManager();
 			const response = {
 				success: summary.analyzed > 0 || summary.cached > 0,
@@ -264,6 +269,7 @@ class NewsMonitorHandler {
 			cached: 0,
 			timeout: 0,
 			error: 0,
+			quota_exhausted: 0,
 			alerts_sent: 0,
 		};
 
@@ -282,6 +288,9 @@ class NewsMonitorHandler {
 				summary.timeout++;
 			} else if (result.status === AnalysisStatus.ERROR) {
 				summary.error++;
+				if (result.error && result.error.code === 'GEMINI_QUOTA_EXHAUSTED') {
+					summary.quota_exhausted++;
+				}
 			}
 		}
 

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -185,13 +185,13 @@
       "get": {
         "tags": ["News"], "summary": "Analyze configured or queried market symbols", "operationId": "getNewsMonitor",
         "parameters": [{ "$ref": "#/components/parameters/CryptoSymbols" }, { "$ref": "#/components/parameters/StockSymbols" }],
-        "responses": { "200": { "$ref": "#/components/responses/AnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" } },
+        "responses": { "200": { "$ref": "#/components/responses/NewsMonitorAnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       },
       "post": {
         "tags": ["News"], "summary": "Analyze market symbols from a JSON request", "operationId": "postNewsMonitor",
         "requestBody": { "$ref": "#/components/requestBodies/NewsMonitor" },
-        "responses": { "200": { "$ref": "#/components/responses/AnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" } },
+        "responses": { "200": { "$ref": "#/components/responses/NewsMonitorAnalysisResult" }, "400": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
     },
@@ -253,6 +253,7 @@
       "JsonResult": { "description": "Successful JSON response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonObject" } } } },
       "DeliveryResult": { "description": "Per-channel delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DeliveryResult" }, "example": { "success": true, "results": [{ "channel": "telegram", "success": true }] } } } },
       "AnalysisResult": { "description": "Analysis and delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonObject" } } } },
+      "NewsMonitorAnalysisResult": { "description": "News monitor analysis and delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NewsMonitorResponse" } } } },
       "AlertList": { "description": "Stored alert page", "content": { "application/json": { "schema": { "type": "object", "properties": { "alerts": { "type": "array", "items": { "$ref": "#/components/schemas/JsonObject" } }, "nextCursor": { "type": ["string", "null"] } } } } } },
       "JobResult": { "description": "Asynchronous job state", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Job" } } } },
       "StatusResult": { "description": "Non-sensitive runtime readiness", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Status" } } } }
@@ -280,6 +281,32 @@
       "ScannerPresetRequest": { "type": "object", "required": ["name"], "properties": { "name": { "type": "string", "minLength": 1 }, "exchange": { "type": "string" }, "timeframe": { "type": "string" }, "scans": { "type": "array", "items": { "type": "string" } }, "limit": { "type": "integer", "minimum": 1, "maximum": 20 }, "bbw_threshold": { "type": "number" } } },
       "TradingViewJobRequest": { "oneOf": [{ "allOf": [{ "type": "object", "required": ["type"], "properties": { "type": { "const": "expanded-analysis" } } }, { "$ref": "#/components/schemas/ExpandedAnalysisRequest" }] }, { "allOf": [{ "type": "object", "required": ["type"], "properties": { "type": { "const": "market-scanner" } } }, { "$ref": "#/components/schemas/MarketScannerRequest" }] }] },
       "NewsMonitorRequest": { "type": "object", "properties": { "crypto": { "type": "array", "items": { "type": "string" } }, "stocks": { "type": "array", "items": { "type": "string" } }, "channels": { "type": "array", "minItems": 1, "items": { "type": "string", "enum": ["telegram", "whatsapp"] } }, "telegramChatId": { "type": "string", "minLength": 1 }, "whatsappChatId": { "type": "string", "minLength": 1 } } },
+      "NewsMonitorResponse": {
+        "type": "object",
+        "required": ["success", "results", "summary", "requestId"],
+        "properties": {
+          "success": { "type": "boolean" },
+          "partial_success": { "type": "boolean" },
+          "results": { "type": "array", "items": { "$ref": "#/components/schemas/JsonObject" } },
+          "summary": {
+            "type": "object",
+            "properties": {
+              "total": { "type": "integer" },
+              "analyzed": { "type": "integer" },
+              "cached": { "type": "integer" },
+              "timeout": { "type": "integer" },
+              "error": { "type": "integer" },
+              "quota_exhausted": { "type": "integer", "description": "Number of symbols that exhausted Gemini 429 RESOURCE_EXHAUSTED retries." },
+              "alerts_sent": { "type": "integer" }
+            }
+          },
+          "requestedChannels": { "type": "array", "items": { "type": "string" } },
+          "deliveredChannels": { "type": "array", "items": { "type": "string" } },
+          "totalDurationMs": { "type": "integer" },
+          "requestId": { "type": "string" },
+          "tokenUsage": { "$ref": "#/components/schemas/JsonObject" }
+        }
+      },
       "DeliveryResult": { "type": "object", "properties": { "success": { "type": "boolean" }, "results": { "type": "array", "items": { "type": "object", "properties": { "channel": { "type": "string" }, "success": { "type": "boolean" }, "error": { "type": "string" } } } }, "enriched": { "type": "boolean" }, "tokenUsage": { "$ref": "#/components/schemas/JsonObject" }, "requestedChannels": { "type": "array", "items": { "type": "string" } }, "deliveredChannels": { "type": "array", "items": { "type": "string" } } } },
       "Job": { "type": "object", "properties": { "success": { "type": "boolean" }, "jobId": { "type": "string", "format": "uuid" }, "status": { "type": "string", "enum": ["pending", "processing", "completed", "failed", "canceled"] }, "progress": { "$ref": "#/components/schemas/JsonObject" }, "result": { "$ref": "#/components/schemas/JsonObject" } } },
       "Status": { "type": "object", "properties": { "service": { "$ref": "#/components/schemas/JsonObject" }, "featureFlags": { "$ref": "#/components/schemas/JsonObject" }, "deliveryChannels": { "$ref": "#/components/schemas/JsonObject" }, "dependencies": { "$ref": "#/components/schemas/JsonObject" } } }

--- a/src/services/grounding/gemini.js
+++ b/src/services/grounding/gemini.js
@@ -151,6 +151,7 @@ async function analyzeNewsForSymbol(symbol, context, options = {}) {
 		const searchResult = await genaiClient.search({
 			query: searchQuery,
 			maxResults: 3,
+			rethrowQuotaErrors: true,
 		});
 		if (tokenUsage && searchResult.usage) {
 			tokenUsage.addUsage(searchResult.usage, GROUNDING_MODEL_NAME);

--- a/src/services/grounding/genaiClient.js
+++ b/src/services/grounding/genaiClient.js
@@ -18,6 +18,18 @@ const { getOpenRouterClient } = require('../inference/openRouterClient');
 const { normalizeUsageMetadata } = require('../../lib/tokenUsage');
 const sentryService = require('../monitoring/SentryService');
 
+function isGeminiQuotaError(error) {
+	const status = Number(error && (error.status || error.statusCode || error.code));
+	if (status === 429) {
+		return true;
+	}
+
+	const message = String((error && error.message) || '').toUpperCase();
+	return message.includes('429') ||
+		message.includes('RESOURCE_EXHAUSTED') ||
+		message.includes('QUOTA');
+}
+
 /**
  * Error class for non-retryable provider configuration failures.
  * Thrown when an LLM provider returns a known permanent error
@@ -225,6 +237,9 @@ class GenaiClient {
 			}
 			console.warn('[genaiClient] Google Search returned no results. Falling back to Brave Search.');
 		} catch (error) {
+			if (isGeminiQuotaError(error)) {
+				throw error;
+			}
 			console.warn(`[genaiClient] Google Search failed: ${error.message}. Falling back to Brave Search.`);
 		}
 

--- a/src/services/grounding/genaiClient.js
+++ b/src/services/grounding/genaiClient.js
@@ -201,7 +201,7 @@ class GenaiClient {
 		};
 	}
 
-	async search({ query, model = GROUNDING_MODEL_NAME, maxResults = 3, textWithCitations = false }) {
+	async search({ query, model = GROUNDING_MODEL_NAME, maxResults = 3, textWithCitations = false, rethrowQuotaErrors = false }) {
 		if (ENABLE_NEWS_MONITOR_TEST_MODE) {
 			console.debug('[genaiClient] News Monitor Test Mode enabled - returning mock search results');
 			return {
@@ -237,7 +237,7 @@ class GenaiClient {
 			}
 			console.warn('[genaiClient] Google Search returned no results. Falling back to Brave Search.');
 		} catch (error) {
-			if (isGeminiQuotaError(error)) {
+			if (rethrowQuotaErrors && isGeminiQuotaError(error)) {
 				throw error;
 			}
 			console.warn(`[genaiClient] Google Search failed: ${error.message}. Falling back to Brave Search.`);

--- a/tests/unit/analyzer.test.js
+++ b/tests/unit/analyzer.test.js
@@ -156,6 +156,37 @@ describe('Analyzer - Unit Tests', () => {
 		}));
 	});
 
+	it('should retry when Gemini price search returns quota exhaustion', async () => {
+		process.env.NEWS_GEMINI_QUOTA_MAX_RETRIES = '1';
+		process.env.NEWS_GEMINI_QUOTA_RETRY_BASE_MS = '1';
+		const { NewsAnalyzer } = require('../../src/controllers/webhooks/handlers/newsMonitor/analyzer');
+		const activeGemini = require('../../src/services/grounding/gemini');
+		const activeGenaiClient = require('../../src/services/grounding/genaiClient');
+		const analyzer = new NewsAnalyzer();
+		analyzer.timeout = 1000;
+		const quotaError = new Error('429 RESOURCE_EXHAUSTED: {"error":{"details":[{"retryDelay":"1ms"}]}}');
+		activeGemini.analyzeNewsForSymbol.mockResolvedValue({
+			event_category: 'price_surge',
+			event_significance: 0.8,
+			sentiment_score: 0.8,
+			headline: 'Bitcoin surges on positive news',
+			confidence: 0.8,
+			sources: ['https://example.com/news'],
+		});
+		activeGenaiClient.search
+			.mockRejectedValueOnce(quotaError)
+			.mockResolvedValueOnce({
+				searchResultText: '{"price":"100","change_24h":"1.5","context":"ok","sources":[]}',
+				results: [],
+			});
+
+		const result = await analyzer.analyzeSymbol('BTCUSDT', 'req-price-quota');
+
+		expect(activeGenaiClient.search).toHaveBeenCalledTimes(2);
+		expect(activeGemini.analyzeNewsForSymbol).toHaveBeenCalledTimes(1);
+		expect(result.status).toBe('analyzed');
+	});
+
 	it('analyzer should have buildAlert method', () => {
 		const { getAnalyzer } = require('../../src/controllers/webhooks/handlers/newsMonitor/analyzer');
 		const analyzer = getAnalyzer();

--- a/tests/unit/analyzer.test.js
+++ b/tests/unit/analyzer.test.js
@@ -27,6 +27,9 @@ describe('Analyzer - Unit Tests', () => {
 	});
 
 	afterEach(() => {
+		delete process.env.NEWS_GEMINI_CONCURRENCY;
+		delete process.env.NEWS_GEMINI_QUOTA_MAX_RETRIES;
+		delete process.env.NEWS_GEMINI_QUOTA_RETRY_BASE_MS;
 		jest.resetModules();
 	});
 
@@ -61,6 +64,78 @@ describe('Analyzer - Unit Tests', () => {
 		const results = await analyzer.analyzeSymbols([]);
 		expect(Array.isArray(results)).toBe(true);
 		expect(results.length).toBe(0);
+	});
+
+	it('should obey configured Gemini concurrency when analyzing multiple symbols', async () => {
+		process.env.NEWS_GEMINI_CONCURRENCY = '2';
+		const { NewsAnalyzer } = require('../../src/controllers/webhooks/handlers/newsMonitor/analyzer');
+		const analyzer = new NewsAnalyzer();
+		let active = 0;
+		let maxActive = 0;
+		const releaseQueue = [];
+
+		analyzer.analyzeSymbol = jest.fn(async (symbol) => {
+			active += 1;
+			maxActive = Math.max(maxActive, active);
+			await new Promise(resolve => releaseQueue.push(resolve));
+			active -= 1;
+			return { symbol, status: 'analyzed', cached: false };
+		});
+
+		const run = analyzer.analyzeSymbols(['BTCUSDT', 'ETHUSDT', 'SOLUSDT', 'ADAUSDT'], 'req-1');
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(analyzer.analyzeSymbol).toHaveBeenCalledTimes(2);
+		expect(maxActive).toBeLessThanOrEqual(2);
+
+		while (releaseQueue.length > 0) {
+			releaseQueue.shift()();
+			await Promise.resolve();
+			await Promise.resolve();
+		}
+
+		const results = await run;
+		expect(results).toHaveLength(4);
+		expect(maxActive).toBeLessThanOrEqual(2);
+	});
+
+	it('should retry Gemini quota exhaustion within the symbol timeout budget', async () => {
+		process.env.NEWS_GEMINI_QUOTA_MAX_RETRIES = '1';
+		process.env.NEWS_GEMINI_QUOTA_RETRY_BASE_MS = '1';
+		const { NewsAnalyzer } = require('../../src/controllers/webhooks/handlers/newsMonitor/analyzer');
+		const analyzer = new NewsAnalyzer();
+		analyzer.timeout = 1000;
+		const quotaError = new Error('429 RESOURCE_EXHAUSTED: quota exceeded. RetryDelay: 1ms');
+		analyzer.analyzeSymbolInternal = jest.fn()
+			.mockRejectedValueOnce(quotaError)
+			.mockResolvedValueOnce({ status: 'analyzed', alert: null, cached: false });
+
+		const result = await analyzer.analyzeSymbol('BTCUSDT', 'req-2');
+
+		expect(analyzer.analyzeSymbolInternal).toHaveBeenCalledTimes(2);
+		expect(result.status).toBe('analyzed');
+		expect(result.error).toBeUndefined();
+	});
+
+	it('should return deterministic quota errors when retries are exhausted', async () => {
+		process.env.NEWS_GEMINI_QUOTA_MAX_RETRIES = '1';
+		process.env.NEWS_GEMINI_QUOTA_RETRY_BASE_MS = '1';
+		const { NewsAnalyzer } = require('../../src/controllers/webhooks/handlers/newsMonitor/analyzer');
+		const analyzer = new NewsAnalyzer();
+		const quotaError = new Error('429 RESOURCE_EXHAUSTED: quota exceeded. RetryDelay: 1ms');
+		analyzer.analyzeSymbolInternal = jest.fn().mockRejectedValue(quotaError);
+
+		const results = await analyzer.analyzeSymbols(['BTCUSDT'], 'req-3');
+
+		expect(analyzer.analyzeSymbolInternal).toHaveBeenCalledTimes(2);
+		expect(results[0]).toEqual(expect.objectContaining({
+			symbol: 'BTCUSDT',
+			status: 'error',
+			error: expect.objectContaining({
+				code: 'GEMINI_QUOTA_EXHAUSTED',
+			}),
+		}));
 	});
 
 	it('analyzer should have buildAlert method', () => {

--- a/tests/unit/analyzer.test.js
+++ b/tests/unit/analyzer.test.js
@@ -118,6 +118,24 @@ describe('Analyzer - Unit Tests', () => {
 		expect(result.error).toBeUndefined();
 	});
 
+	it('should honor quoted Gemini retryDelay values from RetryInfo JSON', async () => {
+		process.env.NEWS_GEMINI_QUOTA_MAX_RETRIES = '1';
+		process.env.NEWS_GEMINI_QUOTA_RETRY_BASE_MS = '1000';
+		const { NewsAnalyzer } = require('../../src/controllers/webhooks/handlers/newsMonitor/analyzer');
+		const analyzer = new NewsAnalyzer();
+		analyzer.timeout = 100;
+		const quotaError = new Error('429 RESOURCE_EXHAUSTED: {"error":{"details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"1ms"}]}}');
+		analyzer.analyzeSymbolInternal = jest.fn()
+			.mockRejectedValueOnce(quotaError)
+			.mockResolvedValueOnce({ status: 'analyzed', alert: null, cached: false });
+
+		const result = await analyzer.analyzeSymbol('BTCUSDT', 'req-json-retry');
+
+		expect(analyzer.analyzeSymbolInternal).toHaveBeenCalledTimes(2);
+		expect(result.status).toBe('analyzed');
+		expect(result.error).toBeUndefined();
+	});
+
 	it('should return deterministic quota errors when retries are exhausted', async () => {
 		process.env.NEWS_GEMINI_QUOTA_MAX_RETRIES = '1';
 		process.env.NEWS_GEMINI_QUOTA_RETRY_BASE_MS = '1';

--- a/tests/unit/analyzer.test.js
+++ b/tests/unit/analyzer.test.js
@@ -100,6 +100,22 @@ describe('Analyzer - Unit Tests', () => {
 		expect(maxActive).toBeLessThanOrEqual(2);
 	});
 
+	it('should not give queued symbols a fresh timeout beyond the batch budget', async () => {
+		process.env.NEWS_GEMINI_CONCURRENCY = '1';
+		const { NewsAnalyzer } = require('../../src/controllers/webhooks/handlers/newsMonitor/analyzer');
+		const analyzer = new NewsAnalyzer();
+		analyzer.timeout = 25;
+		analyzer.analyzeSymbolInternal = jest.fn(() => new Promise(() => {}));
+
+		const results = await analyzer.analyzeSymbols(['BTCUSDT', 'ETHUSDT'], 'req-batch-timeout');
+
+		expect(analyzer.analyzeSymbolInternal).toHaveBeenCalledTimes(1);
+		expect(results).toEqual([
+			expect.objectContaining({ symbol: 'BTCUSDT', status: 'timeout' }),
+			expect.objectContaining({ symbol: 'ETHUSDT', status: 'timeout' }),
+		]);
+	});
+
 	it('should retry Gemini quota exhaustion within the symbol timeout budget', async () => {
 		process.env.NEWS_GEMINI_QUOTA_MAX_RETRIES = '1';
 		process.env.NEWS_GEMINI_QUOTA_RETRY_BASE_MS = '1';

--- a/tests/unit/genaiClient.test.js
+++ b/tests/unit/genaiClient.test.js
@@ -73,6 +73,19 @@ describe('GenaiClient robustness', () => {
 			expect(global.fetch).toHaveBeenCalledTimes(1);
 		});
 
+		it('rethrows Gemini quota exhaustion instead of falling back to Brave', async () => {
+			const quotaError = Object.assign(
+				new Error('429 RESOURCE_EXHAUSTED: {"error":{"details":[{"retryDelay":"30s"}]}}'),
+				{ status: 429 },
+			);
+			genaiClient.genAI.models.generateContent.mockRejectedValueOnce(quotaError);
+
+			await expect(genaiClient.search({ query: 'test' }))
+				.rejects
+				.toThrow('RESOURCE_EXHAUSTED');
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
 		it('falls back to Brave when Google Search returns no results', async () => {
 			// Mock empty Google Search response
 			genaiClient.genAI.models.generateContent.mockResolvedValueOnce({

--- a/tests/unit/genaiClient.test.js
+++ b/tests/unit/genaiClient.test.js
@@ -73,14 +73,34 @@ describe('GenaiClient robustness', () => {
 			expect(global.fetch).toHaveBeenCalledTimes(1);
 		});
 
-		it('rethrows Gemini quota exhaustion instead of falling back to Brave', async () => {
+		it('falls back to Brave for Gemini quota exhaustion by default', async () => {
+			const quotaError = Object.assign(
+				new Error('429 RESOURCE_EXHAUSTED: {"error":{"details":[{"retryDelay":"30s"}]}}'),
+				{ status: 429 },
+			);
+			genaiClient.genAI.models.generateContent.mockRejectedValueOnce(quotaError);
+			global.fetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					web: { results: [{ title: 'BraveQuotaFallback', url: 'http://quota-fallback.com' }] },
+				}),
+			});
+
+			const res = await genaiClient.search({ query: 'test' });
+
+			expect(res.results).toHaveLength(1);
+			expect(res.results[0].title).toBe('BraveQuotaFallback');
+			expect(global.fetch).toHaveBeenCalledTimes(1);
+		});
+
+		it('rethrows Gemini quota exhaustion when requested by caller', async () => {
 			const quotaError = Object.assign(
 				new Error('429 RESOURCE_EXHAUSTED: {"error":{"details":[{"retryDelay":"30s"}]}}'),
 				{ status: 429 },
 			);
 			genaiClient.genAI.models.generateContent.mockRejectedValueOnce(quotaError);
 
-			await expect(genaiClient.search({ query: 'test' }))
+			await expect(genaiClient.search({ query: 'test', rethrowQuotaErrors: true }))
 				.rejects
 				.toThrow('RESOURCE_EXHAUSTED');
 			expect(global.fetch).not.toHaveBeenCalled();

--- a/tests/unit/news-monitor-handler.test.js
+++ b/tests/unit/news-monitor-handler.test.js
@@ -1,0 +1,28 @@
+const { NewsMonitorHandler } = require('../../src/controllers/webhooks/handlers/newsMonitor/newsMonitor');
+
+describe('NewsMonitorHandler', () => {
+	it('should count Gemini quota exhaustion separately in summary', () => {
+		const handler = new NewsMonitorHandler();
+
+		const summary = handler.generateSummary([
+			{
+				status: 'error',
+				error: {
+					code: 'GEMINI_QUOTA_EXHAUSTED',
+					message: '429 RESOURCE_EXHAUSTED',
+				},
+			},
+			{
+				status: 'analyzed',
+				alert: null,
+			},
+		]);
+
+		expect(summary).toEqual(expect.objectContaining({
+			total: 2,
+			analyzed: 1,
+			error: 1,
+			quota_exhausted: 1,
+		}));
+	});
+});

--- a/tests/unit/openapi-contract.test.js
+++ b/tests/unit/openapi-contract.test.js
@@ -60,4 +60,19 @@ describe('OpenAPI contract', () => {
 			]);
 		}
 	});
+
+	it('keeps the shared analysis response generic outside news-monitor', () => {
+		if (!fs.existsSync(contractPath)) return;
+		const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
+
+		expect(contract.components.responses.AnalysisResult.content['application/json'].schema).toEqual({
+			$ref: '#/components/schemas/JsonObject',
+		});
+		expect(contract.paths['/api/news-monitor'].get.responses['200']).toEqual({
+			$ref: '#/components/responses/NewsMonitorAnalysisResult',
+		});
+		expect(contract.paths['/api/news-monitor'].post.responses['200']).toEqual({
+			$ref: '#/components/responses/NewsMonitorAnalysisResult',
+		});
+	});
 });


### PR DESCRIPTION

## Summary

Adds quota-aware Gemini handling for `/api/news-monitor` so multi-symbol analysis can be throttled and `429 RESOURCE_EXHAUSTED` failures retry within the per-symbol timeout budget instead of surfacing as generic provider errors.

## Key Changes

- Added optional `NEWS_GEMINI_CONCURRENCY` to cap concurrent Gemini-backed symbol analyses while preserving legacy full fan-out when unset.
- Added per-symbol retry handling for Gemini quota exhaustion with provider retry-delay parsing, bounded exponential backoff, and deterministic `GEMINI_QUOTA_EXHAUSTED` results when retries are exhausted.
- Added `summary.quota_exhausted` to news-monitor responses and Sentry analysis-span attributes for easier production tracking.
- Updated README, `.env.example`, OpenAPI, Postman examples, and agent context for the new runtime contract.

## Technical Implementation

- `NewsAnalyzer.analyzeSymbols()` now uses a small async worker scheduler keyed by `NEWS_GEMINI_CONCURRENCY`.
- `NewsAnalyzer.analyzeSymbol()` delegates to quota-aware retry logic that keeps all attempts inside `NEWS_TIMEOUT_MS`.
- `/api/news-monitor` summary generation now counts exhausted Gemini quota failures separately from generic errors.

## Testing

- `pnpm test -- tests/unit/analyzer.test.js tests/unit/news-monitor-handler.test.js tests/integration/news-monitor-basic.test.js --testTimeout=10000`
- `pnpm test`

## References

- Fixes #114
- **Linear**: [CB-34](https://linear.app/knil/issue/CB-34/handle-gemini-quota-exhaustion-in-production-news-monitoring)