### PR TITLE
docs: document WEBHOOK_API_KEY and other missing env vars (CB-35)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,15 @@ TELEGRAM_CHAT_ID=your_telegram_chat_id_here
 ENABLE_TELEGRAM_BOT=true
 
 # ============================================================================
+# OPTIONAL: Security and API Authentication
+# ============================================================================
+
+# API Key to secure all /api endpoints (highly recommended in production).
+# When configured, requests must include the header: x-api-key: your_key_here
+# or the legacy query parameter: api-key=your_key_here
+# WEBHOOK_API_KEY=your_webhook_api_key_here
+
+# ============================================================================
 # OPTIONAL: WhatsApp Alerts (GreenAPI Integration)
 # ============================================================================
 
@@ -95,6 +104,13 @@ TRADINGVIEW_MCP_DEFAULT_TIMEFRAME=1h
 
 # Enable volume breakout validation for TradingView alerts (default: false)
 ENABLE_TRADINGVIEW_VOLUME_CONFIRMATION=false
+
+# Fallback symbols for /api/webhook/expanded-analysis-alert using EXCHANGE:SYMBOL format (comma-separated)
+# Example: BINANCE:BTCUSDT,NASDAQ:NVDA
+EXPANDED_ANALYSIS_ALERT_SYMBOLS=BINANCE:BTCUSDT,NASDAQ:NVDA
+
+# Total analysis deadline for /api/webhook/expanded-analysis-alert in milliseconds (default: 60000)
+EXPANDED_ANALYSIS_ALERT_TIMEOUT_MS=60000
 
 # ============================================================================
 # OPTIONAL: Admin Notifications
@@ -226,6 +242,10 @@ SENTRY_RELEASE=local # Explicit release tag (e.g., `v1.2.3`). Auto-derived from 
 # When enabled, each alert is persisted to the `alerts` collection after delivery.
 # Failure to write to Firestore never blocks or fails alert delivery (fail-open).
 ENABLE_FIRESTORE_ALERT_STORAGE=false
+
+# Enable storing async TradingView scanner/analysis jobs in Cloud Firestore (default: false)
+# When enabled, job execution state is persisted to the `jobs` collection.
+ENABLE_FIRESTORE_JOB_STORAGE=false
 
 # Firebase project ID (optional if already embedded in the service account JSON)
 FIREBASE_PROJECT_ID=your_firebase_project_id

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 
 ### Optional Variables
 
+#### Security
+
+- `WEBHOOK_API_KEY` - API key used to secure `/api/*` endpoints. When configured, clients must provide the key via the `x-api-key` header (or the `api-key` query parameter)
+
 #### WhatsApp Alerts (GreenAPI)
 
 - `ENABLE_WHATSAPP_ALERTS` - Enable WhatsApp alerts (`true` or `false`, default: `false`)
@@ -128,7 +132,7 @@ pnpm install --frozen-lockfile
 
 ### 2. Create `.env` File
 
-Copy the `.env.example` file to `.env` and fill in your configuration values:
+Copy the `.env.example` file (which serves as the canonical operator template) to `.env` and fill in your configuration values:
 
 ```bash
 cp .env.example .env
@@ -137,6 +141,7 @@ cp .env.example .env
 Then edit `.env` with your specific values. See `.env.example` for complete documentation of all available environment variables organized by category:
 
 - **Required**: Core bot token and chat IDs
+- **Optional: Security**: API Key configuration to secure webhook endpoints
 - **Optional: WhatsApp**: GreenAPI integration for multi-channel alerts
 - **Optional: AI Grounding**: Gemini API for alert enrichment
 - **Optional: Prompt Management**: Langfuse-backed runtime prompts with local fallbacks


### PR DESCRIPTION
## Summary

Document the missing environment variables (`WEBHOOK_API_KEY`, `ENABLE_FIRESTORE_JOB_STORAGE`, `EXPANDED_ANALYSIS_ALERT_SYMBOLS`, and `EXPANDED_ANALYSIS_ALERT_TIMEOUT_MS`) in `.env.example` to match the current runtime contract and README. Also update the setup flow in `README.md` to note that `.env.example` is the canonical operator template.

## Key Changes

- Add `WEBHOOK_API_KEY` to `.env.example` under a new `OPTIONAL: Security and API Authentication` section, with details on its usage.
- Add `ENABLE_FIRESTORE_JOB_STORAGE` under the `OPTIONAL: Firestore Alert Storage` section in `.env.example`.
- Add `EXPANDED_ANALYSIS_ALERT_SYMBOLS` and `EXPANDED_ANALYSIS_ALERT_TIMEOUT_MS` under the `OPTIONAL: TradingView MCP Enrichment` section in `.env.example`.
- Add `WEBHOOK_API_KEY` under the `Optional Variables` -> `Security` section in `README.md`.
- Add a note in `README.md` setup flow clarifying that `.env.example` is the canonical operator template.

## Technical Implementation

- Updated `.env.example` to include the missing environment variables categorized correctly with descriptive comments.
- Updated `README.md` to list `WEBHOOK_API_KEY` and updated the setup instructions.

## Testing

- Ran full test suite locally (`pnpm test`) and verified that all 715 tests pass.

## References

- **GitHub**: Closes #118
- **Linear**: [CB-35](https://linear.app/knil/issue/CB-35/document-webhook-api-key-enable-firestore-job-storage-and-expanded)