### PR TITLE
fix(bootstrap): allow api-only startup (CB-39)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@
 # REQUIRED: Core Bot Configuration
 # ============================================================================
 
-# Telegram bot token (get from BotFather on Telegram)
+# Telegram bot token (required only when ENABLE_TELEGRAM_BOT=true outside PR previews)
 BOT_TOKEN=your_telegram_bot_token_here
 
 # Telegram chat ID where bot sends alerts (use /start to find your chat ID)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 
 ### Required Variables
 
-- `BOT_TOKEN` - Telegram bot token (from BotFather)
+- `BOT_TOKEN` - Telegram bot token (from BotFather). Required only when `ENABLE_TELEGRAM_BOT=true` and the app is expected to launch Telegraf outside PR previews
 - `TELEGRAM_CHAT_ID` - Telegram chat ID where alerts are sent
 - `ENABLE_TELEGRAM_BOT` - Enable Telegram bot (`true` or `false`)
 
@@ -1037,7 +1037,7 @@ curl -X POST https://your-domain/api/webhook/alert \
 ### Configuration for Multi-Channel
 
 ```bash
-# Telegram (required)
+# Telegram (required only when the Telegram bot is enabled outside PR previews)
 ENABLE_TELEGRAM_BOT=true
 BOT_TOKEN=your_telegram_token
 TELEGRAM_CHAT_ID=-1001234567890
@@ -1057,9 +1057,14 @@ GEMINI_API_KEY=your_google_ai_studio_api_key
 
 **Both channels failing**:
 1. Verify network connectivity from server
-2. Check BOT_TOKEN validity (Telegram)
+2. If `ENABLE_TELEGRAM_BOT=true`, check BOT_TOKEN validity (Telegram)
 3. Check GreenAPI credentials and account status (WhatsApp)
 4. Review application logs for detailed error messages
+
+**API-only or WhatsApp-only startup**:
+1. Set `ENABLE_TELEGRAM_BOT=false`
+2. Omit `BOT_TOKEN` if Telegram is intentionally disabled
+3. Keep using `/api` routes and non-Telegram channels normally
 
 **WhatsApp not sending**:
 1. Verify `ENABLE_WHATSAPP_ALERTS=true`

--- a/index.js
+++ b/index.js
@@ -13,12 +13,10 @@ const app = require('./app.js');
 const { Telegraf, Markup } = require('telegraf');
 const { getRoutes } = require('./src/routes');
 const { initializeNotificationServices } = require('./src/controllers/webhooks/handlers/alert/alert');
+const { getTelegramBootstrapConfig } = require('./src/lib/telegramBootstrap');
 const Sentry = require('@sentry/node');
 
-const token = process.env.BOT_TOKEN;
-if (token === undefined) {
-	throw new Error('BOT_TOKEN must be provided!');
-}
+const { token } = getTelegramBootstrapConfig();
 
 let bot;
 
@@ -46,12 +44,11 @@ app.use(function onError(err, req, res, next) {
 app.listen(port, async () => {
 	console.log(now + ' - Running server on port ' + port);
 
-	const telegramBotIsEnabled = process.env.ENABLE_TELEGRAM_BOT === 'true';
+	const { telegramBotIsEnabled, isPreviewEnv, shouldStartTelegramBot } = getTelegramBootstrapConfig();
 	console.debug('telegramBotIsEnabled:', telegramBotIsEnabled);
-	const isPreviewEnv = process.env.RENDER === 'true' && process.env.IS_PULL_REQUEST === 'true';
 	console.debug('isPreviewEnv:', isPreviewEnv);
 
-	if (telegramBotIsEnabled && !isPreviewEnv) {
+	if (shouldStartTelegramBot) {
 		console.log('Telegram Bot is enabled');
 		bot = new Telegraf(token);
 		bot.command(['precio'], getPrice);

--- a/src/lib/telegramBootstrap.js
+++ b/src/lib/telegramBootstrap.js
@@ -1,0 +1,21 @@
+function getTelegramBootstrapConfig() {
+	const telegramBotIsEnabled = process.env.ENABLE_TELEGRAM_BOT === 'true';
+	const isPreviewEnv = process.env.RENDER === 'true' && process.env.IS_PULL_REQUEST === 'true';
+	const shouldStartTelegramBot = telegramBotIsEnabled && !isPreviewEnv;
+	const token = process.env.BOT_TOKEN;
+
+	if (shouldStartTelegramBot && token === undefined) {
+		throw new Error('BOT_TOKEN must be provided!');
+	}
+
+	return {
+		isPreviewEnv,
+		shouldStartTelegramBot,
+		telegramBotIsEnabled,
+		token,
+	};
+}
+
+module.exports = {
+	getTelegramBootstrapConfig,
+};

--- a/tests/unit/telegram-bootstrap.test.js
+++ b/tests/unit/telegram-bootstrap.test.js
@@ -1,0 +1,64 @@
+const { getTelegramBootstrapConfig } = require('../../src/lib/telegramBootstrap');
+
+describe('getTelegramBootstrapConfig', () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	it('does not require BOT_TOKEN when Telegram is disabled', () => {
+		process.env.ENABLE_TELEGRAM_BOT = 'false';
+		delete process.env.BOT_TOKEN;
+		delete process.env.RENDER;
+		delete process.env.IS_PULL_REQUEST;
+
+		expect(getTelegramBootstrapConfig()).toEqual({
+			isPreviewEnv: false,
+			shouldStartTelegramBot: false,
+			telegramBotIsEnabled: false,
+			token: undefined,
+		});
+	});
+
+	it('does not require BOT_TOKEN in preview environments that do not launch Telegraf', () => {
+		process.env.ENABLE_TELEGRAM_BOT = 'true';
+		process.env.RENDER = 'true';
+		process.env.IS_PULL_REQUEST = 'true';
+		delete process.env.BOT_TOKEN;
+
+		expect(getTelegramBootstrapConfig()).toEqual({
+			isPreviewEnv: true,
+			shouldStartTelegramBot: false,
+			telegramBotIsEnabled: true,
+			token: undefined,
+		});
+	});
+
+	it('fails fast when Telegram is enabled for runtime use but BOT_TOKEN is missing', () => {
+		process.env.ENABLE_TELEGRAM_BOT = 'true';
+		delete process.env.RENDER;
+		delete process.env.IS_PULL_REQUEST;
+		delete process.env.BOT_TOKEN;
+
+		expect(() => getTelegramBootstrapConfig()).toThrow('BOT_TOKEN must be provided!');
+	});
+
+	it('returns the token when Telegram startup is enabled', () => {
+		process.env.ENABLE_TELEGRAM_BOT = 'true';
+		process.env.BOT_TOKEN = 'test-bot-token';
+		delete process.env.RENDER;
+		delete process.env.IS_PULL_REQUEST;
+
+		expect(getTelegramBootstrapConfig()).toEqual({
+			isPreviewEnv: false,
+			shouldStartTelegramBot: true,
+			telegramBotIsEnabled: true,
+			token: 'test-bot-token',
+		});
+	});
+});


### PR DESCRIPTION
## fix(bootstrap): allow api-only startup

## Summary

Allow the service to boot without `BOT_TOKEN` when `ENABLE_TELEGRAM_BOT=false` or when the runtime is a PR preview that does not launch Telegraf, while preserving fail-fast validation for real Telegram bot deployments.

## Key Changes

### :gear: Bootstrap gating

- Extracts Telegram startup decisions into `src/lib/telegramBootstrap.js`
- Requires `BOT_TOKEN` only when the runtime will actually start Telegraf
- Preserves Telegram-disabled and preview startup paths without forcing a Telegram token

### :test_tube: Regression coverage

- Adds focused unit coverage for disabled, preview, enabled-without-token, and enabled-with-token startup paths
- Verifies the bootstrap contract independently from full process startup

### :memo: Deployment docs

- Clarifies in `README.md` and `.env.example` that `BOT_TOKEN` is only required for enabled Telegram runtime boot
- Documents the API-only / WhatsApp-only startup workflow

## Technical Implementation

### Architecture changes

#### `telegramBootstrap`

The new helper centralizes feature-flag and preview gating so `index.js` can ask a single function whether Telegraf should start and whether a token is required.

```js
function getTelegramBootstrapConfig() {
  const telegramBotIsEnabled = process.env.ENABLE_TELEGRAM_BOT === 'true';
  const isPreviewEnv = process.env.RENDER === 'true' && process.env.IS_PULL_REQUEST === 'true';
  const shouldStartTelegramBot = telegramBotIsEnabled && !isPreviewEnv;
  const token = process.env.BOT_TOKEN;

  if (shouldStartTelegramBot && token === undefined) {
    throw new Error('BOT_TOKEN must be provided!');
  }

  return { isPreviewEnv, shouldStartTelegramBot, telegramBotIsEnabled, token };
}
```

### File Structure Additions

```text
src/lib/telegramBootstrap.js        # Telegram startup gating and token validation
tests/unit/telegram-bootstrap.test.js # Regression tests for API-only, preview, and enabled startup paths
```

## Documentation Updates

- **Telegram bootstrap contract** Clarifies when `BOT_TOKEN` is required and how to run API-only / WhatsApp-only deployments

## Testing

### Pre-merge Verification

- [x] `pnpm test -- tests/unit/telegram-bootstrap.test.js --runInBand`
- [x] `pnpm test`
- [x] `pnpm exec eslint index.js src/lib/telegramBootstrap.js tests/unit/telegram-bootstrap.test.js`
- [ ] Global `pnpm lint` remains noisy due unrelated repo-wide ESLint debt outside this diff

## References

- GitHub Issue: https://github.com/francovp/cabros-bot/issues/124
- Linear: https://linear.app/knil/issue/CB-39/allow-api-only-startup-when-enable-telegram-bot-is-false

---

**Review Checklist:**

- [ ] Code quality meets project standards
- [ ] All tests pass and coverage is maintained
- [ ] Documentation is complete and accurate
- [ ] Breaking change assessment completed
