### PR TITLE
feat(issue-automator): self-review fallback when Codex review hits rate limit

### DIFF
--- a/.agents/skills/issue-automator/SKILL.md
+++ b/.agents/skills/issue-automator/SKILL.md
@@ -135,7 +135,12 @@ Follow these steps in strict chronological order to automate issue resolution:
 ### Step 5: Verification & Deploy Check
 1. Ensure the PR meets all criteria in `references/readiness-and-verification.md`.
 2. Retrieve the PR number and run `scripts/verify-preview.sh <PR_NUMBER>` to verify the Render preview deployment is live and healthy.
-3. Address any unresolved discussions, especially review comments from `@francovp` or `@codex`.
+3. **Address any unresolved discussions**, especially review comments from `@francovp` or `@codex`.
+   - **Codex review failure detection**: If a Codex review body text starts with `You have reached your Codex usage limits for code reviews`, the automated Codex review has failed due to rate limiting. Do NOT wait for Codex. Instead, immediately perform the code review yourself:
+     - Use `caveman-review` skill (`task(load_skills=["caveman-review"], ...)`) for compressed review findings, OR
+     - Deploy a `deep` subagent with explicit instructions to review the PR diff for correctness, edge cases, security concerns, type safety, and alignment with acceptance criteria.
+     - If the failed Codex review created a blocking review thread, resolve or address it after your self-review completes.
+     - A passing self-review satisfies the "no unresolved discussions" criterion in the merge gate — do NOT reset the quiet window for a usage-limited Codex review.
 4. Observe the quiet window and retry policies specified in `references/readiness-and-verification.md`.
 5. **Verify the PR title has the Linear ID suffix**: If `LINEAR_ISSUE_ID` is set and the PR title is missing `(LINEAR_ISSUE_ID)` at the end, fix it:
    ```bash

--- a/.agents/skills/issue-automator/references/readiness-and-verification.md
+++ b/.agents/skills/issue-automator/references/readiness-and-verification.md
@@ -39,4 +39,17 @@ If any criterion is uncertain, keep the same gate but hand the PR off through `I
 1. **Window Duration**: After the latest commit, wait a quiet window of 5 minutes before calling the PR clean or ready.
 2. **Midpoint & Endpoint Checks**: During the quiet window, re-check reviews and threads once around the midpoint (2.5 minutes) and once at the end.
 3. **Reset Trigger**: If Codex posts a new review or a new thread appears, reset the quiet window from that event or from the new commit (whichever is later).
+   - **Exception — rate‑limited review**: If the Codex review body text starts with `You have reached your Codex usage limits for code reviews`, this is a review failure, not a real review. Do NOT reset the quiet window. Instead, perform a self-review (see Codex Review Rate Limit Handling section below).
 4. **Instability Handling**: If the quiet window cannot complete due to repeated issue-specific instability, end with outcome `LOCAL_DEADLOCK`.
+
+## Codex Review Rate Limit Handling
+
+Codex reviews may fail when the Codex usage quota for code reviews is exhausted. Detect and fall back to a self-review.
+
+1. **Detection**: When checking for Codex reviews on the PR, inspect the review body text. If it starts with `You have reached your Codex usage limits for code reviews`, the automated Codex review has failed due to rate limiting.
+2. **Self-Review Fallback**: Immediately perform a code review using available tools:
+   - Use `caveman-review` skill via `task(load_skills=["caveman-review"], ...)` for compressed, one-line-per-finding review output, OR
+   - Deploy a `deep` subagent with explicit instructions to review the PR diff for: logic correctness, edge case coverage, error handling, type safety, security concerns, and alignment with issue acceptance criteria and existing code patterns.
+3. **Thread Handling**: If the failed Codex review created a blocking review thread (e.g., Codex requested changes), resolve or address that thread once the self-review passes.
+4. **Gate Effect**: A passing self-review satisfies the "no unresolved discussions" criterion in the merge gate. The quiet window is NOT reset for a usage-limited Codex review — it continues normally.
+5. **Outcome**: If the self-review passes all criteria, the agent may proceed to merge (if otherwise ready) or hand off for human review per Step 7.


### PR DESCRIPTION
feat(issue-automator): self-review fallback when Codex review hits rate limit

## Summary

Update the issue-automator skill to detect when a Codex review fails with "You have reached your Codex usage limits for code reviews" and fall back to performing the code review itself using a subagent or available skill instead of waiting indefinitely.

## Key Changes

### 🛡️ Codex rate-limit detection in `SKILL.md` (Step 5 — Verification & Deploy Check)

- Enhanced the "Address unresolved discussions" step to inspect Codex review body text
- If the text starts with `You have reached your Codex usage limits for code reviews`, the automated review has failed — do NOT wait for Codex
- Perform self-review immediately via `caveman-review` skill or a `deep` subagent
- Resolve any blocking review threads the failed Codex review created
- Passing self-review satisfies the merge gate's "no unresolved discussions" criterion
- Quiet window is NOT reset for a usage-limited Codex review

### 📋 Codex Review Rate Limit Handling section in `references/readiness-and-verification.md`

- New dedicated section covering: detection, self-review fallback options, thread handling, gate effect, and outcome guidance
- Exception added to Quiet Window reset trigger: rate-limited Codex reviews do not reset the window

## Technical Implementation

No environment variables, dependencies, or architecture changes. The update is purely procedural — workflow instructions in the issue-automator skill files.

### Files Modified

- `.agents/skills/issue-automator/SKILL.md` — Step 5, sub-step 3 expanded with rate-limit detection and self-review fallback
- `.agents/skills/issue-automator/references/readiness-and-verification.md` — New "Codex Review Rate Limit Handling" section + Quiet Window exception

## Testing

- Both files read correctly post-edit and render as valid markdown
- Instructions are self-consistent between SKILL.md and the reference file

## References

- **Issue**: User request to handle Codex "usage limits" review failure gracefully
