### PR TITLE
fix: await Telegram TradingView job creation (CB-51)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -412,11 +412,13 @@ The system provides asynchronous job endpoints to support executing both `expand
 - `src/services/jobs/JobService.js` — Coordinates job state tracking, background worker execution, progress reports, durable persistence checkpoints, and job eviction (jobs older than 1 hour).
 - `src/services/jobs/JobRepository.js` — Stores sanitized job records in memory and, when `ENABLE_FIRESTORE_JOB_STORAGE=true`, in Firestore collection `tradingviewJobs`.
 - `src/controllers/webhooks/handlers/jobs/jobs.js` — HTTP route controller handlers (`postCreateJob`, `getJobStatus`).
+- `src/controllers/commands.js` — Telegram `/analisis` and `/scanner` commands create these jobs and must `await jobService.createJob()` before replying or handling validation/storage errors.
 
 **Failure and Edge Case Behavior**:
 - Sync validation: throws `400` synchronously on invalid inputs before job registration.
 - Feature checks: returns `404 FEATURE_DISABLED` if market scanner jobs are created but `ENABLE_MARKET_SCANNER` is not `'true'`.
 - Persistence: `createJob()` and `getJob()` are async because job metadata/results may be written to or read from Firestore.
+- Telegram commands: async `createJob()` rejections must stay inside the command `try/catch` so `replyValidationError()` can return clear command feedback instead of producing unhandled promise rejections.
 - Eviction: completed/failed jobs older than 1 hour are deleted from memory/Firestore and return `404 Not Found`; active jobs are preserved.
 - Background failures: if the worker runs into unexpected exceptions or timeouts, the job is marked `failed` and reported to Sentry.
 - Async Callbacks: If `callbackUrl` is provided, a callback is dispatched when the job reaches a terminal state (`completed`, `failed`, `cancelled`, `timed_out`). Payloads are signed with HMAC-SHA256 in the `x-callback-signature` header using `callbackSecret` (if provided by client) or the server-configured `JOB_CALLBACK_SIGNING_SECRET`. Transient network failures are retried up to 3 times (4 total attempts) with exponential backoff (starting at 1s, configurable via `JOB_CALLBACK_RETRY_DELAY_MS`). The callback process fails open, writing log events and updating job metadata (`callbackStatus`) without affecting the core job status.

--- a/src/controllers/commands.js
+++ b/src/controllers/commands.js
@@ -54,7 +54,7 @@ const createTradingViewJobCommand = (type, command, buildPayload) => async (cont
 
 	try {
 		const payload = buildPayload(args);
-		const result = jobService.createJob(type, payload, buildBotFromContext(context));
+		const result = await jobService.createJob(type, payload, buildBotFromContext(context));
 		await context.reply(`Job ${result.jobId} creado para ${type}. Estado: ${result.status}.`);
 	} catch (error) {
 		await replyValidationError(context, error);

--- a/tests/unit/telegram-commands.test.js
+++ b/tests/unit/telegram-commands.test.js
@@ -52,7 +52,7 @@ describe('Telegram TradingView commands', () => {
 	});
 
 	it('creates an expanded analysis job from Telegram args', async () => {
-		jobService.createJob.mockReturnValue({
+		jobService.createJob.mockResolvedValue({
 			success: true,
 			jobId: 'job-1',
 			status: 'pending',
@@ -76,7 +76,7 @@ describe('Telegram TradingView commands', () => {
 	});
 
 	it('creates a market scanner job from Telegram args', async () => {
-		jobService.createJob.mockReturnValue({
+		jobService.createJob.mockResolvedValue({
 			success: true,
 			jobId: 'job-2',
 			status: 'pending',
@@ -102,11 +102,9 @@ describe('Telegram TradingView commands', () => {
 	});
 
 	it('returns clear validation errors from job commands', async () => {
-		jobService.createJob.mockImplementation(() => {
-			const error = new Error('Market scanner is not enabled');
-			error.code = 'FEATURE_DISABLED';
-			throw error;
-		});
+		const error = new Error('Market scanner is not enabled');
+		error.code = 'FEATURE_DISABLED';
+		jobService.createJob.mockRejectedValue(error);
 		const context = buildContext('/scanner');
 
 		await marketScannerCmd(context);


### PR DESCRIPTION

## Summary

Await async TradingView job creation from Telegram commands so `/analisis` and `/scanner` reply with resolved job metadata and catch job creation failures.

## Key Changes

- Await `jobService.createJob()` in the shared Telegram TradingView command handler.
- Update Telegram command unit tests to mock async resolved and rejected job creation.
- Document that Telegram job commands must await `createJob()` because persistence and validation paths are asynchronous.

## Technical Implementation

- `src/controllers/commands.js` now awaits the async job service before reading `jobId` and `status`.
- Rejected async job creation now stays inside the existing `try/catch` and uses `replyValidationError()`.

## Testing

- `pnpm test -- tests/unit/telegram-commands.test.js`
- `pnpm test`

## References

- Fixes #149
- **Linear**: [CB-51](https://linear.app/knil/issue/CB-51/gh-149-await-async-tradingview-job-creation-in-telegram-commands)