### PR TITLE
fix(storage): hash replay document keys (CB-57)

### DIFF
--- a/src/services/storage/AlertStorageService.js
+++ b/src/services/storage/AlertStorageService.js
@@ -25,6 +25,7 @@
  */
 
 const admin = require('firebase-admin');
+const crypto = require('crypto');
 const { encodeAlertPaginationCursor, parseAlertPaginationCursor } = require('./alertPaginationCursor');
 
 const COLLECTION_NAME = 'alerts';
@@ -579,7 +580,8 @@ async function saveReplayAttempt({ alertId, idempotencyKey, channels, deliveryRe
 		throw createStorageUnavailableError();
 	}
 
-	const replayId = `${alertId}_${idempotencyKey}`;
+	const idempotencyKeyHash = crypto.createHash('sha256').update(idempotencyKey).digest('hex');
+	const replayId = `${alertId}_${idempotencyKeyHash}`;
 	const document = {
 		alertId,
 		idempotencyKey,

--- a/tests/unit/alert-storage-service.test.js
+++ b/tests/unit/alert-storage-service.test.js
@@ -11,6 +11,7 @@
 
 // The moduleNameMapper in jest.config.js ensures this resolves to __mocks__/firebase-admin.js
 const admin = require('firebase-admin');
+const crypto = require('crypto');
 const AlertStorageService = require('../../src/services/storage/AlertStorageService');
 const { parseAlertPaginationCursor } = require('../../src/services/storage/alertPaginationCursor');
 
@@ -543,26 +544,43 @@ describe('AlertStorageService', () => {
 	});
 
 	describe('saveReplayAttempt()', () => {
-		it('stores replay attempts in a separate collection using the idempotency key', async () => {
+		it('stores replay attempts using a hashed idempotency key document ID', async () => {
 			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+			const idempotencyKey = 'replay/key-1';
+			const idempotencyKeyHash = crypto.createHash('sha256').update(idempotencyKey).digest('hex');
 
 			const result = await AlertStorageService.saveReplayAttempt({
 				alertId: 'alert-123',
-				idempotencyKey: 'replay-key-1',
+				idempotencyKey,
 				channels: ['telegram'],
 				deliveryResults: [{ channel: 'telegram', success: true }],
 			});
 
-			expect(result).toBe('alert-123_replay-key-1');
+			expect(result).toBe(`alert-123_${idempotencyKeyHash}`);
 			expect(mockCollection).toHaveBeenCalledWith('alertReplays');
 			expect(mockDocSet).toHaveBeenCalledWith({
 				alertId: 'alert-123',
-				idempotencyKey: 'replay-key-1',
+				idempotencyKey,
 				channels: ['telegram'],
 				deliveryResults: [{ channel: 'telegram', success: true }],
 				replayedAt: expect.anything(),
 				source: 'alert-replay',
 			});
+		});
+
+		it('uses a bounded replay document ID for long idempotency keys', async () => {
+			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+			const idempotencyKey = 'a'.repeat(10_000);
+
+			const result = await AlertStorageService.saveReplayAttempt({
+				alertId: 'alert-123',
+				idempotencyKey,
+				channels: [],
+				deliveryResults: [],
+			});
+
+			expect(result).toMatch(/^alert-123_[a-f0-9]{64}$/);
+			expect(result).toHaveLength('alert-123_'.length + 64);
 		});
 
 		it('throws STORAGE_UNAVAILABLE when replay audit storage fails', async () => {


### PR DESCRIPTION
# fix(storage): hash replay document keys (CB-57)

## Summary

Prevent caller-controlled replay idempotency keys from becoming Firestore document IDs by deriving a bounded SHA-256 identifier.

## Key Changes

### :lock: Safe replay audit identifiers

- Hash idempotency keys before building `alertReplays` document IDs.
- Preserve the original key inside the audit document to retain existing audit data semantics.

### :test_tube: Regression coverage

- Cover slash-containing idempotency keys.
- Cover 10,000-character idempotency keys and assert the persisted identifier remains bounded.

## Technical Implementation

### AlertStorageService

`saveReplayAttempt()` now builds IDs as `<alertId>_<sha256(idempotencyKey)>` using Node.js native `crypto`.

## Testing

### Test Suite

- **35 focused unit tests** in `alert-storage-service.test.js`
- **Full Jest suite** passed on the final verification run

### Test Files

- `tests/unit/alert-storage-service.test.js`: validates deterministic hashed IDs and bounded long-key behavior.

## References

- Closes #153
- GitHub issue: https://github.com/francovp/cabros-bot/issues/153
- Linear: https://linear.app/knil/issue/CB-57/hash-replay-idempotency-keys-before-using-firestore-document-ids

---

**Review Checklist:**

- [ ] Replay audit IDs contain only the alert ID and SHA-256 digest
- [ ] Existing replay audit document fields remain unchanged
