### PR TITLE
feat(admin): add API admin console (CB-58)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-api-admin-console.md
+++ b/docs/superpowers/plans/2026-07-17-api-admin-console.md
@@ -1,0 +1,252 @@
+# API Admin Console Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a same-origin `/admin` console for Cabros Bot operations and an OpenAPI-backed API playground.
+
+**Architecture:** Serve three static admin assets through the existing public docs router. A small browser client keeps its API key only in `sessionStorage`, calls the existing `/api` routes with native `fetch`, and reads `/openapi.json` to populate the playground. A tiny shared request helper stays dependency-free and is unit tested in Node.
+
+**Tech Stack:** Node.js 20, Express 4, vanilla HTML/CSS/JavaScript, Jest, Supertest.
+
+## Global Constraints
+
+- Keep all protected `/api` handlers behind the existing `validateApiKey` middleware.
+- Do not add dependencies, backend credential storage, a proxy, API routes, or API-contract changes.
+- Store the operator key only in `sessionStorage` and only send it in the `x-api-key` header.
+- Keep `/docs` and `/openapi.json` public and read-only.
+- Use external static CSS and JavaScript so Helmet's default CSP remains valid.
+- Update `CabrosBot.postman_collection.json` only if an API contract changes; this plan makes none.
+
+---
+
+### Task 1: Serve the admin shell
+
+**Files:**
+- Create: `src/admin/index.html`
+- Create: `src/admin/admin.css`
+- Create: `src/admin/admin.js`
+- Modify: `src/openapi/docs.js`
+- Modify: `tests/integration/openapi-docs.test.js`
+
+**Interfaces:**
+- Consumes: the public `getOpenApiDocsRouter()` router.
+- Produces: `GET /admin`, `/admin/admin.css`, and `/admin/admin.js` public static assets.
+
+- [ ] **Step 1: Write the failing route test**
+
+```js
+it('serves the API admin shell and external assets without an API key', async () => {
+  const page = await request(app).get('/admin');
+  const script = await request(app).get('/admin/admin.js');
+
+  expect(page.status).toBe(200);
+  expect(page.text).toContain('Cabros Bot Console');
+  expect(page.text).toContain('/admin/admin.js');
+  expect(page.text).not.toContain(process.env.WEBHOOK_API_KEY);
+  expect(script.status).toBe(200);
+  expect(script.headers['content-type']).toMatch(/javascript/);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm test -- tests/integration/openapi-docs.test.js --testNamePattern="API admin shell"`
+
+Expected: FAIL because `/admin` does not exist.
+
+- [ ] **Step 3: Add the static route and accessible shell**
+
+Add `adminDir = path.join(__dirname, '../admin')`, `router.get('/admin', ...)`, and `router.use('/admin', express.static(adminDir, { index: false, immutable: true, maxAge: '1d' }))` to `src/openapi/docs.js`. Create an external-asset HTML shell with:
+
+```html
+<main class="console-shell">
+  <header><h1>Cabros Bot Console</h1><button id="clear-key">Clear key</button></header>
+  <section aria-labelledby="connection-title">
+    <h2 id="connection-title">Connection</h2>
+    <label>API key <input id="api-key" type="password" autocomplete="off"></label>
+    <button id="save-key">Use key for this session</button>
+  </section>
+  <nav aria-label="Console sections">
+    <button data-view="status">Status</button><button data-view="alerts">Alerts</button>
+    <button data-view="presets">Presets</button><button data-view="jobs">Jobs</button>
+    <button data-view="analysis">Analysis</button><button data-view="playground">Playground</button>
+  </nav>
+  <section id="view" aria-live="polite"></section>
+</main>
+<script src="/admin/admin-request.js" defer></script>
+<script src="/admin/admin.js" defer></script>
+```
+
+Style focus indicators, responsive layout, visible request state, readable response blocks, and destructive-action confirmation in `admin.css`. Do not put credentials in values rendered back into the document.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `pnpm test -- tests/integration/openapi-docs.test.js --testNamePattern="API admin shell"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin src/openapi/docs.js tests/integration/openapi-docs.test.js
+git commit -m "feat(admin): serve operator console"
+```
+
+### Task 2: Add testable, browser-safe request helpers
+
+**Files:**
+- Create: `src/admin/admin-request.js`
+- Create: `tests/unit/admin-request.test.js`
+
+**Interfaces:**
+- Produces: `window.CabrosAdminRequest.createRequest({ path, method, query, body, apiKey })` returning `{ url, options }`; CommonJS export exposes the same API for Jest.
+- Consumes: native browser `URLSearchParams`, `fetch`, and the existing API-key header convention.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+```js
+const { createRequest } = require('../../src/admin/admin-request');
+
+it('creates a same-origin request with an API-key header and JSON body', () => {
+  expect(createRequest({
+    path: '/api/webhook/volume-confirmation', method: 'POST', apiKey: 'secret',
+    body: { symbol: 'BINANCE:BTCUSDT' }, query: { dryRun: false },
+  })).toEqual({
+    url: '/api/webhook/volume-confirmation?dryRun=false',
+    options: expect.objectContaining({
+      method: 'POST', body: '{"symbol":"BINANCE:BTCUSDT"}',
+      headers: { 'Content-Type': 'application/json', 'x-api-key': 'secret' },
+    }),
+  });
+});
+
+it('rejects a non-relative API path', () => {
+  expect(() => createRequest({ path: 'https://example.com', method: 'GET' })).toThrow('API path must start with /api/');
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm test -- tests/unit/admin-request.test.js`
+
+Expected: FAIL because the helper does not exist.
+
+- [ ] **Step 3: Implement the minimal helper**
+
+Implement a UMD-style module that exports in Node and assigns `window.CabrosAdminRequest` in the browser. Validate that `path` starts with `/api/`, omit `undefined` query values, serialize only non-empty JSON bodies, set `Content-Type: application/json` for bodies, and set `x-api-key` only when a key is present. Do not construct absolute URLs and do not expose a header-inspection API.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `pnpm test -- tests/unit/admin-request.test.js`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin/admin-request.js tests/unit/admin-request.test.js
+git commit -m "feat(admin): add safe request helper"
+```
+
+### Task 3: Implement the operator workflows and playground
+
+**Files:**
+- Modify: `src/admin/index.html`
+- Modify: `src/admin/admin.js`
+- Modify: `src/admin/admin.css`
+- Modify: `tests/integration/openapi-docs.test.js`
+
+**Interfaces:**
+- Consumes: `window.CabrosAdminRequest.createRequest`, `/openapi.json`, and the existing `/api` operations.
+- Produces: interactive Status, Alerts, Presets, Jobs, Analysis, and Playground views.
+
+- [ ] **Step 1: Extend the route test for public contract discovery**
+
+```js
+it('keeps the admin client contract-driven without exposing the configured API key', async () => {
+  const client = await request(app).get('/admin/admin.js');
+
+  expect(client.status).toBe(200);
+  expect(client.text).toContain("fetch('/openapi.json')");
+  expect(client.text).not.toContain(process.env.WEBHOOK_API_KEY);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm test -- tests/integration/openapi-docs.test.js --testNamePattern="contract-driven"`
+
+Expected: FAIL because the client does not load the contract.
+
+- [ ] **Step 3: Implement the smallest useful views**
+
+In `admin.js`, load the public contract once and create forms from a small operation map:
+
+```js
+const VIEWS = {
+  status: [{ method: 'GET', path: '/api/status', label: 'Refresh status' }],
+  alerts: [{ method: 'GET', path: '/api/alerts', label: 'Load alerts' }],
+  presets: [{ method: 'GET', path: '/api/scanner-presets', label: 'Load presets' }],
+  jobs: [{ method: 'POST', path: '/api/jobs/tradingview-analysis', label: 'Create job' }],
+  analysis: [
+    { method: 'POST', path: '/api/webhook/expanded-analysis-alert', label: 'Expanded analysis' },
+    { method: 'POST', path: '/api/webhook/market-scanner-alert', label: 'Market scanner' },
+    { method: 'POST', path: '/api/webhook/volume-confirmation', label: 'Volume confirmation' },
+    { method: 'POST', path: '/api/news-monitor', label: 'News monitor' },
+  ],
+};
+```
+
+Render a JSON textarea for POST bodies and query inputs for GET operations. Include operation-specific example JSON from the contract. For alert replay, preset run/delete, and job cancel/retry actions, ask `window.confirm()` immediately before the request. The Playground lists contract paths/operations, lets the operator supply path parameters, query JSON, and a request body, then calls the helper. Render status, elapsed time, and formatted JSON/text response; never render the API key or raw request headers.
+
+Use `sessionStorage.getItem('cabros-admin-api-key')` only to prefill the password field while the session exists, update it only after an explicit save action, and remove it on clear. Every request failure must render its HTTP status or network message and leave the console usable.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `pnpm test -- tests/integration/openapi-docs.test.js --testNamePattern="contract-driven"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin/index.html src/admin/admin.js src/admin/admin.css tests/integration/openapi-docs.test.js
+git commit -m "feat(admin): add API workflows"
+```
+
+### Task 4: Verify the complete integration and documentation
+
+**Files:**
+- Modify: `context/codex-api-admin-site.md`
+
+**Interfaces:**
+- Consumes: completed static console assets and their focused tests.
+- Produces: a review-ready branch summary without API-contract documentation changes.
+
+- [ ] **Step 1: Run focused checks**
+
+Run: `pnpm test -- tests/unit/admin-request.test.js tests/integration/openapi-docs.test.js`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the full regression suite**
+
+Run: `pnpm test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Check the production diff**
+
+Run: `git diff master...HEAD --check && git diff master...HEAD -- src/openapi/openapi.json CabrosBot.postman_collection.json`
+
+Expected: no whitespace errors and no API-contract or Postman changes.
+
+- [ ] **Step 4: Update the branch context**
+
+Update `context/codex-api-admin-site.md` so its title ends with `(CB-58)`, its summary covers the complete console, and its References section includes `Fixes #190` and the Linear issue URL.
+
+## Self-Review
+
+- Spec coverage: Tasks 1–3 cover the same-origin UI, browser-only credentials, six required views, native fetch, contract discovery, and destructive-action confirmation. Task 4 verifies the scope boundary.
+- Placeholder scan: no incomplete placeholders or undefined implementation steps remain.
+- Type consistency: `createRequest()` is defined by Task 2 and consumed by Task 3 with the same object argument and return values.

--- a/docs/superpowers/specs/2026-07-17-api-admin-design.md
+++ b/docs/superpowers/specs/2026-07-17-api-admin-design.md
@@ -1,0 +1,34 @@
+# API administration site design
+
+## Goal
+
+Add an operator website at `/admin` to manage Cabros Bot's existing protected API. It provides dedicated workflows for operations, alerts, scanner presets, asynchronous jobs, and market analysis, plus a generic OpenAPI-based playground.
+
+## Chosen approach
+
+The administration UI is served by the existing Express application under `/admin`. It uses the current deployment as the API origin, so it does not require CORS changes or a separate deployment. It is an API client only: it adds no authentication backend, data store, or proxy.
+
+The operator enters an API key in the browser. The key is kept only in `sessionStorage`, sent only as the existing `x-api-key` request header, and cleared when the browser session ends. It is never placed in URLs, logs, page markup, or API responses.
+
+## Interface
+
+- **Status**: fetches `/api/status` and shows readiness, capabilities, feature flags, and dependency state.
+- **Alerts**: lists stored alerts, supports filtering and paging, shows alert details, and permits replay after a clear confirmation.
+- **Scanner presets**: lists, creates, updates, deletes, and runs existing presets. Delete and run require confirmation.
+- **Jobs**: creates TradingView analysis jobs, polls selected job status, and exposes the existing cancel/retry actions only when applicable.
+- **Analysis**: provides focused request forms for expanded analysis, market scanner, volume confirmation, and news monitor.
+- **Playground**: builds arbitrary requests from the public `/openapi.json` contract. It supports the documented method, path, query parameters, JSON body, request execution, and formatted response rendering.
+
+## Data flow and failure handling
+
+Browser actions call existing `/api` endpoints directly with `fetch`. The UI preserves server status codes and response bodies for the operator, masks API-key fields in visible request summaries, and gives actionable responses for unavailable capabilities, request validation errors, and network failures. A failed request never prevents a subsequent operation.
+
+The UI reuses the current `validateApiKey` protection; no protected route is changed or bypassed. The existing public `/docs` and `/openapi.json` remain read-only.
+
+## Scope boundaries
+
+This first version does not add user accounts, server-side credential storage, a proxy, audit persistence, a new API endpoint, or a custom UI for every OpenAPI operation. The Playground is the escape hatch for endpoints without a dedicated workflow.
+
+## Verification
+
+Add focused tests for static admin delivery and client request construction where practical, update the Postman collection only if an API contract changes (none is planned), and run the full project test suite after implementation.

--- a/src/admin/admin-request.js
+++ b/src/admin/admin-request.js
@@ -1,0 +1,40 @@
+'use strict';
+
+(function exposeRequestHelper(root, factory) {
+	const api = factory();
+
+	if (typeof module === 'object' && module.exports) {
+		module.exports = api;
+		return;
+	}
+
+	root.CabrosAdminRequest = api;
+}(typeof window === 'undefined' ? globalThis : window, () => {
+	const hasJsonBody = (body) => body !== undefined && body !== null
+		&& (!Array.isArray(body) || body.length > 0)
+		&& (typeof body !== 'object' || Object.keys(body).length > 0);
+
+	const createRequest = ({ path, method, query, body, apiKey }) => {
+		if (!path.startsWith('/api/')) {
+			throw new Error('API path must start with /api/');
+		}
+
+		const params = new URLSearchParams();
+		Object.entries(query || {}).forEach(([key, value]) => {
+			if (value !== undefined) params.set(key, value);
+		});
+
+		const headers = {};
+		const options = { method, headers };
+		if (hasJsonBody(body)) {
+			headers['Content-Type'] = 'application/json';
+			options.body = JSON.stringify(body);
+		}
+		if (apiKey) headers['x-api-key'] = apiKey;
+
+		const search = params.toString();
+		return { url: search ? `${path}?${search}` : path, options };
+	};
+
+	return { createRequest };
+}));

--- a/src/admin/admin-request.js
+++ b/src/admin/admin-request.js
@@ -15,7 +15,7 @@
 		&& (typeof body !== 'object' || Object.keys(body).length > 0);
 
 	const createRequest = ({ path, method, query, body, apiKey }) => {
-		if (!path.startsWith('/api/')) {
+		if (typeof path !== 'string' || !path.startsWith('/api/') || path.includes('?') || path.includes('#')) {
 			throw new Error('API path must start with /api/');
 		}
 

--- a/src/admin/admin-request.js
+++ b/src/admin/admin-request.js
@@ -10,14 +10,60 @@
 
 	root.CabrosAdminRequest = api;
 }(typeof window === 'undefined' ? globalThis : window, () => {
+	const confirmations = {
+		'POST /api/alerts/{alertId}/replay': 'Replay this alert?',
+		'POST /api/scanner-presets/{id}/run': 'Run this scanner preset?',
+		'DELETE /api/scanner-presets/{id}': 'Delete this scanner preset?',
+		'POST /api/jobs/{jobId}/cancel': 'Cancel this job?',
+		'POST /api/jobs/{jobId}/retry': 'Retry this job?',
+		'POST /api/jobs/{jobId}/retry-failed': 'Retry failed items for this job?',
+	};
+
 	const hasJsonBody = (body) => body !== undefined && body !== null
 		&& (!Array.isArray(body) || body.length > 0)
 		&& (typeof body !== 'object' || Object.keys(body).length > 0);
+
+	const validateQuery = (query) => {
+		if (query === undefined) return query;
+		if (query === null || typeof query !== 'object' || Array.isArray(query)) {
+			throw new Error('Query must be a JSON object.');
+		}
+		if (Object.keys(query).some((key) => ['api-key', 'x-api-key'].includes(key.toLowerCase()))) {
+			throw new Error('Query credentials are not allowed; use the API key field.');
+		}
+		return query;
+	};
+
+	const redactSecret = (value, secret) => {
+		if (!secret) return String(value);
+		const raw = String(secret);
+		const escaped = JSON.stringify(raw).slice(1, -1);
+		return [...new Set([raw, escaped])]
+			.sort((left, right) => right.length - left.length)
+			.reduce((redacted, variant) => redacted.split(variant).join('[REDACTED]'), String(value));
+	};
+
+	const operationDefinitions = (contract) => Object.entries(contract.paths)
+		.flatMap(([path, methods]) => Object.entries(methods)
+			.filter(([method]) => ['get', 'post', 'put', 'patch', 'delete'].includes(method))
+			.map(([method, operation]) => {
+				const upperMethod = method.toUpperCase();
+				return {
+					method: upperMethod,
+					path,
+					label: operation.summary || `${upperMethod} ${path}`,
+					confirm: confirmations[`${upperMethod} ${path}`],
+				};
+			}))
+		.sort((left, right) => left.path.localeCompare(right.path) || left.method.localeCompare(right.method));
+
+	const confirmRequest = (definition, confirm) => !definition.confirm || confirm(definition.confirm);
 
 	const createRequest = ({ path, method, query, body, apiKey }) => {
 		if (typeof path !== 'string' || !path.startsWith('/api/') || path.includes('?') || path.includes('#')) {
 			throw new Error('API path must start with /api/');
 		}
+		validateQuery(query);
 
 		const params = new URLSearchParams();
 		Object.entries(query || {}).forEach(([key, value]) => {
@@ -36,5 +82,11 @@
 		return { url: search ? `${path}?${search}` : path, options };
 	};
 
-	return { createRequest };
+	return {
+		confirmRequest,
+		createRequest,
+		operationDefinitions,
+		redactSecret,
+		validateQuery,
+	};
 }));

--- a/src/admin/admin.css
+++ b/src/admin/admin.css
@@ -1,0 +1,22 @@
+:root { color-scheme: dark; font-family: system-ui, sans-serif; background: #10151c; color: #edf2f7; }
+* { box-sizing: border-box; }
+body { margin: 0; }
+button, input { font: inherit; }
+button { cursor: pointer; border: 1px solid #65758b; border-radius: .4rem; background: #1d2a3a; color: inherit; padding: .55rem .8rem; }
+button:hover { background: #2a3d54; }
+button:focus-visible, input:focus-visible { outline: 3px solid #65c3ff; outline-offset: 2px; }
+.console-shell { width: min(100% - 2rem, 70rem); margin: 2rem auto; display: grid; gap: 1rem; }
+header, section, nav { background: #17212d; border: 1px solid #34465b; border-radius: .6rem; padding: 1rem; }
+header, nav { display: flex; align-items: center; gap: .75rem; flex-wrap: wrap; }
+header h1 { margin: 0; font-size: clamp(1.4rem, 4vw, 2rem); margin-right: auto; }
+h2 { margin-top: 0; }
+label { display: grid; gap: .4rem; max-width: 30rem; }
+input { width: 100%; border: 1px solid #65758b; border-radius: .4rem; background: #0e1721; color: inherit; padding: .55rem; }
+#save-key { margin-top: .75rem; }
+#view { min-height: 5rem; }
+.request-state { color: #9ed0f5; }
+.response-block { overflow: auto; padding: 1rem; background: #0e1721; border-radius: .4rem; white-space: pre-wrap; }
+.destructive-action { background: #732f3f; border-color: #ef8798; }
+.destructive-action:hover { background: #944052; }
+.confirm-action { border: 2px solid #ef8798; padding: 1rem; }
+@media (max-width: 36rem) { .console-shell { width: min(100% - 1rem, 70rem); margin: .5rem auto; } header { align-items: stretch; } header button { width: 100%; } nav button { flex: 1 1 8rem; } }

--- a/src/admin/admin.css
+++ b/src/admin/admin.css
@@ -1,22 +1,31 @@
 :root { color-scheme: dark; font-family: system-ui, sans-serif; background: #10151c; color: #edf2f7; }
 * { box-sizing: border-box; }
 body { margin: 0; }
-button, input { font: inherit; }
+button, input, select, textarea { font: inherit; }
 button { cursor: pointer; border: 1px solid #65758b; border-radius: .4rem; background: #1d2a3a; color: inherit; padding: .55rem .8rem; }
 button:hover { background: #2a3d54; }
-button:focus-visible, input:focus-visible { outline: 3px solid #65c3ff; outline-offset: 2px; }
+button:disabled { cursor: wait; opacity: .65; }
+button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible { outline: 3px solid #65c3ff; outline-offset: 2px; }
 .console-shell { width: min(100% - 2rem, 70rem); margin: 2rem auto; display: grid; gap: 1rem; }
 header, section, nav { background: #17212d; border: 1px solid #34465b; border-radius: .6rem; padding: 1rem; }
 header, nav { display: flex; align-items: center; gap: .75rem; flex-wrap: wrap; }
 header h1 { margin: 0; font-size: clamp(1.4rem, 4vw, 2rem); margin-right: auto; }
-h2 { margin-top: 0; }
-label { display: grid; gap: .4rem; max-width: 30rem; }
-input { width: 100%; border: 1px solid #65758b; border-radius: .4rem; background: #0e1721; color: inherit; padding: .55rem; }
+h2, h3 { margin-top: 0; }
+label { display: grid; gap: .4rem; }
+input, select, textarea { width: 100%; border: 1px solid #65758b; border-radius: .4rem; background: #0e1721; color: inherit; padding: .55rem; }
+textarea { resize: vertical; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
 #save-key { margin-top: .75rem; }
-#view { min-height: 5rem; }
+#key-state:empty { display: none; }
+#view { min-height: 5rem; display: grid; gap: 1rem; }
+#view > h2 { margin-bottom: 0; }
+nav [aria-current="page"] { background: #35628a; border-color: #86ceff; }
+.operation-card { display: grid; gap: .75rem; border: 1px solid #34465b; border-radius: .5rem; padding: 1rem; }
+.operation-card h3 { margin-bottom: -.25rem; }
+.operation-card button { justify-self: start; }
+.form-fields { display: grid; gap: .75rem; }
 .request-state { color: #9ed0f5; }
-.response-block { overflow: auto; padding: 1rem; background: #0e1721; border-radius: .4rem; white-space: pre-wrap; }
+.response-block { min-height: 3rem; overflow: auto; margin: 0; padding: 1rem; background: #0e1721; border-radius: .4rem; white-space: pre-wrap; }
+.response-error { color: #ffc4cd; border: 1px solid #ef8798; }
 .destructive-action { background: #732f3f; border-color: #ef8798; }
 .destructive-action:hover { background: #944052; }
-.confirm-action { border: 2px solid #ef8798; padding: 1rem; }
 @media (max-width: 36rem) { .console-shell { width: min(100% - 1rem, 70rem); margin: .5rem auto; } header { align-items: stretch; } header button { width: 100%; } nav button { flex: 1 1 8rem; } }

--- a/src/admin/admin.js
+++ b/src/admin/admin.js
@@ -1,7 +1,325 @@
 'use strict';
 
-document.addEventListener('DOMContentLoaded', () => {
-	const view = document.getElementById('view');
+const VIEWS = {
+	status: [{ method: 'GET', path: '/api/status', label: 'Refresh status' }],
+	alerts: [{ method: 'GET', path: '/api/alerts', label: 'Load alerts' }],
+	presets: [{ method: 'GET', path: '/api/scanner-presets', label: 'Load presets' }],
+	jobs: [{ method: 'POST', path: '/api/jobs/tradingview-analysis', label: 'Create job' }],
+	analysis: [
+		{ method: 'POST', path: '/api/webhook/expanded-analysis-alert', label: 'Expanded analysis' },
+		{ method: 'POST', path: '/api/webhook/market-scanner-alert', label: 'Market scanner' },
+		{ method: 'POST', path: '/api/webhook/volume-confirmation', label: 'Volume confirmation' },
+		{ method: 'POST', path: '/api/news-monitor', label: 'News monitor' },
+	],
+};
 
-	view.textContent = 'Select a console section to begin.';
+const VIEW_ACTIONS = {
+	alerts: [
+		{
+			method: 'POST', path: '/api/alerts/{alertId}/replay', label: 'Replay alert',
+			confirm: 'Replay this alert?',
+		},
+	],
+	presets: [
+		{
+			method: 'POST', path: '/api/scanner-presets/{id}/run', label: 'Run preset',
+			confirm: 'Run this scanner preset?',
+		},
+		{
+			method: 'DELETE', path: '/api/scanner-presets/{id}', label: 'Delete preset',
+			confirm: 'Delete this scanner preset?',
+		},
+	],
+	jobs: [
+		{ method: 'GET', path: '/api/jobs/{jobId}', label: 'Get job status' },
+		{
+			method: 'POST', path: '/api/jobs/{jobId}/cancel', label: 'Cancel job',
+			confirm: 'Cancel this job?',
+		},
+		{
+			method: 'POST', path: '/api/jobs/{jobId}/retry', label: 'Retry job',
+			confirm: 'Retry this job?',
+		},
+	],
+};
+
+const contractPromise = fetch('/openapi.json').then((response) => {
+	if (!response.ok) throw new Error(`OpenAPI contract returned HTTP ${response.status}`);
+	return response.json();
+});
+
+const element = (tag, options = {}) => {
+	const node = document.createElement(tag);
+	if (options.className) node.className = options.className;
+	if (options.text) node.textContent = options.text;
+	return node;
+};
+
+const parseJson = (value, label) => {
+	if (!value.trim()) return undefined;
+	try {
+		return JSON.parse(value);
+	} catch (error) {
+		throw new Error(`${label} must be valid JSON: ${error.message}`);
+	}
+};
+
+const resolveRef = (contract, value) => {
+	if (!value || !value.$ref) return value;
+	return value.$ref.slice(2).split('/').reduce((current, key) => current[key], contract);
+};
+
+const getOperation = (contract, definition) => contract.paths[definition.path]
+	&& contract.paths[definition.path][definition.method.toLowerCase()];
+
+const getParameters = (contract, operation) => (operation && operation.parameters || [])
+	.map((parameter) => resolveRef(contract, parameter));
+
+const getBodyExample = (contract, operation) => {
+	const requestBody = resolveRef(contract, operation && operation.requestBody);
+	const json = requestBody && requestBody.content && requestBody.content['application/json'];
+	if (!json) return {};
+	if (json.example !== undefined) return json.example;
+	const firstExample = json.examples && Object.values(json.examples)[0];
+	return firstExample && firstExample.value || {};
+};
+
+const getQueryExample = (contract, operation) => Object.fromEntries(getParameters(contract, operation)
+	.filter((parameter) => parameter.in === 'query' && (parameter.example !== undefined
+		|| parameter.schema && (parameter.schema.example !== undefined || parameter.schema.default !== undefined)))
+	.map((parameter) => [parameter.name, parameter.example !== undefined
+		? parameter.example
+		: parameter.schema.example !== undefined ? parameter.schema.example : parameter.schema.default]));
+
+const addJsonField = (form, labelText, name, value) => {
+	const label = element('label', { text: labelText });
+	const textarea = element('textarea');
+	textarea.name = name;
+	textarea.rows = 8;
+	textarea.value = JSON.stringify(value, null, 2);
+	label.append(textarea);
+	form.append(label);
+};
+
+const addPathFields = (form, path) => {
+	const names = [...path.matchAll(/\{([^}]+)\}/g)].map((match) => match[1]);
+	names.forEach((name) => {
+		const label = element('label', { text: name });
+		const input = element('input');
+		input.name = `path-${name}`;
+		input.required = true;
+		input.placeholder = name;
+		label.append(input);
+		form.append(label);
+	});
+	return names;
+};
+
+const fillPath = (path, names, form) => names.reduce((resolved, name) => resolved.replace(
+	`{${name}}`,
+	encodeURIComponent(form.elements[`path-${name}`].value),
+), path);
+
+const showError = (output, message) => {
+	output.className = 'response-block response-error';
+	output.textContent = message;
+};
+
+const redactApiKey = (value, apiKey) => apiKey
+	? String(value).split(apiKey).join('[REDACTED]')
+	: String(value);
+
+const sendRequest = async ({ definition, path, query, body, button, output }) => {
+	const apiKey = document.getElementById('api-key').value;
+	const summary = redactApiKey(`${definition.method} ${path}`, apiKey);
+	let request;
+	try {
+		request = window.CabrosAdminRequest.createRequest({
+			path,
+			method: definition.method,
+			query,
+			body,
+			apiKey,
+		});
+	} catch (error) {
+		showError(output, error.message);
+		return;
+	}
+
+	if (definition.confirm && !window.confirm(definition.confirm)) return;
+
+	button.disabled = true;
+	output.className = 'response-block request-state';
+	output.textContent = `${summary}\nRequest in progress…`;
+	const started = performance.now();
+	try {
+		const response = await fetch(request.url, request.options);
+		const elapsed = Math.round(performance.now() - started);
+		const text = await response.text();
+		let formatted = text || '(empty response)';
+		try {
+			formatted = JSON.stringify(JSON.parse(text), null, 2);
+		} catch (_) {
+			// Non-JSON responses stay readable as text.
+		}
+		output.className = `response-block${response.ok ? '' : ' response-error'}`;
+		output.textContent = `${summary}\nHTTP ${response.status} · ${elapsed} ms\n\n${redactApiKey(formatted, apiKey)}`;
+	} catch (error) {
+		const elapsed = Math.round(performance.now() - started);
+		showError(output, `${summary}\nNetwork error · ${elapsed} ms\n\n${redactApiKey(error.message, apiKey)}`);
+	} finally {
+		button.disabled = false;
+	}
+};
+
+const createOperationForm = (contract, definition) => {
+	const operation = getOperation(contract, definition);
+	const form = element('form', { className: 'operation-card' });
+	const title = element('h3', { text: definition.label });
+	const route = element('code', { text: `${definition.method} ${definition.path}` });
+	form.append(title, route);
+	const pathNames = addPathFields(form, definition.path);
+
+	if (definition.method === 'GET') {
+		addJsonField(form, 'Query JSON', 'query', getQueryExample(contract, operation));
+	} else if (operation && operation.requestBody) {
+		addJsonField(form, 'Request body JSON', 'body', getBodyExample(contract, operation));
+	}
+
+	const button = element('button', { text: definition.label });
+	button.type = 'submit';
+	if (definition.confirm) button.className = 'destructive-action';
+	const output = element('pre', { className: 'response-block', text: 'No request sent.' });
+	form.append(button, output);
+	form.addEventListener('submit', (event) => {
+		event.preventDefault();
+		try {
+			const query = form.elements.query ? parseJson(form.elements.query.value, 'Query') : undefined;
+			const body = form.elements.body ? parseJson(form.elements.body.value, 'Request body') : undefined;
+			sendRequest({
+				definition,
+				path: fillPath(definition.path, pathNames, form),
+				query,
+				body,
+				button,
+				output,
+			});
+		} catch (error) {
+			showError(output, error.message);
+		}
+	});
+	return form;
+};
+
+const operationDefinitions = (contract) => Object.entries(contract.paths).flatMap(([path, methods]) => Object.entries(methods)
+	.filter(([method]) => ['get', 'post', 'put', 'patch', 'delete'].includes(method))
+	.map(([method, operation]) => ({
+		method: method.toUpperCase(),
+		path,
+		label: operation.summary || `${method.toUpperCase()} ${path}`,
+	})))
+	.sort((left, right) => left.path.localeCompare(right.path) || left.method.localeCompare(right.method));
+
+const renderPlayground = (contract, view) => {
+	const form = element('form', { className: 'operation-card playground' });
+	form.append(element('h2', { text: 'Playground' }));
+	const selectLabel = element('label', { text: 'Operation' });
+	const select = element('select');
+	const definitions = operationDefinitions(contract);
+	definitions.forEach((definition, index) => {
+		const option = element('option', { text: `${definition.method} ${definition.path} — ${definition.label}` });
+		option.value = index;
+		select.append(option);
+	});
+	selectLabel.append(select);
+	const fields = element('div', { className: 'form-fields' });
+	const button = element('button', { text: 'Send request' });
+	button.type = 'submit';
+	const output = element('pre', { className: 'response-block', text: 'No request sent.' });
+	form.append(selectLabel, fields, button, output);
+	view.append(form);
+
+	const renderFields = () => {
+		fields.replaceChildren();
+		const definition = definitions[Number(select.value)];
+		const operation = getOperation(contract, definition);
+		addPathFields(fields, definition.path);
+		addJsonField(fields, 'Query JSON', 'query', getQueryExample(contract, operation));
+		addJsonField(fields, 'Request body JSON', 'body', getBodyExample(contract, operation));
+	};
+
+	select.addEventListener('change', renderFields);
+	form.addEventListener('submit', (event) => {
+		event.preventDefault();
+		try {
+			const definition = definitions[Number(select.value)];
+			const pathNames = [...definition.path.matchAll(/\{([^}]+)\}/g)].map((match) => match[1]);
+			sendRequest({
+				definition,
+				path: fillPath(definition.path, pathNames, form),
+				query: parseJson(form.elements.query.value, 'Query'),
+				body: parseJson(form.elements.body.value, 'Request body'),
+				button,
+				output,
+			});
+		} catch (error) {
+			showError(output, error.message);
+		}
+	});
+	renderFields();
+};
+
+const renderView = async (name) => {
+	const view = document.getElementById('view');
+	view.replaceChildren(element('p', { className: 'request-state', text: 'Loading API contract…' }));
+	try {
+		const contract = await contractPromise;
+		view.replaceChildren();
+		if (name === 'playground') {
+			renderPlayground(contract, view);
+			return;
+		}
+		view.append(element('h2', { text: name[0].toUpperCase() + name.slice(1) }));
+		[...(VIEWS[name] || []), ...(VIEW_ACTIONS[name] || [])]
+			.forEach((definition) => view.append(createOperationForm(contract, definition)));
+	} catch (error) {
+		showError(view, `Unable to load the API contract: ${error.message}`);
+	}
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+	const apiKey = document.getElementById('api-key');
+	const keyState = document.getElementById('key-state');
+	try {
+		apiKey.value = sessionStorage.getItem('cabros-admin-api-key') || '';
+	} catch (_) {
+		keyState.textContent = 'Session storage is unavailable; the key will remain in this tab only.';
+	}
+
+	document.getElementById('save-key').addEventListener('click', () => {
+		try {
+			sessionStorage.setItem('cabros-admin-api-key', apiKey.value);
+			keyState.textContent = 'API key saved for this browser session.';
+		} catch (error) {
+			keyState.textContent = `Could not save the API key: ${error.message}`;
+		}
+	});
+
+	document.getElementById('clear-key').addEventListener('click', () => {
+		apiKey.value = '';
+		try {
+			sessionStorage.removeItem('cabros-admin-api-key');
+			keyState.textContent = 'API key cleared.';
+		} catch (error) {
+			keyState.textContent = `API key cleared from the form; session storage failed: ${error.message}`;
+		}
+	});
+
+	document.querySelectorAll('[data-view]').forEach((button) => button.addEventListener('click', () => {
+		document.querySelectorAll('[data-view]').forEach((item) => item.removeAttribute('aria-current'));
+		button.setAttribute('aria-current', 'page');
+		renderView(button.dataset.view);
+	}));
+
+	renderView('status');
 });

--- a/src/admin/admin.js
+++ b/src/admin/admin.js
@@ -125,13 +125,9 @@ const showError = (output, message) => {
 	output.textContent = message;
 };
 
-const redactApiKey = (value, apiKey) => apiKey
-	? String(value).split(apiKey).join('[REDACTED]')
-	: String(value);
-
 const sendRequest = async ({ definition, path, query, body, button, output }) => {
 	const apiKey = document.getElementById('api-key').value;
-	const summary = redactApiKey(`${definition.method} ${path}`, apiKey);
+	const summary = window.CabrosAdminRequest.redactSecret(`${definition.method} ${path}`, apiKey);
 	let request;
 	try {
 		request = window.CabrosAdminRequest.createRequest({
@@ -146,7 +142,7 @@ const sendRequest = async ({ definition, path, query, body, button, output }) =>
 		return;
 	}
 
-	if (definition.confirm && !window.confirm(definition.confirm)) return;
+	if (!window.CabrosAdminRequest.confirmRequest(definition, (message) => window.confirm(message))) return;
 
 	button.disabled = true;
 	output.className = 'response-block request-state';
@@ -163,10 +159,10 @@ const sendRequest = async ({ definition, path, query, body, button, output }) =>
 			// Non-JSON responses stay readable as text.
 		}
 		output.className = `response-block${response.ok ? '' : ' response-error'}`;
-		output.textContent = `${summary}\nHTTP ${response.status} · ${elapsed} ms\n\n${redactApiKey(formatted, apiKey)}`;
+		output.textContent = `${summary}\nHTTP ${response.status} · ${elapsed} ms\n\n${window.CabrosAdminRequest.redactSecret(formatted, apiKey)}`;
 	} catch (error) {
 		const elapsed = Math.round(performance.now() - started);
-		showError(output, `${summary}\nNetwork error · ${elapsed} ms\n\n${redactApiKey(error.message, apiKey)}`);
+		showError(output, `${summary}\nNetwork error · ${elapsed} ms\n\n${window.CabrosAdminRequest.redactSecret(error.message, apiKey)}`);
 	} finally {
 		button.disabled = false;
 	}
@@ -194,7 +190,9 @@ const createOperationForm = (contract, definition) => {
 	form.addEventListener('submit', (event) => {
 		event.preventDefault();
 		try {
-			const query = form.elements.query ? parseJson(form.elements.query.value, 'Query') : undefined;
+			const query = form.elements.query
+				? window.CabrosAdminRequest.validateQuery(parseJson(form.elements.query.value, 'Query'))
+				: undefined;
 			const body = form.elements.body ? parseJson(form.elements.body.value, 'Request body') : undefined;
 			sendRequest({
 				definition,
@@ -211,21 +209,12 @@ const createOperationForm = (contract, definition) => {
 	return form;
 };
 
-const operationDefinitions = (contract) => Object.entries(contract.paths).flatMap(([path, methods]) => Object.entries(methods)
-	.filter(([method]) => ['get', 'post', 'put', 'patch', 'delete'].includes(method))
-	.map(([method, operation]) => ({
-		method: method.toUpperCase(),
-		path,
-		label: operation.summary || `${method.toUpperCase()} ${path}`,
-	})))
-	.sort((left, right) => left.path.localeCompare(right.path) || left.method.localeCompare(right.method));
-
 const renderPlayground = (contract, view) => {
 	const form = element('form', { className: 'operation-card playground' });
 	form.append(element('h2', { text: 'Playground' }));
 	const selectLabel = element('label', { text: 'Operation' });
 	const select = element('select');
-	const definitions = operationDefinitions(contract);
+	const definitions = window.CabrosAdminRequest.operationDefinitions(contract);
 	definitions.forEach((definition, index) => {
 		const option = element('option', { text: `${definition.method} ${definition.path} — ${definition.label}` });
 		option.value = index;
@@ -243,6 +232,7 @@ const renderPlayground = (contract, view) => {
 		fields.replaceChildren();
 		const definition = definitions[Number(select.value)];
 		const operation = getOperation(contract, definition);
+		button.className = definition.confirm ? 'destructive-action' : '';
 		addPathFields(fields, definition.path);
 		addJsonField(fields, 'Query JSON', 'query', getQueryExample(contract, operation));
 		addJsonField(fields, 'Request body JSON', 'body', getBodyExample(contract, operation));
@@ -257,7 +247,7 @@ const renderPlayground = (contract, view) => {
 			sendRequest({
 				definition,
 				path: fillPath(definition.path, pathNames, form),
-				query: parseJson(form.elements.query.value, 'Query'),
+				query: window.CabrosAdminRequest.validateQuery(parseJson(form.elements.query.value, 'Query')),
 				body: parseJson(form.elements.body.value, 'Request body'),
 				button,
 				output,

--- a/src/admin/admin.js
+++ b/src/admin/admin.js
@@ -107,6 +107,14 @@ const withReplayIdempotencyKey = (definition, body) => {
 	return { ...(body || {}), idempotencyKey: createIdempotencyKey() };
 };
 
+const getRequestBody = (definition, form) => {
+	const input = form.elements.body;
+	const body = input ? parseJson(input.value, 'Request body') : undefined;
+	const requestBody = withReplayIdempotencyKey(definition, body);
+	if (input && requestBody !== body) input.value = JSON.stringify(requestBody, null, 2);
+	return requestBody;
+};
+
 const addJsonField = (form, labelText, name, value) => {
 	const label = element('label', { text: labelText });
 	const textarea = element('textarea');
@@ -338,10 +346,7 @@ const createOperationForm = (contract, definition) => {
 			const query = form.elements.query
 				? window.CabrosAdminRequest.validateQuery(parseJson(form.elements.query.value, 'Query'))
 				: undefined;
-			const body = withReplayIdempotencyKey(
-				definition,
-				form.elements.body ? parseJson(form.elements.body.value, 'Request body') : undefined,
-			);
+			const body = getRequestBody(definition, form);
 			sendRequest({
 				definition,
 				path: fillPath(definition.path, pathNames, form),
@@ -396,7 +401,7 @@ const renderPlayground = (contract, view) => {
 				definition,
 				path: fillPath(definition.path, pathNames, form),
 				query: window.CabrosAdminRequest.validateQuery(parseJson(form.elements.query.value, 'Query')),
-				body: parseJson(form.elements.body.value, 'Request body'),
+				body: getRequestBody(definition, form),
 				button,
 				output,
 			});

--- a/src/admin/admin.js
+++ b/src/admin/admin.js
@@ -1,9 +1,13 @@
 'use strict';
 
+/* global document, window */
+
 const VIEWS = {
 	status: [{ method: 'GET', path: '/api/status', label: 'Refresh status' }],
-	alerts: [{ method: 'GET', path: '/api/alerts', label: 'Load alerts' }],
-	presets: [{ method: 'GET', path: '/api/scanner-presets', label: 'Load presets' }],
+	presets: [
+		{ method: 'GET', path: '/api/scanner-presets', label: 'Load presets' },
+		{ method: 'POST', path: '/api/scanner-presets', label: 'Create preset' },
+	],
 	jobs: [{ method: 'POST', path: '/api/jobs/tradingview-analysis', label: 'Create job' }],
 	analysis: [
 		{ method: 'POST', path: '/api/webhook/expanded-analysis-alert', label: 'Expanded analysis' },
@@ -15,12 +19,14 @@ const VIEWS = {
 
 const VIEW_ACTIONS = {
 	alerts: [
+		{ method: 'GET', path: '/api/alerts/{alertId}', label: 'Get alert by ID' },
 		{
 			method: 'POST', path: '/api/alerts/{alertId}/replay', label: 'Replay alert',
 			confirm: 'Replay this alert?',
 		},
 	],
 	presets: [
+		{ method: 'PUT', path: '/api/scanner-presets/{id}', label: 'Update preset' },
 		{
 			method: 'POST', path: '/api/scanner-presets/{id}/run', label: 'Run preset',
 			confirm: 'Run this scanner preset?',
@@ -30,23 +36,23 @@ const VIEW_ACTIONS = {
 			confirm: 'Delete this scanner preset?',
 		},
 	],
-	jobs: [
-		{ method: 'GET', path: '/api/jobs/{jobId}', label: 'Get job status' },
-		{
-			method: 'POST', path: '/api/jobs/{jobId}/cancel', label: 'Cancel job',
-			confirm: 'Cancel this job?',
-		},
-		{
-			method: 'POST', path: '/api/jobs/{jobId}/retry', label: 'Retry job',
-			confirm: 'Retry this job?',
-		},
-	],
 };
 
-const contractPromise = fetch('/openapi.json').then((response) => {
-	if (!response.ok) throw new Error(`OpenAPI contract returned HTTP ${response.status}`);
-	return response.json();
-});
+let contractPromise;
+const loadContract = () => {
+	if (!contractPromise) {
+		contractPromise = fetch('/openapi.json')
+			.then((response) => {
+				if (!response.ok) throw new Error(`OpenAPI contract returned HTTP ${response.status}`);
+				return response.json();
+			})
+			.catch((error) => {
+				contractPromise = undefined;
+				throw error;
+			});
+	}
+	return contractPromise;
+};
 
 const element = (tag, options = {}) => {
 	const node = document.createElement(tag);
@@ -101,6 +107,18 @@ const addJsonField = (form, labelText, name, value) => {
 	form.append(label);
 };
 
+const addField = (form, labelText, name, options = {}) => {
+	const label = element('label', { text: labelText });
+	const input = element(options.tag || 'input');
+	input.name = name;
+	Object.entries(options).forEach(([key, value]) => {
+		if (key !== 'tag') input[key] = value;
+	});
+	label.append(input);
+	form.append(label);
+	return input;
+};
+
 const addPathFields = (form, path) => {
 	const names = [...path.matchAll(/\{([^}]+)\}/g)].map((match) => match[1]);
 	names.forEach((name) => {
@@ -152,20 +170,136 @@ const sendRequest = async ({ definition, path, query, body, button, output }) =>
 		const response = await fetch(request.url, request.options);
 		const elapsed = Math.round(performance.now() - started);
 		const text = await response.text();
+		let data;
 		let formatted = text || '(empty response)';
 		try {
-			formatted = JSON.stringify(JSON.parse(text), null, 2);
+			data = JSON.parse(text);
+			formatted = JSON.stringify(data, null, 2);
 		} catch (_) {
 			// Non-JSON responses stay readable as text.
 		}
 		output.className = `response-block${response.ok ? '' : ' response-error'}`;
 		output.textContent = `${summary}\nHTTP ${response.status} · ${elapsed} ms\n\n${window.CabrosAdminRequest.redactSecret(formatted, apiKey)}`;
+		return data;
 	} catch (error) {
 		const elapsed = Math.round(performance.now() - started);
 		showError(output, `${summary}\nNetwork error · ${elapsed} ms\n\n${window.CabrosAdminRequest.redactSecret(error.message, apiKey)}`);
 	} finally {
 		button.disabled = false;
 	}
+};
+
+const createAlertListForm = () => {
+	const definition = { method: 'GET', path: '/api/alerts', label: 'Load alerts' };
+	const form = element('form', { className: 'operation-card' });
+	form.append(
+		element('h3', { text: definition.label }),
+		element('code', { text: `${definition.method} ${definition.path}` }),
+	);
+	const limit = addField(form, 'Limit', 'limit', { type: 'number', min: 1, max: 100, value: 50 });
+	const before = addField(form, 'Before cursor', 'before', { placeholder: 'nextBefore from the previous page' });
+	const source = addField(form, 'Source', 'source', { placeholder: 'webhook' });
+	const enriched = addField(form, 'Enriched', 'enriched', { tag: 'select' });
+	[
+		['', 'All alerts'],
+		['true', 'Enriched only'],
+		['false', 'Not enriched'],
+	].forEach(([value, text]) => {
+		const option = element('option', { text });
+		option.value = value;
+		enriched.append(option);
+	});
+	const button = element('button', { text: definition.label });
+	button.type = 'submit';
+	const next = element('button', { text: 'Next page' });
+	next.type = 'button';
+	next.disabled = true;
+	const output = element('pre', { className: 'response-block', text: 'No request sent.' });
+	form.append(button, next, output);
+
+	let nextBefore;
+	const requestPage = async (cursor) => {
+		if (cursor) before.value = cursor;
+		const query = Object.fromEntries(Object.entries({
+			limit: limit.value,
+			before: before.value,
+			source: source.value,
+			enriched: enriched.value,
+		}).filter(([, value]) => value !== ''));
+		const data = await sendRequest({ definition, path: definition.path, query, button, output });
+		nextBefore = data && data.pagination && data.pagination.nextBefore;
+		next.disabled = !nextBefore;
+	};
+	form.addEventListener('submit', (event) => {
+		event.preventDefault();
+		return requestPage(before.value);
+	});
+	next.addEventListener('click', () => requestPage(nextBefore));
+	return form;
+};
+
+const createJobStatusForm = () => {
+	const definition = { method: 'GET', path: '/api/jobs/{jobId}', label: 'Get job status' };
+	const form = element('form', { className: 'operation-card' });
+	form.append(
+		element('h3', { text: definition.label }),
+		element('code', { text: `${definition.method} ${definition.path}` }),
+	);
+	const pathNames = addPathFields(form, definition.path);
+	const button = element('button', { text: definition.label });
+	button.type = 'submit';
+	const actions = element('div', { className: 'form-actions' });
+	const output = element('pre', { className: 'response-block', text: 'No request sent.' });
+	form.append(button, actions, output);
+
+	const renderActions = (job, jobId) => {
+		actions.replaceChildren();
+		const failedItems = [...(job.results || []), ...(job.scanResults || [])]
+			.some((result) => ['error', 'timeout'].includes(result.status));
+		const definitions = [];
+		if (['pending', 'processing'].includes(job.status)) {
+			definitions.push({
+				method: 'POST', path: '/api/jobs/{jobId}/cancel', label: 'Cancel job', confirm: 'Cancel this job?',
+			});
+		}
+		if (['failed', 'timed_out', 'cancelled'].includes(job.status)) {
+			definitions.push({
+				method: 'POST', path: '/api/jobs/{jobId}/retry', label: 'Retry job', confirm: 'Retry this job?',
+			});
+		}
+		if (failedItems) {
+			definitions.push({
+				method: 'POST', path: '/api/jobs/{jobId}/retry-failed', label: 'Retry failed items',
+				confirm: 'Retry failed items for this job?',
+			});
+		}
+		definitions.forEach((action) => {
+			const actionButton = element('button', { text: action.label });
+			actionButton.type = 'button';
+			actionButton.className = 'destructive-action';
+			actionButton.addEventListener('click', () => sendRequest({
+				definition: action,
+				path: action.path.replace('{jobId}', encodeURIComponent(jobId)),
+				button: actionButton,
+				output,
+			}));
+			actions.append(actionButton);
+		});
+	};
+
+	form.addEventListener('submit', async (event) => {
+		event.preventDefault();
+		const jobId = form.elements['path-jobId'].value;
+		const data = await sendRequest({
+			definition,
+			path: fillPath(definition.path, pathNames, form),
+			button,
+			output,
+		});
+		if (data && data.status) renderActions(data, jobId);
+		else actions.replaceChildren();
+	});
+	return form;
 };
 
 const createOperationForm = (contract, definition) => {
@@ -263,13 +397,23 @@ const renderView = async (name) => {
 	const view = document.getElementById('view');
 	view.replaceChildren(element('p', { className: 'request-state', text: 'Loading API contract…' }));
 	try {
-		const contract = await contractPromise;
+		const contract = await loadContract();
 		view.replaceChildren();
 		if (name === 'playground') {
 			renderPlayground(contract, view);
 			return;
 		}
 		view.append(element('h2', { text: name[0].toUpperCase() + name.slice(1) }));
+		if (name === 'alerts') {
+			view.append(createAlertListForm());
+			VIEW_ACTIONS.alerts.forEach((definition) => view.append(createOperationForm(contract, definition)));
+			return;
+		}
+		if (name === 'jobs') {
+			VIEWS.jobs.forEach((definition) => view.append(createOperationForm(contract, definition)));
+			view.append(createJobStatusForm());
+			return;
+		}
 		[...(VIEWS[name] || []), ...(VIEW_ACTIONS[name] || [])]
 			.forEach((definition) => view.append(createOperationForm(contract, definition)));
 	} catch (error) {

--- a/src/admin/admin.js
+++ b/src/admin/admin.js
@@ -1,0 +1,7 @@
+'use strict';
+
+document.addEventListener('DOMContentLoaded', () => {
+	const view = document.getElementById('view');
+
+	view.textContent = 'Select a console section to begin.';
+});

--- a/src/admin/admin.js
+++ b/src/admin/admin.js
@@ -103,7 +103,7 @@ const createIdempotencyKey = () => (window.crypto && typeof window.crypto.random
 
 const withReplayIdempotencyKey = (definition, body) => {
 	if (definition.method !== 'POST' || definition.path !== '/api/alerts/{alertId}/replay') return body;
-	if (body && typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim()) return body;
+	if (body && ['idempotencyKey', 'idempotency_key'].some((key) => typeof body[key] === 'string' && body[key].trim())) return body;
 	return { ...(body || {}), idempotencyKey: createIdempotencyKey() };
 };
 

--- a/src/admin/admin.js
+++ b/src/admin/admin.js
@@ -97,6 +97,16 @@ const getQueryExample = (contract, operation) => Object.fromEntries(getParameter
 		? parameter.example
 		: parameter.schema.example !== undefined ? parameter.schema.example : parameter.schema.default]));
 
+const createIdempotencyKey = () => (window.crypto && typeof window.crypto.randomUUID === 'function'
+	? window.crypto.randomUUID()
+	: `admin-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+
+const withReplayIdempotencyKey = (definition, body) => {
+	if (definition.method !== 'POST' || definition.path !== '/api/alerts/{alertId}/replay') return body;
+	if (body && typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim()) return body;
+	return { ...(body || {}), idempotencyKey: createIdempotencyKey() };
+};
+
 const addJsonField = (form, labelText, name, value) => {
 	const label = element('label', { text: labelText });
 	const textarea = element('textarea');
@@ -310,9 +320,10 @@ const createOperationForm = (contract, definition) => {
 	form.append(title, route);
 	const pathNames = addPathFields(form, definition.path);
 
-	if (definition.method === 'GET') {
+	if (definition.method === 'GET' || getParameters(contract, operation).some((parameter) => parameter.in === 'query')) {
 		addJsonField(form, 'Query JSON', 'query', getQueryExample(contract, operation));
-	} else if (operation && operation.requestBody) {
+	}
+	if (definition.method !== 'GET' && operation && operation.requestBody) {
 		addJsonField(form, 'Request body JSON', 'body', getBodyExample(contract, operation));
 	}
 
@@ -327,7 +338,10 @@ const createOperationForm = (contract, definition) => {
 			const query = form.elements.query
 				? window.CabrosAdminRequest.validateQuery(parseJson(form.elements.query.value, 'Query'))
 				: undefined;
-			const body = form.elements.body ? parseJson(form.elements.body.value, 'Request body') : undefined;
+			const body = withReplayIdempotencyKey(
+				definition,
+				form.elements.body ? parseJson(form.elements.body.value, 'Request body') : undefined,
+			);
 			sendRequest({
 				definition,
 				path: fillPath(definition.path, pathNames, form),

--- a/src/admin/admin.js
+++ b/src/admin/admin.js
@@ -267,7 +267,7 @@ const createJobStatusForm = () => {
 				method: 'POST', path: '/api/jobs/{jobId}/retry', label: 'Retry job', confirm: 'Retry this job?',
 			});
 		}
-		if (failedItems) {
+		if (job.status !== 'processing' && failedItems) {
 			definitions.push({
 				method: 'POST', path: '/api/jobs/{jobId}/retry-failed', label: 'Retry failed items',
 				confirm: 'Retry failed items for this job?',

--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Cabros Bot Console</title>
+  <link rel="stylesheet" href="/admin/admin.css">
+</head>
+<body>
+  <main class="console-shell">
+    <header><h1>Cabros Bot Console</h1><button id="clear-key">Clear key</button></header>
+    <section aria-labelledby="connection-title">
+      <h2 id="connection-title">Connection</h2>
+      <label>API key <input id="api-key" type="password" autocomplete="off"></label>
+      <button id="save-key">Use key for this session</button>
+    </section>
+    <nav aria-label="Console sections">
+      <button data-view="status">Status</button><button data-view="alerts">Alerts</button>
+      <button data-view="presets">Presets</button><button data-view="jobs">Jobs</button>
+      <button data-view="analysis">Analysis</button><button data-view="playground">Playground</button>
+    </nav>
+    <section id="view" aria-live="polite"></section>
+  </main>
+  <script src="/admin/admin-request.js" defer></script>
+  <script src="/admin/admin.js" defer></script>
+</body>
+</html>

--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Cabros Bot Console</title>
-  <link rel="stylesheet" href="/admin/admin.css?v=2">
+  <link rel="stylesheet" href="/admin/admin.css">
 </head>
 <body>
   <main class="console-shell">
@@ -22,7 +22,7 @@
     </nav>
     <section id="view" aria-live="polite"></section>
   </main>
-  <script src="/admin/admin-request.js?v=2" defer></script>
-  <script src="/admin/admin.js?v=2" defer></script>
+  <script src="/admin/admin-request.js" defer></script>
+  <script src="/admin/admin.js" defer></script>
 </body>
 </html>

--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -8,16 +8,17 @@
 </head>
 <body>
   <main class="console-shell">
-    <header><h1>Cabros Bot Console</h1><button id="clear-key">Clear key</button></header>
+    <header><h1>Cabros Bot Console</h1><button id="clear-key" type="button">Clear key</button></header>
     <section aria-labelledby="connection-title">
       <h2 id="connection-title">Connection</h2>
       <label>API key <input id="api-key" type="password" autocomplete="off"></label>
-      <button id="save-key">Use key for this session</button>
+      <button id="save-key" type="button">Use key for this session</button>
+      <p id="key-state" class="request-state" aria-live="polite"></p>
     </section>
     <nav aria-label="Console sections">
-      <button data-view="status">Status</button><button data-view="alerts">Alerts</button>
-      <button data-view="presets">Presets</button><button data-view="jobs">Jobs</button>
-      <button data-view="analysis">Analysis</button><button data-view="playground">Playground</button>
+      <button data-view="status" type="button">Status</button><button data-view="alerts" type="button">Alerts</button>
+      <button data-view="presets" type="button">Presets</button><button data-view="jobs" type="button">Jobs</button>
+      <button data-view="analysis" type="button">Analysis</button><button data-view="playground" type="button">Playground</button>
     </nav>
     <section id="view" aria-live="polite"></section>
   </main>

--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Cabros Bot Console</title>
-  <link rel="stylesheet" href="/admin/admin.css">
+  <link rel="stylesheet" href="/admin/admin.css?v=2">
 </head>
 <body>
   <main class="console-shell">
@@ -22,7 +22,7 @@
     </nav>
     <section id="view" aria-live="polite"></section>
   </main>
-  <script src="/admin/admin-request.js" defer></script>
-  <script src="/admin/admin.js" defer></script>
+  <script src="/admin/admin-request.js?v=2" defer></script>
+  <script src="/admin/admin.js?v=2" defer></script>
 </body>
 </html>

--- a/src/openapi/docs.js
+++ b/src/openapi/docs.js
@@ -36,8 +36,7 @@ function getOpenApiDocsRouter() {
 
 	router.use('/admin', express.static(adminDir, {
 		index: false,
-		immutable: true,
-		maxAge: '1d',
+		setHeaders: (res) => res.setHeader('Cache-Control', 'no-cache'),
 	}));
 
 	return router;

--- a/src/openapi/docs.js
+++ b/src/openapi/docs.js
@@ -7,6 +7,7 @@ const contract = require('./openapi.json');
 
 const docsHtmlPath = path.join(__dirname, 'index.html');
 const initializerPath = path.join(__dirname, 'swagger-initializer.js');
+const adminDir = path.join(__dirname, '../admin');
 
 function getOpenApiDocsRouter() {
 	const router = express.Router();
@@ -23,6 +24,17 @@ function getOpenApiDocsRouter() {
 
 	router.get('/docs/swagger-initializer.js', (req, res) => res.sendFile(initializerPath));
 	router.use('/docs', express.static(swaggerUiDist.getAbsoluteFSPath(), {
+		index: false,
+		immutable: true,
+		maxAge: '1d',
+	}));
+
+	router.get('/admin', (req, res) => {
+		res.set('Cache-Control', 'no-cache');
+		return res.sendFile(path.join(adminDir, 'index.html'));
+	});
+
+	router.use('/admin', express.static(adminDir, {
 		index: false,
 		immutable: true,
 		maxAge: '1d',

--- a/tests/integration/openapi-docs.test.js
+++ b/tests/integration/openapi-docs.test.js
@@ -42,13 +42,15 @@ describe('public OpenAPI documentation', () => {
 	it('serves the API admin shell and external assets without an API key', async () => {
 		const page = await request(app).get('/admin');
 		const script = await request(app).get('/admin/admin.js');
+		const versionedScript = await request(app).get('/admin/admin.js?v=2');
 
 		expect(page.status).toBe(200);
 		expect(page.text).toContain('Cabros Bot Console');
-		expect(page.text).toContain('/admin/admin.js');
+		expect(page.text).toContain('/admin/admin.js?v=2');
 		expect(page.text).not.toContain(process.env.WEBHOOK_API_KEY);
 		expect(script.status).toBe(200);
 		expect(script.headers['content-type']).toMatch(/javascript/);
+		expect(versionedScript.status).toBe(200);
 	});
 
 	it('keeps the admin client contract-driven without exposing the configured API key', async () => {

--- a/tests/integration/openapi-docs.test.js
+++ b/tests/integration/openapi-docs.test.js
@@ -50,4 +50,12 @@ describe('public OpenAPI documentation', () => {
 		expect(script.status).toBe(200);
 		expect(script.headers['content-type']).toMatch(/javascript/);
 	});
+
+	it('keeps the admin client contract-driven without exposing the configured API key', async () => {
+		const client = await request(app).get('/admin/admin.js');
+
+		expect(client.status).toBe(200);
+		expect(client.text).toContain("fetch('/openapi.json')");
+		expect(client.text).not.toContain(process.env.WEBHOOK_API_KEY);
+	});
 });

--- a/tests/integration/openapi-docs.test.js
+++ b/tests/integration/openapi-docs.test.js
@@ -42,22 +42,22 @@ describe('public OpenAPI documentation', () => {
 	it('serves the API admin shell and external assets without an API key', async () => {
 		const page = await request(app).get('/admin');
 		const script = await request(app).get('/admin/admin.js');
-		const versionedScript = await request(app).get('/admin/admin.js?v=2');
 
 		expect(page.status).toBe(200);
 		expect(page.text).toContain('Cabros Bot Console');
-		expect(page.text).toContain('/admin/admin.js?v=2');
+		expect(page.text).toContain('/admin/admin.js');
+		expect(page.text).not.toMatch(/admin\.(?:js|css)\?v=/);
 		expect(page.text).not.toContain(process.env.WEBHOOK_API_KEY);
 		expect(script.status).toBe(200);
 		expect(script.headers['content-type']).toMatch(/javascript/);
-		expect(versionedScript.status).toBe(200);
+		expect(script.headers['cache-control']).toBe('no-cache');
 	});
 
 	it('keeps the admin client contract-driven without exposing the configured API key', async () => {
 		const client = await request(app).get('/admin/admin.js');
 
 		expect(client.status).toBe(200);
-		expect(client.text).toContain("fetch('/openapi.json')");
+		expect(client.text).toContain('fetch(\'/openapi.json\')');
 		expect(client.text).not.toContain(process.env.WEBHOOK_API_KEY);
 	});
 });

--- a/tests/integration/openapi-docs.test.js
+++ b/tests/integration/openapi-docs.test.js
@@ -38,4 +38,16 @@ describe('public OpenAPI documentation', () => {
 		expect(stylesheet.status).toBe(200);
 		expect(stylesheet.headers['content-type']).toMatch(/text\/css/);
 	});
+
+	it('serves the API admin shell and external assets without an API key', async () => {
+		const page = await request(app).get('/admin');
+		const script = await request(app).get('/admin/admin.js');
+
+		expect(page.status).toBe(200);
+		expect(page.text).toContain('Cabros Bot Console');
+		expect(page.text).toContain('/admin/admin.js');
+		expect(page.text).not.toContain(process.env.WEBHOOK_API_KEY);
+		expect(script.status).toBe(200);
+		expect(script.headers['content-type']).toMatch(/javascript/);
+	});
 });

--- a/tests/unit/admin-client.test.js
+++ b/tests/unit/admin-client.test.js
@@ -222,6 +222,28 @@ describe('admin browser client', () => {
 		expect(browser.helperCalls.at(-1).body.idempotencyKey).toEqual(expect.any(String));
 	});
 
+	it('preserves a supplied snake_case replay idempotency key', async () => {
+		const browser = createBrowser({
+			fetchImpl: async (url) => response(url === '/openapi.json' ? contract : {}),
+		});
+		await flush();
+		await selectView(browser, 'alerts');
+
+		const replayForm = findForm(browser.elementsById.view, 'POST /api/alerts/{alertId}/replay');
+		replayForm.elements['path-alertId'].value = 'alert-1';
+		replayForm.elements.body.value = JSON.stringify({
+			channels: ['telegram'],
+			idempotency_key: 'operator-replay-key',
+		});
+		await replayForm.dispatch('submit');
+		await flush();
+
+		expect(browser.helperCalls.at(-1).body).toEqual({
+			channels: ['telegram'],
+			idempotency_key: 'operator-replay-key',
+		});
+	});
+
 	it('retries the OpenAPI contract after the first load rejects', async () => {
 		let contractAttempts = 0;
 		const browser = createBrowser({

--- a/tests/unit/admin-client.test.js
+++ b/tests/unit/admin-client.test.js
@@ -197,6 +197,29 @@ describe('admin browser client', () => {
 		expect(events.slice(-2).map(([type]) => type)).toEqual(['confirm', 'fetch']);
 		expect(browser.helperCalls.at(-1).body.idempotencyKey).toEqual(expect.any(String));
 		expect(browser.helperCalls.at(-1).body.idempotencyKey).not.toBe('');
+		const replayIdempotencyKey = browser.helperCalls.at(-1).body.idempotencyKey;
+		await replayForm.dispatch('submit');
+		await flush();
+		expect(browser.helperCalls.at(-1).body.idempotencyKey).toBe(replayIdempotencyKey);
+	});
+
+	it('adds an idempotency key when Playground replays an alert', async () => {
+		const browser = createBrowser({
+			fetchImpl: async (url) => response(url === '/openapi.json' ? contract : {}),
+		});
+		await flush();
+		await selectView(browser, 'playground');
+
+		const playground = find(browser.elementsById.view, (node) => node.tagName === 'FORM'
+			&& node.textContent.includes('Playground'));
+		const select = find(playground, (node) => node.tagName === 'SELECT');
+		select.value = select.children.find((option) => option.textContent.includes('POST /api/alerts/{alertId}/replay')).value;
+		await select.dispatch('change');
+		playground.elements['path-alertId'].value = 'alert-1';
+		await playground.dispatch('submit');
+		await flush();
+
+		expect(browser.helperCalls.at(-1).body.idempotencyKey).toEqual(expect.any(String));
 	});
 
 	it('retries the OpenAPI contract after the first load rejects', async () => {

--- a/tests/unit/admin-client.test.js
+++ b/tests/unit/admin-client.test.js
@@ -293,6 +293,45 @@ describe('admin browser client', () => {
 		expect(findButton(statusForm, 'Retry failed items')).toBeUndefined();
 	});
 
+	it('does not offer or dispatch retry-failed for a processing job with failed items', async () => {
+		const job = {
+			success: true,
+			jobId: 'job-1',
+			type: 'expanded-analysis',
+			status: 'processing',
+			progress: { completed: 2, total: 4 },
+			createdAt: '2026-07-17T20:00:00.000Z',
+			updatedAt: '2026-07-17T20:01:00.000Z',
+			totalDurationMs: 60000,
+			results: [{ status: 'error' }, { status: 'timeout' }],
+		};
+		const browser = createBrowser({
+			fetchImpl: async (url) => {
+				if (url === '/openapi.json') return response(contract);
+				if (url === '/api/jobs/job-1') return response(job);
+				return response({});
+			},
+		});
+		await flush();
+		await selectView(browser, 'jobs');
+
+		const statusForm = findForm(browser.elementsById.view, 'GET /api/jobs/{jobId}');
+		statusForm.elements['path-jobId'].value = 'job-1';
+		await statusForm.dispatch('submit');
+		await flush();
+		const retryFailed = findButton(statusForm, 'Retry failed items');
+		if (retryFailed) {
+			await retryFailed.dispatch('click');
+			await flush();
+		}
+
+		expect(browser.context.fetch).not.toHaveBeenCalledWith(
+			'/api/jobs/job-1/retry-failed',
+			expect.anything(),
+		);
+		expect(retryFailed).toBeUndefined();
+	});
+
 	it('shows both retry actions only for a fetched failed job with failed items', async () => {
 		const job = { jobId: 'job-1', status: 'failed', results: [{ status: 'error' }] };
 		const browser = createBrowser({

--- a/tests/unit/admin-client.test.js
+++ b/tests/unit/admin-client.test.js
@@ -195,6 +195,8 @@ describe('admin browser client', () => {
 		await replayForm.dispatch('submit');
 		await flush();
 		expect(events.slice(-2).map(([type]) => type)).toEqual(['confirm', 'fetch']);
+		expect(browser.helperCalls.at(-1).body.idempotencyKey).toEqual(expect.any(String));
+		expect(browser.helperCalls.at(-1).body.idempotencyKey).not.toBe('');
 	});
 
 	it('retries the OpenAPI contract after the first load rejects', async () => {
@@ -270,6 +272,18 @@ describe('admin browser client', () => {
 		await selectView(browser, 'presets');
 		expect(findForm(browser.elementsById.view, 'POST /api/scanner-presets')).toBeDefined();
 		expect(findForm(browser.elementsById.view, 'PUT /api/scanner-presets/{id}')).toBeDefined();
+	});
+
+	it('renders query controls for POST operations that declare query parameters', async () => {
+		const browser = createBrowser({
+			fetchImpl: async (url) => response(url === '/openapi.json' ? contract : {}),
+		});
+		await flush();
+
+		await selectView(browser, 'presets');
+		const runForm = findForm(browser.elementsById.view, 'POST /api/scanner-presets/{id}/run');
+		expect(runForm.elements.query).toBeDefined();
+		expect(runForm.elements.query.value).toContain('"dryRun": false');
 	});
 
 	it('shows cancel only for a fetched active job', async () => {

--- a/tests/unit/admin-client.test.js
+++ b/tests/unit/admin-client.test.js
@@ -1,0 +1,323 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const requestHelper = require('../../src/admin/admin-request');
+const contract = require('../../src/openapi/openapi.json');
+
+class FakeElement {
+	constructor(tagName) {
+		this.tagName = tagName.toUpperCase();
+		this.children = [];
+		this.dataset = {};
+		this.listeners = {};
+		this.attributes = {};
+		this.className = '';
+		this.value = '';
+		this.disabled = false;
+		this._text = '';
+	}
+
+	get textContent() {
+		return this._text + this.children.map((child) => child.textContent).join('');
+	}
+
+	set textContent(value) {
+		this._text = String(value);
+		this.children = [];
+	}
+
+	get elements() {
+		return new Proxy({}, {
+			get: (_, name) => find(this, (node) => node.name === name),
+		});
+	}
+
+	append(...nodes) {
+		nodes.forEach((node) => {
+			const selectFirstOption = this.tagName === 'SELECT' && this.children.length === 0;
+			node.parentNode = this;
+			this.children.push(node);
+			if (selectFirstOption) this.value = node.value;
+		});
+	}
+
+	replaceChildren(...nodes) {
+		this.children = [];
+		this._text = '';
+		this.append(...nodes);
+	}
+
+	addEventListener(type, listener) {
+		(this.listeners[type] ||= []).push(listener);
+	}
+
+	async dispatch(type) {
+		const event = { preventDefault() {} };
+		for (const listener of this.listeners[type] || []) await listener(event);
+	}
+
+	setAttribute(name, value) {
+		this.attributes[name] = String(value);
+	}
+
+	removeAttribute(name) {
+		delete this.attributes[name];
+	}
+
+	querySelectorAll(selector) {
+		if (selector === '[data-view]') return findAll(this, (node) => node.dataset.view);
+		return [];
+	}
+}
+
+const findAll = (root, predicate) => {
+	const matches = predicate(root) ? [root] : [];
+	return matches.concat(root.children.flatMap((child) => findAll(child, predicate)));
+};
+
+const find = (root, predicate) => findAll(root, predicate)[0];
+const findForm = (root, route) => find(root, (node) => node.tagName === 'FORM' && node.textContent.includes(route));
+const findButton = (root, text) => find(root, (node) => node.tagName === 'BUTTON' && node.textContent === text);
+const flush = async () => {
+	await new Promise((resolve) => setImmediate(resolve));
+	await new Promise((resolve) => setImmediate(resolve));
+};
+
+const response = (body, status = 200) => ({
+	ok: status >= 200 && status < 300,
+	status,
+	json: async () => body,
+	text: async () => JSON.stringify(body),
+});
+
+function createBrowser({ fetchImpl, confirm = () => true, storedKey = '' }) {
+	const body = new FakeElement('body');
+	const elementsById = {};
+	['api-key', 'key-state', 'save-key', 'clear-key', 'view'].forEach((id) => {
+		const tag = id === 'api-key' ? 'input' : id === 'view' ? 'section' : id.endsWith('key') ? 'button' : 'p';
+		const node = new FakeElement(tag);
+		node.id = id;
+		elementsById[id] = node;
+		body.append(node);
+	});
+	['status', 'alerts', 'presets', 'jobs', 'analysis', 'playground'].forEach((view) => {
+		const button = new FakeElement('button');
+		button.dataset.view = view;
+		body.append(button);
+	});
+
+	const documentListeners = {};
+	const document = {
+		body,
+		createElement: (tag) => new FakeElement(tag),
+		getElementById: (id) => elementsById[id],
+		querySelectorAll: (selector) => body.querySelectorAll(selector),
+		addEventListener: (type, listener) => { documentListeners[type] = listener; },
+	};
+	const storage = new Map(storedKey ? [['cabros-admin-api-key', storedKey]] : []);
+	const helperCalls = [];
+	const helper = {
+		...requestHelper,
+		createRequest: (input) => {
+			helperCalls.push(input);
+			return requestHelper.createRequest(input);
+		},
+	};
+	const context = {
+		document,
+		fetch: jest.fn(fetchImpl),
+		performance: { now: jest.fn().mockReturnValueOnce(10).mockReturnValue(20) },
+		sessionStorage: {
+			getItem: (key) => storage.get(key) || null,
+			setItem: (key, value) => storage.set(key, value),
+			removeItem: (key) => storage.delete(key),
+		},
+		window: { CabrosAdminRequest: helper, confirm },
+	};
+	vm.runInNewContext(
+		fs.readFileSync(path.join(__dirname, '../../src/admin/admin.js'), 'utf8'),
+		context,
+	);
+	documentListeners.DOMContentLoaded();
+
+	return { body, context, elementsById, helperCalls, storage };
+}
+
+async function selectView(browser, name) {
+	await find(browser.body, (node) => node.dataset.view === name).dispatch('click');
+	await flush();
+}
+
+describe('admin browser client', () => {
+	it('uses the current session key, redacts output, and cancels before dispatch', async () => {
+		const events = [];
+		const browser = createBrowser({
+			fetchImpl: async (url, options) => {
+				events.push(['fetch', url, options]);
+				if (url === '/openapi.json') return response(contract);
+				return response({ echoed: 'current-secret' });
+			},
+			confirm: () => {
+				events.push(['confirm']);
+				return false;
+			},
+		});
+		await flush();
+		browser.elementsById['api-key'].value = 'current-secret';
+		await browser.elementsById['save-key'].dispatch('click');
+
+		const statusForm = findForm(browser.elementsById.view, 'GET /api/status');
+		await statusForm.dispatch('submit');
+		await flush();
+
+		expect(browser.helperCalls.at(-1).apiKey).toBe('current-secret');
+		expect(events.at(-1)[2].headers['x-api-key']).toBe('current-secret');
+		expect(browser.storage.get('cabros-admin-api-key')).toBe('current-secret');
+		expect(statusForm.textContent).toContain('[REDACTED]');
+		expect(statusForm.textContent).not.toContain('current-secret');
+		expect(events.filter(([type]) => type === 'fetch').every(([, url]) => !url.includes('current-secret'))).toBe(true);
+
+		await selectView(browser, 'alerts');
+		const replayForm = findForm(browser.elementsById.view, 'POST /api/alerts/{alertId}/replay');
+		replayForm.elements['path-alertId'].value = 'alert-1';
+		const fetchCount = events.filter(([type]) => type === 'fetch').length;
+		await replayForm.dispatch('submit');
+		await flush();
+		expect(events.at(-1)).toEqual(['confirm']);
+		expect(events.filter(([type]) => type === 'fetch')).toHaveLength(fetchCount);
+
+		browser.context.window.confirm = () => {
+			events.push(['confirm']);
+			return true;
+		};
+		await replayForm.dispatch('submit');
+		await flush();
+		expect(events.slice(-2).map(([type]) => type)).toEqual(['confirm', 'fetch']);
+	});
+
+	it('retries the OpenAPI contract after the first load rejects', async () => {
+		let contractAttempts = 0;
+		const browser = createBrowser({
+			fetchImpl: async (url) => {
+				if (url !== '/openapi.json') return response({});
+				contractAttempts++;
+				if (contractAttempts === 1) throw new Error('temporary outage');
+				return response(contract);
+			},
+		});
+		await flush();
+		expect(browser.elementsById.view.textContent).toContain('temporary outage');
+
+		await selectView(browser, 'alerts');
+
+		expect(contractAttempts).toBe(2);
+		expect(findForm(browser.elementsById.view, 'GET /api/alerts')).toBeDefined();
+		await selectView(browser, 'presets');
+		expect(contractAttempts).toBe(2);
+	});
+
+	it('renders dedicated alert filters and follows the returned before cursor', async () => {
+		let alertPage = 0;
+		const requests = [];
+		const browser = createBrowser({
+			fetchImpl: async (url, options) => {
+				if (url === '/openapi.json') return response(contract);
+				requests.push([url, options]);
+				if (url.startsWith('/api/alerts')) {
+					alertPage++;
+					return response({ alerts: [], pagination: alertPage === 1
+						? { hasMore: true, nextBefore: 'cursor-2' }
+						: { hasMore: false } });
+				}
+				return response({});
+			},
+		});
+		await flush();
+		await selectView(browser, 'alerts');
+
+		const listForm = findForm(browser.elementsById.view, 'GET /api/alerts');
+		expect(listForm.elements.limit).toBeDefined();
+		expect(listForm.elements.before).toBeDefined();
+		expect(listForm.elements.source).toBeDefined();
+		expect(listForm.elements.enriched).toBeDefined();
+		listForm.elements.limit.value = '10';
+		listForm.elements.source.value = 'webhook';
+		await listForm.dispatch('submit');
+		await flush();
+		await findButton(listForm, 'Next page').dispatch('click');
+		await flush();
+		expect(requests.at(-1)[0]).toBe('/api/alerts?limit=10&before=cursor-2&source=webhook');
+	});
+
+	it('renders dedicated alert detail lookup', async () => {
+		const browser = createBrowser({
+			fetchImpl: async (url) => response(url === '/openapi.json' ? contract : {}),
+		});
+		await flush();
+		await selectView(browser, 'alerts');
+
+		expect(findForm(browser.elementsById.view, 'GET /api/alerts/{alertId}')).toBeDefined();
+	});
+
+	it('renders dedicated preset create and update controls', async () => {
+		const browser = createBrowser({
+			fetchImpl: async (url) => response(url === '/openapi.json' ? contract : {}),
+		});
+		await flush();
+
+		await selectView(browser, 'presets');
+		expect(findForm(browser.elementsById.view, 'POST /api/scanner-presets')).toBeDefined();
+		expect(findForm(browser.elementsById.view, 'PUT /api/scanner-presets/{id}')).toBeDefined();
+	});
+
+	it('shows cancel only for a fetched active job', async () => {
+		const job = { jobId: 'job-1', status: 'processing', results: [] };
+		const browser = createBrowser({
+			fetchImpl: async (url) => {
+				if (url === '/openapi.json') return response(contract);
+				if (url === '/api/jobs/job-1') return response(job);
+				return response({});
+			},
+		});
+		await flush();
+		await selectView(browser, 'jobs');
+
+		const statusForm = findForm(browser.elementsById.view, 'GET /api/jobs/{jobId}');
+		statusForm.elements['path-jobId'].value = 'job-1';
+		await statusForm.dispatch('submit');
+		await flush();
+		expect(findButton(statusForm, 'Cancel job')).toBeDefined();
+		expect(findButton(statusForm, 'Retry job')).toBeUndefined();
+		expect(findButton(statusForm, 'Retry failed items')).toBeUndefined();
+	});
+
+	it('shows both retry actions only for a fetched failed job with failed items', async () => {
+		const job = { jobId: 'job-1', status: 'failed', results: [{ status: 'error' }] };
+		const browser = createBrowser({
+			fetchImpl: async (url) => {
+				if (url === '/openapi.json') return response(contract);
+				if (url === '/api/jobs/job-1') return response(job);
+				return response({});
+			},
+		});
+		await flush();
+		await selectView(browser, 'jobs');
+
+		const statusForm = findForm(browser.elementsById.view, 'GET /api/jobs/{jobId}');
+		statusForm.elements['path-jobId'].value = 'job-1';
+		await statusForm.dispatch('submit');
+		await flush();
+		expect(findButton(statusForm, 'Cancel job')).toBeUndefined();
+		expect(findButton(statusForm, 'Retry job')).toBeDefined();
+		const retryFailed = findButton(statusForm, 'Retry failed items');
+		expect(retryFailed).toBeDefined();
+		await retryFailed.dispatch('click');
+		await flush();
+		expect(browser.context.fetch).toHaveBeenLastCalledWith(
+			'/api/jobs/job-1/retry-failed',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});

--- a/tests/unit/admin-request.test.js
+++ b/tests/unit/admin-request.test.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
 const { createRequest } = require('../../src/admin/admin-request');
 
 describe('createRequest', () => {
@@ -25,6 +28,13 @@ describe('createRequest', () => {
 			.toThrow('API path must start with /api/');
 	});
 
+	it('rejects API paths containing query strings or fragments', () => {
+		expect(() => createRequest({ path: '/api/status?enabled=true', method: 'GET' }))
+			.toThrow('API path must start with /api/');
+		expect(() => createRequest({ path: '/api/status#details', method: 'GET' }))
+			.toThrow('API path must start with /api/');
+	});
+
 	it('omits undefined query values and empty JSON bodies', () => {
 		expect(createRequest({
 			path: '/api/status',
@@ -35,5 +45,19 @@ describe('createRequest', () => {
 			url: '/api/status?enabled=true',
 			options: { method: 'GET', headers: {} },
 		});
+	});
+});
+
+it('exposes a working helper on a browser-like window global', () => {
+	const browser = {};
+	const source = fs.readFileSync(path.join(__dirname, '../../src/admin/admin-request.js'), 'utf8');
+
+	vm.runInNewContext(source, { window: browser, URLSearchParams });
+
+	expect(browser.CabrosAdminRequest.createRequest({
+		path: '/api/status', method: 'GET', query: { detail: 'full' },
+	})).toEqual({
+		url: '/api/status?detail=full',
+		options: { method: 'GET', headers: {} },
 	});
 });

--- a/tests/unit/admin-request.test.js
+++ b/tests/unit/admin-request.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { createRequest } = require('../../src/admin/admin-request');
+
+describe('createRequest', () => {
+	it('creates a same-origin request with an API-key header and JSON body', () => {
+		expect(createRequest({
+			path: '/api/webhook/volume-confirmation',
+			method: 'POST',
+			apiKey: 'secret',
+			body: { symbol: 'BINANCE:BTCUSDT' },
+			query: { dryRun: false },
+		})).toEqual({
+			url: '/api/webhook/volume-confirmation?dryRun=false',
+			options: expect.objectContaining({
+				method: 'POST',
+				body: '{"symbol":"BINANCE:BTCUSDT"}',
+				headers: { 'Content-Type': 'application/json', 'x-api-key': 'secret' },
+			}),
+		});
+	});
+
+	it('rejects a non-relative API path', () => {
+		expect(() => createRequest({ path: 'https://example.com', method: 'GET' }))
+			.toThrow('API path must start with /api/');
+	});
+
+	it('omits undefined query values and empty JSON bodies', () => {
+		expect(createRequest({
+			path: '/api/status',
+			method: 'GET',
+			query: { enabled: true, unused: undefined },
+			body: {},
+		})).toEqual({
+			url: '/api/status?enabled=true',
+			options: { method: 'GET', headers: {} },
+		});
+	});
+});

--- a/tests/unit/admin-request.test.js
+++ b/tests/unit/admin-request.test.js
@@ -3,7 +3,13 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
-const { createRequest } = require('../../src/admin/admin-request');
+const {
+	confirmRequest,
+	createRequest,
+	operationDefinitions,
+	redactSecret,
+	validateQuery,
+} = require('../../src/admin/admin-request');
 
 describe('createRequest', () => {
 	it('creates a same-origin request with an API-key header and JSON body', () => {
@@ -35,6 +41,13 @@ describe('createRequest', () => {
 			.toThrow('API path must start with /api/');
 	});
 
+	it('rejects invalid or credential-bearing query objects', () => {
+		expect(() => createRequest({ path: '/api/status', method: 'GET', query: [] }))
+			.toThrow('Query must be a JSON object.');
+		expect(() => createRequest({ path: '/api/status', method: 'GET', query: { 'API-Key': 'secret' } }))
+			.toThrow('Query credentials are not allowed; use the API key field.');
+	});
+
 	it('omits undefined query values and empty JSON bodies', () => {
 		expect(createRequest({
 			path: '/api/status',
@@ -59,5 +72,65 @@ it('exposes a working helper on a browser-like window global', () => {
 	})).toEqual({
 		url: '/api/status?detail=full',
 		options: { method: 'GET', headers: {} },
+	});
+});
+
+describe('admin client safety', () => {
+	it('requires query JSON to be an object without credential keys', () => {
+		expect(validateQuery(undefined)).toBeUndefined();
+		expect(validateQuery({ limit: 5 })).toEqual({ limit: 5 });
+		expect(() => validateQuery(null)).toThrow('Query must be a JSON object.');
+		expect(() => validateQuery([])).toThrow('Query must be a JSON object.');
+		expect(() => validateQuery('limit=5')).toThrow('Query must be a JSON object.');
+		expect(() => validateQuery({ 'API-Key': 'secret' }))
+			.toThrow('Query credentials are not allowed; use the API key field.');
+		expect(() => validateQuery({ 'X-API-KEY': 'secret' }))
+			.toThrow('Query credentials are not allowed; use the API key field.');
+	});
+
+	it('redacts raw and JSON-escaped API keys with special characters', () => {
+		const secret = 'quote" slash\\ tab\t newline\n';
+		const escapedSecret = JSON.stringify(secret).slice(1, -1);
+
+		const rawResult = redactSecret(`before ${secret} after`, secret);
+		const jsonResult = redactSecret(JSON.stringify({ echoed: secret }), secret);
+
+		expect(rawResult).toBe('before [REDACTED] after');
+		expect(jsonResult).toContain('[REDACTED]');
+		expect(jsonResult).not.toContain(secret);
+		expect(jsonResult).not.toContain(escapedSecret);
+	});
+
+	it('keeps confirmations on every sensitive Playground operation', () => {
+		const sensitiveRoutes = [
+			['post', '/api/alerts/{alertId}/replay'],
+			['post', '/api/scanner-presets/{id}/run'],
+			['delete', '/api/scanner-presets/{id}'],
+			['post', '/api/jobs/{jobId}/cancel'],
+			['post', '/api/jobs/{jobId}/retry'],
+			['post', '/api/jobs/{jobId}/retry-failed'],
+		];
+		const paths = Object.fromEntries(sensitiveRoutes.map(([method, route]) => [route, {
+			[method]: { summary: route },
+		}]));
+		paths['/api/status'] = { get: { summary: 'Status' } };
+
+		const definitions = operationDefinitions({ paths });
+		const status = definitions.find(({ path }) => path === '/api/status');
+		expect(status.confirm).toBeUndefined();
+		sensitiveRoutes.forEach(([method, route]) => {
+			const definition = definitions.find(({ path, method: actualMethod }) => (
+				path === route && actualMethod === method.toUpperCase()
+			));
+			expect(definition.confirm).toEqual(expect.any(String));
+		});
+
+		const replay = definitions.find(({ path }) => path.endsWith('/replay'));
+		let promptedWith;
+		expect(confirmRequest(replay, (message) => {
+			promptedWith = message;
+			return false;
+		})).toBe(false);
+		expect(promptedWith).toBe(replay.confirm);
 	});
 });


### PR DESCRIPTION
## Summary

Adds a same-origin `/admin` operator console for Cabros Bot. The dependency-free browser UI discovers the existing OpenAPI contract and calls the current protected `/api` operations without adding or changing API contracts.

## Key Changes

### :compass: Operator console

- Serves responsive Status, Alerts, Presets, Jobs, Analysis, and Playground views from `/admin`.
- Builds request forms from `/openapi.json`, including path parameters, supported query defaults, and JSON request-body examples.
- Provides dedicated alert filters, cursor paging, and detail lookup; preset create/update controls; and job status actions gated by the fetched job state, including suppression of partial retries while processing.
- Requires a browser confirmation immediately before alert replay, scanner preset run/delete, job cancel/retry, and retry-failed operations.

### :lock: Credential and request safety

- Keeps the API key in browser `sessionStorage` only and sends it only as `x-api-key` for a request.
- Rejects embedded query/fragment paths and credential-shaped query parameters, and redacts API-key values from rendered request results.

### :package: Service integration

- Serves static assets with a no-cache policy and retries failed `/openapi.json` loads while caching successful loads.
- Leaves `src/openapi/openapi.json` and `CabrosBot.postman_collection.json` unchanged.

## Testing

- Focused admin-client/request/docs checks passed: 20 tests.
- Full Jest suite passed: 70 suites, 894 tests.
- Changed-file ESLint and `git diff --check` passed.
- Repository-wide lint remains baseline-red outside this change.

## References

- Fixes #190
- **Linear**: [CB-58](https://linear.app/knil/issue/CB-58/add-in-app-api-admin-console)