### PR TITLE
fix: initialize Firestore when only shadow-mode outcome tracking is enabled (CB-62)

### DIFF
--- a/src/services/storage/AlertStorageService.js
+++ b/src/services/storage/AlertStorageService.js
@@ -50,7 +50,9 @@ function isEnabled() {
 }
 
 function canInitializeFirestore() {
-	return isEnabled() || process.env.ENABLE_FIRESTORE_JOB_STORAGE === 'true';
+	return isEnabled()
+		|| process.env.ENABLE_FIRESTORE_JOB_STORAGE === 'true'
+		|| process.env.ENABLE_SHADOW_MODE_OUTCOME_TRACKING === 'true';
 }
 
 function clampLimit(limit) {

--- a/tests/unit/alert-storage-service.test.js
+++ b/tests/unit/alert-storage-service.test.js
@@ -66,6 +66,8 @@ describe('AlertStorageService', () => {
 
 	afterEach(() => {
 		delete process.env.ENABLE_FIRESTORE_ALERT_STORAGE;
+		delete process.env.ENABLE_FIRESTORE_JOB_STORAGE;
+		delete process.env.ENABLE_SHADOW_MODE_OUTCOME_TRACKING;
 		delete process.env.FIREBASE_PROJECT_ID;
 		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
 	});
@@ -87,6 +89,22 @@ describe('AlertStorageService', () => {
 
 		it('initializes firebase-admin and returns Firestore instance when enabled', () => {
 			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+			const result = AlertStorageService.getFirestore();
+			expect(mockInitializeApp).toHaveBeenCalledTimes(1);
+			expect(result).not.toBeNull();
+			expect(result.collection).toBeDefined();
+		});
+
+		it('initializes Firestore when only ENABLE_SHADOW_MODE_OUTCOME_TRACKING is true', () => {
+			process.env.ENABLE_SHADOW_MODE_OUTCOME_TRACKING = 'true';
+			const result = AlertStorageService.getFirestore();
+			expect(mockInitializeApp).toHaveBeenCalledTimes(1);
+			expect(result).not.toBeNull();
+			expect(result.collection).toBeDefined();
+		});
+
+		it('initializes Firestore when only ENABLE_FIRESTORE_JOB_STORAGE is true', () => {
+			process.env.ENABLE_FIRESTORE_JOB_STORAGE = 'true';
 			const result = AlertStorageService.getFirestore();
 			expect(mockInitializeApp).toHaveBeenCalledTimes(1);
 			expect(result).not.toBeNull();

--- a/tests/unit/signal-outcome-service.test.js
+++ b/tests/unit/signal-outcome-service.test.js
@@ -96,7 +96,30 @@ describe('SignalOutcomeService', () => {
 			expect(res).toBeNull();
 		});
 
-		it('saves a normalised document when enabled', async () => {
+		it('saves a normalised document when only SHADOW_MODE_OUTCOME_TRACKING is enabled', async () => {
+			process.env.ENABLE_SHADOW_MODE_OUTCOME_TRACKING = 'true';
+			// Intentionally NOT setting ENABLE_FIRESTORE_ALERT_STORAGE or ENABLE_FIRESTORE_JOB_STORAGE
+			// to verify the fix for issue #155.
+
+			const resId = await SignalOutcomeService.recordSignal({
+				requestId: 'test-req-shadow-only',
+				source: 'market-scanner',
+				symbol: 'BINANCE:BTCUSDT',
+				price: 50000,
+				side: 'BUY',
+				score: 0.85,
+			});
+
+			expect(resId).not.toBeNull();
+			const saved = global.__firebaseAdminMockState.collections.get(SignalOutcomeService.COLLECTION_NAME).get(resId);
+			expect(saved).toBeDefined();
+			expect(saved.requestId).toBe('test-req-shadow-only');
+			expect(saved.source).toBe('market-scanner');
+			expect(saved.price).toBe(50000);
+			expect(saved.side).toBe('BUY');
+		});
+
+		it('saves a normalised document when enabled with both flags', async () => {
 			process.env.ENABLE_SHADOW_MODE_OUTCOME_TRACKING = 'true';
 			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
 


### PR DESCRIPTION
fix: initialize Firestore when only shadow-mode outcome tracking is enabled (CB-62)

## Summary

Fix Firestore initialization gate so that `SignalOutcomeService` can write to Firestore when only `ENABLE_SHADOW_MODE_OUTCOME_TRACKING=true` is set, without requiring `ENABLE_FIRESTORE_ALERT_STORAGE=true` or `ENABLE_FIRESTORE_JOB_STORAGE=true`.

## Key Changes

### `src/services/storage/AlertStorageService.js`
- Added `ENABLE_SHADOW_MODE_OUTCOME_TRACKING === 'true'` to `canInitializeFirestore()` gate

### `tests/unit/alert-storage-service.test.js`
- New test: initializes Firestore when only `ENABLE_SHADOW_MODE_OUTCOME_TRACKING=true`
- New test: initializes Firestore when only `ENABLE_FIRESTORE_JOB_STORAGE=true`
- Proper cleanup of both env vars in `afterEach`

### `tests/unit/signal-outcome-service.test.js`
- New test: `recordSignal()` writes to mocked Firestore when only `ENABLE_SHADOW_MODE_OUTCOME_TRACKING=true` is set (no other Firestore flags)
- Renamed original test for clarity

## Technical Implementation

The `canInitializeFirestore()` shared gate in `AlertStorageService` previously only checked `ENABLE_FIRESTORE_ALERT_STORAGE` and `ENABLE_FIRESTORE_JOB_STORAGE`. Shadow-mode outcome tracking (`SignalOutcomeService`) uses the same shared `getFirestore()` but had no entry in this gate. Adding the shadow-mode tracking env var to the gate ensures Firestore is initialized for all consumers that need it.

## Testing

- All 641 unit tests pass
- 3 new test cases covering the specific gate conditions

## References

- **Linear**: [CB-62](https://linear.app/knil/issue/CB-62/initialize-firestore-when-only-shadow-mode-outcome-tracking-is-enabled)
- GitHub issue: #155