### PR TITLE
feat: expose message footer capability flag (CB-71)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -130,7 +130,7 @@
           "name": "Success",
           "status": "OK",
           "code": 200,
-          "body": "{\"service\":{\"name\":\"cabros-bot\",\"version\":\"0.1.0\"},\"featureFlags\":{\"telegramBot\":true,\"whatsappAlerts\":false,\"geminiGrounding\":false,\"newsMonitor\":false,\"tradingViewVolumeConfirmation\":false,\"firestoreJobStorage\":false},\"dependencies\":{\"tradingViewVolumeConfirmation\":{\"enabled\":false,\"configured\":true,\"ready\":false,\"status\":\"disabled\"},\"firestoreJobStorage\":{\"enabled\":false,\"configured\":true,\"ready\":false,\"status\":\"disabled\"}}}"
+          "body": "{\"service\":{\"name\":\"cabros-bot\",\"version\":\"0.1.0\"},\"featureFlags\":{\"telegramBot\":true,\"whatsappAlerts\":false,\"geminiGrounding\":false,\"newsMonitor\":false,\"tradingViewVolumeConfirmation\":false,\"firestoreJobStorage\":false,\"messageFooterMetadata\":true},\"dependencies\":{\"tradingViewVolumeConfirmation\":{\"enabled\":false,\"configured\":true,\"ready\":false,\"status\":\"disabled\"},\"firestoreJobStorage\":{\"enabled\":false,\"configured\":true,\"ready\":false,\"status\":\"disabled\"}}}"
         }
       ]
     },
@@ -161,7 +161,7 @@
           "name": "Success",
           "status": "OK",
           "code": 200,
-          "body": "{\"featureFlags\":{\"tradingViewVolumeConfirmation\":true,\"firestoreJobStorage\":true},\"dependencies\":{\"tradingViewVolumeConfirmation\":{\"enabled\":true,\"configured\":true,\"ready\":true,\"status\":\"ready\"},\"firestoreJobStorage\":{\"enabled\":true,\"configured\":true,\"ready\":true,\"status\":\"ready\"}}}"
+          "body": "{\"featureFlags\":{\"tradingViewVolumeConfirmation\":true,\"firestoreJobStorage\":true,\"messageFooterMetadata\":true},\"dependencies\":{\"tradingViewVolumeConfirmation\":{\"enabled\":true,\"configured\":true,\"ready\":true,\"status\":\"ready\"},\"firestoreJobStorage\":{\"enabled\":true,\"configured\":true,\"ready\":true,\"status\":\"ready\"}}}"
         }
       ]
     },

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ When `ENABLE_TRADINGVIEW_VOLUME_CONFIRMATION=true`, `featureFlags.tradingViewVol
 
 When `ENABLE_FIRESTORE_JOB_STORAGE=true`, `featureFlags.firestoreJobStorage` reports the async-job persistence gate and `dependencies.firestoreJobStorage` reports readiness using the configured Firestore credentials. The legacy `ENABLE_FIRESTORE_ALERT_STORAGE=true` gate also reports job storage as enabled because it activates the same runtime persistence path.
 
+`featureFlags.messageFooterMetadata` reports the `ENABLE_MESSAGE_FOOTER_METADATA` setting. It defaults to `true` and is disabled only when the environment variable is explicitly set to `false`.
+
 `GET /api/capabilities` is an alias for the same payload.
 
 **Response:**
@@ -227,7 +229,8 @@ When `ENABLE_FIRESTORE_JOB_STORAGE=true`, `featureFlags.firestoreJobStorage` rep
     "langfusePrompts": false,
     "marketScanner": true,
     "binancePriceCheck": false,
-    "llmAlertEnrichment": false
+    "llmAlertEnrichment": false,
+    "messageFooterMetadata": true
   },
   "deliveryChannels": {
     "telegram": { "enabled": true, "status": "ready" },

--- a/agents.md
+++ b/agents.md
@@ -1053,3 +1053,12 @@ This feature introduces validation of callback URLs to prevent Server-Side Reque
 **Testing**:
 - Unit coverage: `pnpm test -- tests/unit/job-service.test.js`
 - Integration coverage: `pnpm test -- tests/integration/jobs-endpoint.test.js`
+
+## Message Footer Metadata Capability Flag (CB-71 / Issue #175)
+
+`/api/status` and its `/api/capabilities` alias expose `featureFlags.messageFooterMetadata`, matching the alert grounding default-on behavior. The flag is `true` unless `ENABLE_MESSAGE_FOOTER_METADATA=false`.
+
+**Core Components**:
+- `src/controllers/status.js` — Reports the effective message-footer metadata flag.
+- `tests/integration/status-endpoint.test.js` — Covers the default-enabled and explicit-disabled states.
+- `README.md`, `src/openapi/openapi.json`, and `CabrosBot.postman_collection.json` — Document the response field and default.

--- a/agents.md
+++ b/agents.md
@@ -1056,9 +1056,10 @@ This feature introduces validation of callback URLs to prevent Server-Side Reque
 
 ## Message Footer Metadata Capability Flag (CB-71 / Issue #175)
 
-`/api/status` and its `/api/capabilities` alias expose `featureFlags.messageFooterMetadata`, matching the alert grounding default-on behavior. The flag is `true` unless `ENABLE_MESSAGE_FOOTER_METADATA=false`.
+`/api/status` and its `/api/capabilities` alias expose `featureFlags.messageFooterMetadata`, matching the alert grounding and TradingView MCP footer behavior. The flag is `true` unless `ENABLE_MESSAGE_FOOTER_METADATA=false`; standalone, combined, and MCP-only alert enrichment all suppress metadata footers when disabled.
 
 **Core Components**:
 - `src/controllers/status.js` — Reports the effective message-footer metadata flag.
-- `tests/integration/status-endpoint.test.js` — Covers the default-enabled and explicit-disabled states.
+- `src/controllers/webhooks/handlers/alert/grounding.js` and `src/services/tradingview/TradingViewMcpService.js` — Apply the flag to Gemini, combined, and MCP-only enrichment footers.
+- `tests/integration/status-endpoint.test.js`, `tests/unit/alert-handler.test.js`, and `tests/unit/tradingview-mcp-service.test.js` — Cover the default-enabled and explicit-disabled states.
 - `README.md`, `src/openapi/openapi.json`, and `CabrosBot.postman_collection.json` — Document the response field and default.

--- a/src/controllers/status.js
+++ b/src/controllers/status.js
@@ -203,6 +203,7 @@ function getStatus() {
 	const langfusePromptsEnabled = isEnabled(process.env.ENABLE_LANGFUSE_PROMPTS);
 	const binancePriceCheckEnabled = isEnabled(process.env.ENABLE_BINANCE_PRICE_CHECK);
 	const llmAlertEnrichmentEnabled = isEnabled(process.env.ENABLE_LLM_ALERT_ENRICHMENT);
+	const messageFooterMetadataEnabled = process.env.ENABLE_MESSAGE_FOOTER_METADATA !== 'false';
 	const llmAlertEnrichmentDependencyEnabled = llmAlertEnrichmentEnabled && newsMonitorEnabled;
 
 	const telegram = dependencyStatus({
@@ -317,6 +318,7 @@ function getStatus() {
 			marketScanner: marketScannerEnabled,
 			binancePriceCheck: binancePriceCheckEnabled,
 			llmAlertEnrichment: llmAlertEnrichmentEnabled,
+			messageFooterMetadata: messageFooterMetadataEnabled,
 			signalOutcomeTracking: isEnabled(process.env.ENABLE_SIGNAL_OUTCOME_TRACKING),
 		},
 		deliveryChannels: {

--- a/src/controllers/webhooks/handlers/alert/grounding.js
+++ b/src/controllers/webhooks/handlers/alert/grounding.js
@@ -59,6 +59,10 @@ function hasContradictoryConfluenceInsight(mcp = {}) {
 		&& mcp.insights.some(insight => typeof insight === 'string' && insight.startsWith('Confluencia contradictoria:'));
 }
 
+function isMessageFooterMetadataEnabled() {
+	return process.env.ENABLE_MESSAGE_FOOTER_METADATA !== 'false';
+}
+
 function mergeEnrichmentData(text, geminiEnriched, mcpEnriched) {
 	const gemini = geminiEnriched || {};
 	const mcp = mcpEnriched || {};
@@ -78,7 +82,9 @@ function mergeEnrichmentData(text, geminiEnriched, mcpEnriched) {
 	const modelName = geminiBackticked[0] || GROUNDING_MODEL_NAME;
 	const groundingFromGemini = geminiBackticked[1] || GROUNDING_MODEL_NAME;
 	const groundingProviders = mergeUnique([groundingFromGemini], ['tradingview-mcp'], 8);
-	const extraText = '*Model used*: ' + '`' + `${modelName}` + '`' + '\n*Grounding*: ' + '`' + `${groundingProviders.join('`, `')}` + '`';
+	const extraText = isMessageFooterMetadataEnabled()
+		? '*Model used*: ' + '`' + `${modelName}` + '`' + '\n*Grounding*: ' + '`' + `${groundingProviders.join('`, `')}` + '`'
+		: '';
 	const priorityMcpInsights = extractPriorityMcpInsights(mcp);
 	const remainingMcpInsights = Array.isArray(mcp.insights)
 		? mcp.insights.filter(insight => !priorityMcpInsights.includes(insight))
@@ -112,7 +118,7 @@ async function enrichWithGemini(text, tokenUsage) {
 	});
 
 	// Build footer with model metadata (controlled by env var, default: true)
-	const enableFooter = process.env.ENABLE_MESSAGE_FOOTER_METADATA !== 'false';
+	const enableFooter = isMessageFooterMetadataEnabled();
 	const modelName = modelUsed || GROUNDING_MODEL_NAME;
 	const extraText = enableFooter
 		? '*Model used*: ' + '`' + `${modelName}` + '`' + '\n*Grounding*: ' + '`' + `${GROUNDING_MODEL_NAME}` + '`'

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -365,7 +365,7 @@
           "code": { "type": "string", "description": "Machine-readable error code (failed or timed_out jobs only)." }
         }
       },
-      "Status": { "type": "object", "description": "Runtime status. featureFlags.firestoreJobStorage reports the ENABLE_FIRESTORE_JOB_STORAGE gate or the legacy ENABLE_FIRESTORE_ALERT_STORAGE gate; dependencies.firestoreJobStorage reports Firestore credential readiness for that runtime path.", "properties": { "service": { "$ref": "#/components/schemas/JsonObject" }, "featureFlags": { "$ref": "#/components/schemas/JsonObject" }, "deliveryChannels": { "$ref": "#/components/schemas/JsonObject" }, "dependencies": { "$ref": "#/components/schemas/JsonObject" } } }
+      "Status": { "type": "object", "description": "Runtime status. featureFlags.firestoreJobStorage reports the ENABLE_FIRESTORE_JOB_STORAGE gate or the legacy ENABLE_FIRESTORE_ALERT_STORAGE gate; dependencies.firestoreJobStorage reports Firestore credential readiness for that runtime path; featureFlags.messageFooterMetadata reports ENABLE_MESSAGE_FOOTER_METADATA and defaults to true unless explicitly set to false.", "properties": { "service": { "$ref": "#/components/schemas/JsonObject" }, "featureFlags": { "$ref": "#/components/schemas/JsonObject" }, "deliveryChannels": { "$ref": "#/components/schemas/JsonObject" }, "dependencies": { "$ref": "#/components/schemas/JsonObject" } } }
     }
   }
 }

--- a/src/services/tradingview/TradingViewMcpService.js
+++ b/src/services/tradingview/TradingViewMcpService.js
@@ -629,6 +629,9 @@ class TradingViewMcpService {
 		}
 
 		const sentiment = sentimentScore > 0.15 ? 'BULLISH' : sentimentScore < -0.15 ? 'BEARISH' : 'NEUTRAL';
+		const extraText = process.env.ENABLE_MESSAGE_FOOTER_METADATA !== 'false'
+			? '*Grounding*: `tradingview-mcp`'
+			: '';
 
 		return {
 			original_text: originalText,
@@ -641,7 +644,7 @@ class TradingViewMcpService {
 			},
 			sources: [],
 			truncated: false,
-			extraText: '*Grounding*: `tradingview-mcp`',
+			extraText,
 			confluenceData: confluenceAnalysis || null,
 			multiTimeframeData: multiTimeframeAnalysis || null,
 		};

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -126,6 +126,26 @@ describe('Status endpoints', () => {
 		});
 	});
 
+	it('reports message footer metadata as enabled by default', async () => {
+		const response = await request(app)
+			.get('/api/capabilities')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.featureFlags.messageFooterMetadata).toBe(true);
+	});
+
+	it('reports message footer metadata as disabled when explicitly disabled', async () => {
+		process.env.ENABLE_MESSAGE_FOOTER_METADATA = 'false';
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.featureFlags.messageFooterMetadata).toBe(false);
+	});
+
 	it('reports Firestore job storage as disabled by default', async () => {
 		delete process.env.ENABLE_FIRESTORE_ALERT_STORAGE;
 

--- a/tests/unit/alert-handler.test.js
+++ b/tests/unit/alert-handler.test.js
@@ -167,6 +167,33 @@ describe('Alert Handler', () => {
 		process.env.ENABLE_GEMINI_GROUNDING = previousGeminiFlag;
 	});
 
+	it('should suppress combined enrichment footer when message metadata is disabled', async () => {
+		const previousGeminiFlag = process.env.ENABLE_GEMINI_GROUNDING;
+		const previousFooterFlag = process.env.ENABLE_MESSAGE_FOOTER_METADATA;
+		process.env.ENABLE_GEMINI_GROUNDING = 'true';
+		process.env.ENABLE_MESSAGE_FOOTER_METADATA = 'false';
+
+		tradingViewMcpService.isEnabled.mockReturnValue(true);
+		tradingViewMcpService.enrichFromAlertText.mockResolvedValue({
+			insights: ['MCP insight'],
+			sources: [],
+			technical_levels: { supports: [], resistances: [] },
+		});
+		groundAlert.mockResolvedValue({
+			insights: ['Gemini insight'],
+			sources: [],
+			truncated: false,
+			modelUsed: 'gemini-2.5-flash',
+		});
+
+		const result = await enrichAlert({ text: 'BTCUSDT(240) pasó a señal de VENTA' }, { useTradingViewData: true });
+
+		expect(result.extraText).toBe('');
+
+		process.env.ENABLE_GEMINI_GROUNDING = previousGeminiFlag;
+		process.env.ENABLE_MESSAGE_FOOTER_METADATA = previousFooterFlag;
+	});
+
 	it('should preserve signed MCP sentiment score when Gemini score is missing', async () => {
 		const previousGeminiFlag = process.env.ENABLE_GEMINI_GROUNDING;
 		process.env.ENABLE_GEMINI_GROUNDING = 'true';

--- a/tests/unit/tradingview-mcp-service.test.js
+++ b/tests/unit/tradingview-mcp-service.test.js
@@ -4,6 +4,7 @@ describe('TradingViewMcpService', () => {
 	afterEach(() => {
 		delete process.env.ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT;
 		delete process.env.ENABLE_TRADINGVIEW_CONFLUENCE_MULTI_TIMEFRAME;
+		delete process.env.ENABLE_MESSAGE_FOOTER_METADATA;
 	});
 
 	it('returns null when alert text is not a TradingView signal', async () => {
@@ -74,6 +75,19 @@ describe('TradingViewMcpService', () => {
 			exchange: 'BINANCE',
 			timeframe: '4h',
 		}));
+	});
+
+	it('suppresses the metadata footer when explicitly disabled', async () => {
+		process.env.ENABLE_MESSAGE_FOOTER_METADATA = 'false';
+		const service = new TradingViewMcpService({
+			maxRetries: 1,
+			logger: { warn: jest.fn(), error: jest.fn(), log: jest.fn() },
+		});
+		service.callCoinAnalysis = jest.fn().mockResolvedValue({});
+
+		const result = await service.enrichFromAlertText('BTCUSDT(240) pasó a señal de VENTA');
+
+		expect(result.extraText).toBe('');
 	});
 
 	it('prefers structuredContent when MCP server returns schema-native tool results', async () => {


### PR DESCRIPTION
## Summary

Expose the effective `ENABLE_MESSAGE_FOOTER_METADATA` setting through the `/api/status` and `/api/capabilities` `featureFlags` payload.

## Key Changes

- Added `featureFlags.messageFooterMetadata` with the existing default-on behavior.
- Ensured standalone, combined Gemini + TradingView, and MCP-only TradingView enrichment suppress footer metadata when the flag is explicitly `false`.
- Added integration/unit coverage for default, explicit `false`, combined-enrichment, and MCP-only states.
- Updated README, OpenAPI, Postman response examples, and `agents.md`.

## Technical Implementation

`src/controllers/status.js` reports `true` unless `ENABLE_MESSAGE_FOOTER_METADATA` is explicitly set to `false`. Alert grounding and TradingView MCP enrichment both honor the same environment gate for footer generation. No new dependency was introduced.

## Testing

- `pnpm test -- tests/integration/status-endpoint.test.js --runInBand`
- `pnpm test -- tests/unit/alert-handler.test.js --runInBand`
- `pnpm test -- tests/unit/tradingview-mcp-service.test.js --runInBand`
- `pnpm test` — 70 suites, 930 tests passed
- OpenAPI and Postman JSON parsing passed.
- `git diff --check` passed.

## References

- Fixes #175
- **Linear**: [CB-71](https://linear.app/knil/issue/CB-71/gh-175-expose-message-footer-metadata-capability-flag)
- GitHub issue: https://github.com/francovp/cabros-bot/issues/175