### PR TITLE
docs(config): document provider env vars (CB-75)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,25 @@ ENABLE_GEMINI_GROUNDING=false
 # Google API key with Generative AI enabled (get from Google AI Studio)
 GEMINI_API_KEY=your_google_ai_studio_api_key_here
 
+# Primary provider used by grounding and secondary LLM enrichment.
+# Supported values include gemini, azure, openrouter, and cloudflare.
+MODEL_PROVIDER=gemini
+
+# Primary Gemini model used when MODEL_PROVIDER=gemini
+GEMINI_MODEL_NAME=gemini-2.5-flash
+
+# Fallback Gemini model for transient primary-model failures
+GEMINI_MODEL_NAME_FALLBACK=gemini-2.5-flash-lite
+
+# Optional Brave Search fallback or forced-search provider
+BRAVE_SEARCH_API_KEY=your_brave_search_api_key_here
+BRAVE_SEARCH_ENDPOINT=https://api.search.brave.com/res/v1/web/search
+FORCE_BRAVE_SEARCH=false
+
+# Optional OpenRouter provider credentials and model
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+OPENROUTER_MODEL=google/gemini-2.0-flash-001
+
 # Enable model metadata footer in enriched alerts (default: true)
 ENABLE_MESSAGE_FOOTER_METADATA=true
 
@@ -291,7 +310,8 @@ ENABLE_FIRESTORE_ALERT_STORAGE=false
 ENABLE_FIRESTORE_JOB_STORAGE=false
 
 # Enable shadow-mode signal outcome tracking (default: false)
-# ENABLE_SHADOW_MODE_OUTCOME_TRACKING is retained as a legacy alias for one release.
+# Legacy alias retained for one release; prefer ENABLE_SIGNAL_OUTCOME_TRACKING.
+ENABLE_SHADOW_MODE_OUTCOME_TRACKING=false
 ENABLE_SIGNAL_OUTCOME_TRACKING=false
 
 # Firebase project ID (optional if already embedded in the service account JSON)


### PR DESCRIPTION
## Summary

Document the grounding and provider environment variables used by the current runtime configuration in `.env.example`.

## Key Changes

- Added provider selection and Gemini primary/fallback model examples.
- Added Brave Search credentials, endpoint, and force-search settings.
- Added OpenRouter credentials and model settings.
- Added the `ENABLE_SHADOW_MODE_OUTCOME_TRACKING` compatibility alias next to the canonical signal-outcome flag.

## Technical Implementation

Documentation-only update. Runtime defaults and feature gates are unchanged.

## Testing

- `pnpm test` — 70 suites, 940 tests passed.
- `git diff --check` passed.
- Template keys were checked for duplicates.

## References

- Fixes #179
- **Linear**: [CB-75](https://linear.app/knil/issue/CB-75/document-grounding-and-provider-environment-variables)
- Runtime source: `src/services/grounding/config.js`