### PR TITLE
fix: populate structured scores for ranked scanner results (CB-76)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -416,7 +416,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"exchange\": \"BINANCE\",\n  \"timeframe\": \"1h\",\n  \"scans\": [\"bollinger_scan\", \"smart_volume_scanner\"],\n  \"limit\": 3\n}"
+              "raw": "{\n  \"exchange\": \"BINANCE\",\n  \"timeframe\": \"1h\",\n  \"scans\": [\"bollinger_scan\", \"smart_volume_scanner\"],\n  \"limit\": 3,\n  \"ranked\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/webhook/market-scanner-alert?dryRun=true",
@@ -434,8 +434,45 @@
                   "value": "true"
                 }
               ]
-            }
+            },
+            "response": [
+              {
+                "name": "200 Ranked dry-run",
+                "status": "OK",
+                "code": 200,
+                "_postman_previewlanguage": "json",
+                "header": [{ "key": "Content-Type", "value": "application/json" }],
+                "body": "{\n  \"success\": true,\n  \"dryRun\": true,\n  \"ranked\": true,\n  \"scanResults\": [{\n    \"scan\": \"top_gainers\",\n    \"status\": \"success\",\n    \"itemCount\": 1,\n    \"scores\": [{ \"symbol\": \"BTCUSDT\", \"score\": 82, \"reason\": \"+3.5% · RSI 62.0 · Vol 1.8x\" }]\n  }]\n}"
+              }
+            ]
           }
+        },
+        {
+          "name": "POST Market Scanner Alert (invalid ranked flag)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json", "type": "text" },
+              { "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+            ],
+            "body": { "mode": "raw", "raw": "{\n  \"scans\": [\"top_gainers\"],\n  \"ranked\": \"sometimes\"\n}" },
+            "url": {
+              "raw": "{{baseUrl}}/api/webhook/market-scanner-alert?dryRun=true",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "webhook", "market-scanner-alert"],
+              "query": [{ "key": "dryRun", "value": "true" }]
+            }
+          },
+          "response": [
+            {
+              "name": "400 Invalid ranked flag",
+              "status": "Bad Request",
+              "code": 400,
+              "_postman_previewlanguage": "json",
+              "header": [{ "key": "Content-Type", "value": "application/json" }],
+              "body": "{\n  \"error\": \"ranked must be a boolean\",\n  \"code\": \"INVALID_REQUEST\"\n}"
+            }
+          ]
         },
         {
           "name": "POST Volume Confirmation",

--- a/README.md
+++ b/README.md
@@ -578,7 +578,8 @@ Execute multiple market scanner tools on the TradingView MCP server (such as top
     "bollinger_scan"
   ],
   "limit": 5,
-  "bbw_threshold": 0.05
+  "bbw_threshold": 0.05,
+  "ranked": true
 }
 ```
 
@@ -587,6 +588,7 @@ Execute multiple market scanner tools on the TradingView MCP server (such as top
 - `scans`: (Optional) Array of scan types to execute sequentially. Defaults to `['top_gainers', 'top_losers', 'volume_breakout_scanner']`.
 - `limit`: (Optional) Max number of results per section (clamped to `[1, 20]`, default: `5`).
 - `bbw_threshold`: (Optional) Bollinger Band Width threshold for the Bollinger squeeze scan (default: `0.05`).
+- `ranked`: (Optional) Sort results by actionable trade quality and include numeric `score` plus non-empty `reason` in each `scanResults[].scores[]` entry (default: `false`).
 
 **Response (JSON):**
 ```json
@@ -619,6 +621,17 @@ Execute multiple market scanner tools on the TradingView MCP server (such as top
   "timeoutMs": 90000,
   "requestId": "req-xyz789",
   "totalDurationMs": 1450
+}
+```
+
+When `ranked` is `true`, each successful scan also includes structured scores:
+
+```json
+{
+  "scan": "top_gainers",
+  "status": "success",
+  "itemCount": 1,
+  "scores": [{ "symbol": "BTCUSDT", "score": 82, "reason": "+3.5% · RSI 62.0 · Vol 1.8x" }]
 }
 ```
 

--- a/agents.md
+++ b/agents.md
@@ -385,12 +385,14 @@ The system provides a `POST /api/webhook/market-scanner-alert` endpoint that run
   - `scans` — array of scan types from `top_gainers`, `top_losers`, `volume_breakout_scanner`, `smart_volume_scanner`, `bollinger_scan`. Defaults to `['top_gainers', 'top_losers', 'volume_breakout_scanner']`.
   - `limit` — integer limit of items per scan, clamped to `[1, 20]`, default 5.
   - `bbw_threshold` — number representing Bollinger Band Width threshold for Bollinger squeeze scan, default 0.05.
+  - `ranked` — boolean, default `false`; when `true`, reports and structured `scanResults[].scores[]` use the same filtered items and include numeric `score` plus non-empty `reason` fields.
 - The feature is gated by `ENABLE_MARKET_SCANNER=true`.
 - Endpoint-level deadline is controlled by `MARKET_SCANNER_TIMEOUT_MS` (default 90s, capped at 120s).
 
 **Core Components**:
 - `src/controllers/webhooks/handlers/marketScanner/marketScanner.js` — request handler, sequential scan executor, deadline manager, and notification dispatcher.
 - `src/services/tradingview/marketScannerReport.js` — request parsing and validation, section/item formatter, and report builder.
+- Ranked output shares `prepareMarketScannerItems()` between report rendering and response compaction so structured scores cannot diverge from the displayed ranking.
 - `src/services/tradingview/TradingViewMcpService.js` — uses `callScanTool` method to invoke scanner tools on the TradingView MCP server.
 
 **Failure behavior**:

--- a/src/controllers/webhooks/handlers/marketScanner/marketScanner.js
+++ b/src/controllers/webhooks/handlers/marketScanner/marketScanner.js
@@ -6,6 +6,7 @@ const {
 	MarketScannerRequestError,
 	parseMarketScannerRequest,
 	buildMarketScannerReport,
+	prepareMarketScannerItems,
 } = require('../../../../services/tradingview/marketScannerReport');
 const {
 	getNotificationManager,
@@ -288,7 +289,7 @@ function compactScanResults(results, includeScores = false) {
 		};
 
 		if (includeScores && Array.isArray(result.items) && result.items.length > 0) {
-			compact.scores = result.items.map((item) => ({
+			compact.scores = prepareMarketScannerItems(result, true).map((item) => ({
 				symbol: item.symbol,
 				score: item._score,
 				reason: item._scoreReason,

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -240,7 +240,7 @@
       "Alert": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AlertRequest" }, "example": { "text": "BTCUSDT broke resistance with strong volume", "channels": ["telegram"], "telegramChatId": "-1001234567890" } }, "text/plain": { "schema": { "type": "string" }, "example": "BTCUSDT broke resistance" } } },
       "Message": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/MessageRequest" }, "example": { "message": "Deployment completed", "channels": ["telegram", "whatsapp", "discord"] } } } },
       "ExpandedAnalysis": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ExpandedAnalysisRequest" }, "example": { "symbols": ["BINANCE:BTCUSDT", "NASDAQ:NVDA"], "timeframe": "1D", "analysisMode": "standard", "includeMultiTimeframe": false, "channels": ["telegram"], "telegramChatId": "-1001234567890" } } } },
-      "MarketScanner": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/MarketScannerRequest" }, "example": { "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers", "top_losers", "volume_breakout_scanner"], "limit": 5, "channels": ["telegram"] } } } },
+      "MarketScanner": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/MarketScannerRequest" }, "examples": { "default": { "value": { "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers", "top_losers", "volume_breakout_scanner"], "limit": 5, "channels": ["telegram"] } }, "ranked": { "value": { "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers"], "limit": 5, "ranked": true } } } } } },
       "VolumeConfirmation": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/VolumeConfirmationRequest" }, "example": { "symbol": "BINANCE:BTCUSDT", "timeframe": "1h" } } } },
       "Replay": { "content": { "application/json": { "schema": { "type": "object", "properties": { "channels": { "type": "array", "items": { "type": "string", "enum": ["telegram", "whatsapp", "discord"] } } } }, "example": { "channels": ["telegram"] } } } },
       "ScannerPreset": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ScannerPresetRequest" }, "example": { "name": "Daily Scan", "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers"], "limit": 5 } } } },
@@ -272,6 +272,7 @@
           "scans": { "type": "array", "items": { "type": "string", "enum": ["top_gainers", "top_losers", "volume_breakout_scanner", "smart_volume_scanner", "bollinger_scan"] } },
           "limit": { "type": "integer", "minimum": 1, "maximum": 20, "default": 5 },
           "bbw_threshold": { "type": "number", "default": 0.05 },
+          "ranked": { "type": "boolean", "default": false, "description": "When true, sorts each scan by actionable score and includes score/reason entries in scanResults." },
           "channels": { "type": "array", "minItems": 1, "items": { "type": "string", "enum": ["telegram", "whatsapp", "discord"] } },
           "telegramChatId": { "type": "string", "minLength": 1 },
           "whatsappChatId": { "type": "string", "minLength": 1 }

--- a/src/services/tradingview/marketScannerReport.js
+++ b/src/services/tradingview/marketScannerReport.js
@@ -224,22 +224,7 @@ function buildMarketScannerReport(scanResults = [], options = {}) {
 			return;
 		}
 
-		let itemsToRender = scanResult.items || [];
-		if (scanResult.scan === 'top_gainers') {
-			itemsToRender = itemsToRender.filter((item) => typeof item.changePercent === 'number' && item.changePercent > 0);
-		} else if (scanResult.scan === 'top_losers') {
-			itemsToRender = itemsToRender.map((item) => {
-				if (typeof item.changePercent === 'number') {
-					return { ...item, changePercent: -Math.abs(item.changePercent) };
-				}
-				return item;
-			});
-			itemsToRender = itemsToRender.filter((item) => typeof item.changePercent === 'number' && item.changePercent < 0);
-		}
-
-		if (ranked) {
-			itemsToRender = rankScannerItems(itemsToRender, scanResult.scan);
-		}
+		const itemsToRender = prepareMarketScannerItems(scanResult, ranked);
 
 		if (itemsToRender.length === 0) {
 			lines.push('No hay.');
@@ -252,6 +237,27 @@ function buildMarketScannerReport(scanResults = [], options = {}) {
 	});
 
 	return lines.join('\n');
+}
+
+function prepareMarketScannerItems(scanResult = {}, ranked = false) {
+	let itemsToRender = scanResult.items || [];
+	if (scanResult.scan === 'top_gainers') {
+		itemsToRender = itemsToRender.filter((item) => typeof item.changePercent === 'number' && item.changePercent > 0);
+	} else if (scanResult.scan === 'top_losers') {
+		itemsToRender = itemsToRender.map((item) => {
+			if (typeof item.changePercent === 'number') {
+				return { ...item, changePercent: -Math.abs(item.changePercent) };
+			}
+			return item;
+		});
+		itemsToRender = itemsToRender.filter((item) => typeof item.changePercent === 'number' && item.changePercent < 0);
+	}
+
+	if (ranked) {
+		itemsToRender = rankScannerItems(itemsToRender, scanResult.scan);
+	}
+
+	return itemsToRender;
 }
 
 function getInvalidationDistance(price, stopLoss) {
@@ -538,5 +544,6 @@ module.exports = {
 	MarketScannerRequestError,
 	parseMarketScannerRequest,
 	buildMarketScannerReport,
+	prepareMarketScannerItems,
 	SUPPORTED_SCAN_TYPES,
 };

--- a/tests/integration/market-scanner-endpoint.test.js
+++ b/tests/integration/market-scanner-endpoint.test.js
@@ -218,6 +218,11 @@ describe('Market Scanner Alert endpoint', () => {
 		// Scores array should be present in scan results
 		expect(res.body.scanResults[0].scores).toBeDefined();
 		expect(res.body.scanResults[0].scores).toHaveLength(2);
+		for (const score of res.body.scanResults[0].scores) {
+			expect(typeof score.score).toBe('number');
+			expect(score.reason).toEqual(expect.any(String));
+			expect(score.reason).not.toHaveLength(0);
+		}
 		expect(mockTelegramSendMessage).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
fix: populate structured scores for ranked scanner results (CB-76)

## Summary

Fix ranked market-scanner responses returning undefined score metadata.

## Key Changes

- Reuse one filtered/ranked item preparation path for report rendering and `scanResults[].scores[]` compaction.
- Add integration assertions for numeric scores and non-empty reasons.
- Document the ranked response contract in README, OpenAPI, `agents.md`, and Postman examples.

## Technical Implementation

`prepareMarketScannerItems()` preserves the existing gainer/loser filtering and scoring behavior while allowing the handler response to consume the same scored items shown in the alert text.

## Testing

- Red-first regression reproduced `score: undefined` and `reason: undefined`.
- Focused market scanner integration and report tests pass.
- `pnpm test` — 70 suites, 940 tests passed.
- `git diff --check` and JSON contract parsing passed.

## References

- Fixes #181: https://github.com/francovp/cabros-bot/issues/181
- Linear: [CB-76](https://linear.app/knil/issue/CB-76/populate-structured-scores-for-ranked-market-scanner-results)
- Related feature PR: https://github.com/francovp/cabros-bot/pull/159
