### PR TITLE
fix: score no-domain grounding sources as unknown quality (CB-77)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -728,6 +728,7 @@ See `/specs/TERMINOLOGY_GUIDE.md` for extended discussion and examples.
 - news-monitor-persistent-dedup (CB-38 / Issue #120): Added optional Firestore-backed persistent deduplication store for news monitor alerts; converted cache operations to asynchronous; added fail-open fallback to in-memory mode; exposed active dedup mode/backend readiness in `/api/status`.
 - shadow-mode-outcome-tracking (CB-42 / Issue #129): Added shadow-mode outcome tracking for alert-producing surfaces (webhook alerts, market scanner breakouts/gains/losses, expanded-analysis, news alerts). Normalizes signal metadata (requestId, source, symbol, exchange, timeframe, setupType, score, side, price, etc.) and periodically evaluates outcomes over +1h, +4h, +1D, and +1W windows using Binance historical candlestick data. Exposes aggregated metrics under `shadowModeMetrics` inside `GET /api/alerts/summary` and in custom header `X-Shadow-Mode-Metrics` inside `GET /api/alerts/export`.
 - GH-178 / CB-74: `ENABLE_SIGNAL_OUTCOME_TRACKING` is the canonical signal-outcome gate; `ENABLE_SHADOW_MODE_OUTCOME_TRACKING` remains a one-release compatibility alias, and `/api/capabilities` reports the effective gate.
+- GH-182 / CB-77: malformed or no-domain grounding sources count toward the declared UNKNOWN `0.5` quality tier instead of contributing zero; regression coverage lives in `tests/unit/event-detection.test.js`.
 
 ## Architectural Patterns & Extension Guide
 

--- a/src/services/grounding/domainQuality.js
+++ b/src/services/grounding/domainQuality.js
@@ -133,6 +133,7 @@ function scoreQuality(sources) {
 		if (!domain) {
 			tierCounts[SourceQualityTier.UNKNOWN] += 1;
 			unknownDomains += 1;
+			scoreSum += tierToScore(SourceQualityTier.UNKNOWN);
 			continue;
 		}
 		domains.push(domain);

--- a/tests/unit/event-detection.test.js
+++ b/tests/unit/event-detection.test.js
@@ -811,6 +811,13 @@ Some text after...`;
 			expect(result.calibration.grounding_used).toBe(true);
 		});
 
+		it('should score no-domain grounding sources as unknown quality', () => {
+			const result = calibrateNewsConfidence(baseAnalysis(), [{}]);
+
+			expect(result.calibration.actual_quality_tiers.unknown).toBe(1);
+			expect(result.calibration.actual_source_quality).toBe(0.5);
+		});
+
 		it('should return a structured calibration block for downstream debug/dry-run surfaces', () => {
 			const sources = [
 				makeSource({ sourceDomain: 'reuters.com' }),


### PR DESCRIPTION
## Summary

Malformed or no-domain grounding sources now contribute the declared UNKNOWN quality score of `0.5` instead of lowering the average with an implicit zero.

## Key Changes

- Added the UNKNOWN tier score to the no-domain branch in `scoreQuality()`.
- Added regression coverage for `actual_quality_tiers.unknown` and `actual_source_quality`.
- Documented the calibration behavior in `agents.md`.

## Technical Implementation

`src/services/grounding/domainQuality.js` already counted sources without a normalized domain as UNKNOWN, but continued before adding `tierToScore(SourceQualityTier.UNKNOWN)` to `scoreSum`. The shared branch now records that `0.5` score before continuing; parseable-domain behavior is unchanged.

## Testing

- `pnpm test -- tests/unit/event-detection.test.js --runInBand`
- `pnpm test` (`70/70` suites, `941/941` tests)
- `git diff --check`

## References

- Fixes #182: https://github.com/francovp/cabros-bot/issues/182
- Linear: https://linear.app/knil/issue/CB-77/score-no-domain-grounding-sources-as-unknown-quality
- Prior calibration work: PR #161 / CB-49