### PR TITLE
fix(skill): authenticate capabilities fetch (CB-82)

### DIFF
--- a/.agents/skills/detect-unused-features/SKILL.md
+++ b/.agents/skills/detect-unused-features/SKILL.md
@@ -30,12 +30,13 @@ gh auth status 2>/dev/null || echo "NOT_AUTHENTICATED"
 
 ## Step 1: Fetch Production Capabilities
 
-Call the unauthenticated capabilities endpoint and store the result.
+Load `WEBHOOK_API_KEY` from the operator's approved secret mechanism. The key is sent only as the protected `x-api-key` header and is never printed. If it is unavailable, stop before parsing downstream data.
 
 ```bash
-CAPABILITIES=$(curl -s -X 'GET' \
-  'https://cabros-crypto-bot-telegram.onrender.com/api/capabilities' \
-  -H 'accept: application/json')
+if ! CAPABILITIES="$(.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh)"; then
+  echo 'Capability audit stopped: authenticated /api/capabilities evidence is unavailable.' >&2
+  exit 78
+fi
 echo "$CAPABILITIES" | jq '.'
 ```
 

--- a/.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh
+++ b/.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh
@@ -6,7 +6,7 @@ if [[ -z "${WEBHOOK_API_KEY:-}" ]]; then
 	exit 78
 fi
 
-curl --fail-with-body --location --silent --show-error \
+curl --fail-with-body --silent --show-error \
 	-H 'accept: application/json' \
 	-H "x-api-key: ${WEBHOOK_API_KEY}" \
 	"${CAPABILITIES_URL:-https://cabros-crypto-bot-telegram.onrender.com/api/capabilities}"

--- a/.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh
+++ b/.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${WEBHOOK_API_KEY:-}" ]]; then
+	echo 'AUTH_BLOCKED: WEBHOOK_API_KEY is not set; cannot fetch /api/capabilities.' >&2
+	exit 78
+fi
+
+curl --fail-with-body --location --silent --show-error \
+	-H 'accept: application/json' \
+	-H "x-api-key: ${WEBHOOK_API_KEY}" \
+	"${CAPABILITIES_URL:-https://cabros-crypto-bot-telegram.onrender.com/api/capabilities}"

--- a/.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh
+++ b/.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh
@@ -6,7 +6,7 @@ if [[ -z "${WEBHOOK_API_KEY:-}" ]]; then
 	exit 78
 fi
 
-curl --fail-with-body --silent --show-error \
+printf 'x-api-key: %s\n' "$WEBHOOK_API_KEY" | curl --fail-with-body --silent --show-error \
 	-H 'accept: application/json' \
-	-H "x-api-key: ${WEBHOOK_API_KEY}" \
+	-H @- \
 	"${CAPABILITIES_URL:-https://cabros-crypto-bot-telegram.onrender.com/api/capabilities}"

--- a/agents.md
+++ b/agents.md
@@ -161,7 +161,7 @@ Implement the following security practices to safeguard endpoints and credential
 ### Repository skills
 
 - `issue-triage` (`.agents/skills/issue-triage/`): applies one ordered `priority/1-roi` through `priority/7-other` label to evidence-backed open issues, while preserving the existing operational `priority/p*` labels.
-- `detect-unused-features` (`.agents/skills/detect-unused-features/`): fetches protected production capabilities through `WEBHOOK_API_KEY`; `.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh` exits with `AUTH_BLOCKED` before parsing when the key is unavailable and never prints it.
+- `detect-unused-features` (`.agents/skills/detect-unused-features/`): fetches protected production capabilities through `WEBHOOK_API_KEY`; `.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh` exits with `AUTH_BLOCKED` before parsing when the key is unavailable, never prints the key, and does not follow redirects.
 
 ### When implementing a feature:
 

--- a/agents.md
+++ b/agents.md
@@ -161,7 +161,7 @@ Implement the following security practices to safeguard endpoints and credential
 ### Repository skills
 
 - `issue-triage` (`.agents/skills/issue-triage/`): applies one ordered `priority/1-roi` through `priority/7-other` label to evidence-backed open issues, while preserving the existing operational `priority/p*` labels.
-- `detect-unused-features` (`.agents/skills/detect-unused-features/`): fetches protected production capabilities through `WEBHOOK_API_KEY`; `.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh` exits with `AUTH_BLOCKED` before parsing when the key is unavailable, never prints the key, and does not follow redirects.
+- `detect-unused-features` (`.agents/skills/detect-unused-features/`): fetches protected production capabilities through `WEBHOOK_API_KEY`; `.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh` exits with `AUTH_BLOCKED` before parsing when the key is unavailable, supplies the header through stdin instead of argv, never prints the key, and does not follow redirects.
 
 ### When implementing a feature:
 

--- a/agents.md
+++ b/agents.md
@@ -161,6 +161,7 @@ Implement the following security practices to safeguard endpoints and credential
 ### Repository skills
 
 - `issue-triage` (`.agents/skills/issue-triage/`): applies one ordered `priority/1-roi` through `priority/7-other` label to evidence-backed open issues, while preserving the existing operational `priority/p*` labels.
+- `detect-unused-features` (`.agents/skills/detect-unused-features/`): fetches protected production capabilities through `WEBHOOK_API_KEY`; `.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh` exits with `AUTH_BLOCKED` before parsing when the key is unavailable and never prints it.
 
 ### When implementing a feature:
 

--- a/tests/unit/detect-unused-features-skill.test.js
+++ b/tests/unit/detect-unused-features-skill.test.js
@@ -41,6 +41,7 @@ describe('detect-unused-features capabilities fetch', () => {
 		expect(result.stdout).not.toContain('test-key');
 		expect(result.stderr).not.toContain('test-key');
 		expect(result.curlArgs).toContain('x-api-key: test-key');
+		expect(result.curlArgs).not.toContain('--location');
 	});
 
 	it('stops before curl when WEBHOOK_API_KEY is missing', () => {

--- a/tests/unit/detect-unused-features-skill.test.js
+++ b/tests/unit/detect-unused-features-skill.test.js
@@ -1,0 +1,55 @@
+const { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } = require('fs');
+const { spawnSync } = require('child_process');
+const { tmpdir } = require('os');
+const { join } = require('path');
+
+const fetchCapabilities = join(
+	__dirname,
+	'../../.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh',
+);
+
+function runFetch(apiKey) {
+	const tempDir = mkdtempSync(join(tmpdir(), 'detect-unused-features-'));
+	const curlArgsPath = join(tempDir, 'curl-args');
+	const curlPath = join(tempDir, 'curl');
+
+	writeFileSync(
+		curlPath,
+		'#!/bin/sh\nprintf \'%s\\n\' "$@" > "$CURL_ARGS_FILE"\nprintf \'%s\\n\' \'{"featureFlags":{}}\'\n',
+	);
+	chmodSync(curlPath, 0o755);
+
+	const env = { ...process.env, CAPABILITIES_URL: 'https://example.test/api/capabilities' };
+	delete env.WEBHOOK_API_KEY;
+	if (apiKey) env.WEBHOOK_API_KEY = apiKey;
+	env.PATH = `${tempDir}:${env.PATH}`;
+	env.CURL_ARGS_FILE = curlArgsPath;
+
+	const result = spawnSync('bash', [fetchCapabilities], { env, encoding: 'utf8' });
+	const curlArgs = existsSync(curlArgsPath) ? readFileSync(curlArgsPath, 'utf8') : '';
+	rmSync(tempDir, { recursive: true, force: true });
+
+	return { ...result, curlArgs };
+}
+
+describe('detect-unused-features capabilities fetch', () => {
+	it('sends WEBHOOK_API_KEY as x-api-key without printing the secret', () => {
+		const result = runFetch('test-key');
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toBe('{"featureFlags":{}}\n');
+		expect(result.stdout).not.toContain('test-key');
+		expect(result.stderr).not.toContain('test-key');
+		expect(result.curlArgs).toContain('x-api-key: test-key');
+	});
+
+	it('stops before curl when WEBHOOK_API_KEY is missing', () => {
+		const result = runFetch();
+
+		expect(result.status).toBe(78);
+		expect(result.stdout).toBe('');
+		expect(result.stderr).toContain('AUTH_BLOCKED');
+		expect(result.stderr).toContain('WEBHOOK_API_KEY is not set');
+		expect(result.curlArgs).toBe('');
+	});
+});

--- a/tests/unit/detect-unused-features-skill.test.js
+++ b/tests/unit/detect-unused-features-skill.test.js
@@ -11,11 +11,12 @@ const fetchCapabilities = join(
 function runFetch(apiKey) {
 	const tempDir = mkdtempSync(join(tmpdir(), 'detect-unused-features-'));
 	const curlArgsPath = join(tempDir, 'curl-args');
+	const curlStdinPath = join(tempDir, 'curl-stdin');
 	const curlPath = join(tempDir, 'curl');
 
 	writeFileSync(
 		curlPath,
-		'#!/bin/sh\nprintf \'%s\\n\' "$@" > "$CURL_ARGS_FILE"\nprintf \'%s\\n\' \'{"featureFlags":{}}\'\n',
+		'#!/bin/sh\nprintf \'%s\\n\' "$@" > "$CURL_ARGS_FILE"\ncat > "$CURL_STDIN_FILE"\nprintf \'%s\\n\' \'{"featureFlags":{}}\'\n',
 	);
 	chmodSync(curlPath, 0o755);
 
@@ -24,12 +25,14 @@ function runFetch(apiKey) {
 	if (apiKey) env.WEBHOOK_API_KEY = apiKey;
 	env.PATH = `${tempDir}:${env.PATH}`;
 	env.CURL_ARGS_FILE = curlArgsPath;
+	env.CURL_STDIN_FILE = curlStdinPath;
 
 	const result = spawnSync('bash', [fetchCapabilities], { env, encoding: 'utf8' });
 	const curlArgs = existsSync(curlArgsPath) ? readFileSync(curlArgsPath, 'utf8') : '';
+	const curlStdin = existsSync(curlStdinPath) ? readFileSync(curlStdinPath, 'utf8') : '';
 	rmSync(tempDir, { recursive: true, force: true });
 
-	return { ...result, curlArgs };
+	return { ...result, curlArgs, curlStdin };
 }
 
 describe('detect-unused-features capabilities fetch', () => {
@@ -40,8 +43,10 @@ describe('detect-unused-features capabilities fetch', () => {
 		expect(result.stdout).toBe('{"featureFlags":{}}\n');
 		expect(result.stdout).not.toContain('test-key');
 		expect(result.stderr).not.toContain('test-key');
-		expect(result.curlArgs).toContain('x-api-key: test-key');
 		expect(result.curlArgs).not.toContain('--location');
+		expect(result.curlArgs).toContain('@-');
+		expect(result.curlArgs).not.toContain('test-key');
+		expect(result.curlStdin).toBe('x-api-key: test-key\n');
 	});
 
 	it('stops before curl when WEBHOOK_API_KEY is missing', () => {
@@ -52,5 +57,6 @@ describe('detect-unused-features capabilities fetch', () => {
 		expect(result.stderr).toContain('AUTH_BLOCKED');
 		expect(result.stderr).toContain('WEBHOOK_API_KEY is not set');
 		expect(result.curlArgs).toBe('');
+		expect(result.curlStdin).toBe('');
 	});
 });


### PR DESCRIPTION
## Summary

Authenticate the production capabilities fetch used by the `detect-unused-features` audit and stop before parsing when the approved key is unavailable.

## Key Changes

- Added a small fetch helper that sends `WEBHOOK_API_KEY` only as `x-api-key`.
- Added an explicit `AUTH_BLOCKED` exit path when the key is missing.
- Disabled redirects so the API key cannot be forwarded to another host.
- Supplied the API key to `curl` through stdin so it does not appear in process arguments.
- Updated the skill workflow and agent documentation to use the protected request.

## Technical Implementation

- `.agents/skills/detect-unused-features/scripts/fetch-capabilities.sh` performs the authenticated `curl` request and supports `CAPABILITIES_URL` for smoke tests.
- The helper does not follow redirects, keeping the credential scoped to the requested host.
- `curl -H @-` receives the header from stdin instead of argv.
- The skill exits with status `78` before downstream `jq` parsing when authentication is unavailable.

## Testing

- `pnpm test -- tests/unit/detect-unused-features-skill.test.js --runInBand`
- `pnpm test -- tests/integration/news-monitor-binance.test.js --runInBand` (full-suite order flake isolation)
- `pnpm test --runInBand` — 70/71 suites, 950/951 tests; one unrelated order-dependent 401 passed in isolation
- `git diff --check`

## Security

- The API key is never printed by the helper or included in audit output or curl argv.
- The protected `/api/capabilities` route and `x-api-key` authentication remain unchanged.

## References

- Fixes #198
- **Linear**: [CB-82](https://linear.app/knil/issue/CB-82/gh-198-authenticate-capabilities-fetch-in-unused-features-audit)
