### PR TITLE
feat: add higher-timeframe trend alignment scoring to market scanner (CB-86)

### DIFF
--- a/context/feat-htf-trend-alignment-scoring-cb-86.md
+++ b/context/feat-htf-trend-alignment-scoring-cb-86.md
@@ -1,0 +1,31 @@
+feat: add higher-timeframe trend alignment scoring to market scanner (CB-86)
+
+## Summary
+Incorporates higher-timeframe (HTF) trend alignment scoring and counter-trend penalty logic into the market scanner service (`POST /api/webhook/market-scanner-alert`). Candidates matching HTF trend (e.g. bullish HTF for top gainers or bullish breakouts) receive a score boost, while counter-trend setups receive a penalty, reducing false breakout signals and improving setup quality.
+
+## Key Changes
+- **`src/services/tradingview/marketScannerScoring.js`**:
+  - Extended `scoreScannerItem` to accept `options.htfTrend` (or `item.htfTrend` / `item.htf_trend` / `item.higherTimeframeTrend`).
+  - Added HTF setup direction evaluation (`BULLISH` vs `BEARISH`) and applied `htfBoost` (+10 points) or `htfPenalty` (-10 points).
+  - Updated score reason text to explicitly include `HTF aligned (+10)` or `⚠️ HTF counter-trend (-10)`.
+- **`src/services/tradingview/marketScannerReport.js`**:
+  - Added `parseHtfTrend` to `parseMarketScannerRequest` to validate and normalize `htfTrend` input (`bullish`, `bearish`, `neutral`).
+  - Updated `prepareMarketScannerItems`, `buildMarketScannerReport`, and `formatScanItem` to propagate and format HTF trend metadata in scanner reports.
+- **`src/controllers/webhooks/handlers/marketScanner/marketScanner.js`**:
+  - Passed `parsed.htfTrend` to `buildMarketScannerReport` and `compactScanResults`.
+- **Tests**:
+  - `tests/unit/market-scanner-scoring.test.js`: Verified HTF trend alignment boost, counter-trend penalty, and fail-open fallback when HTF trend is omitted.
+  - `tests/integration/market-scanner-endpoint.test.js`: Added integration test for `htfTrend` request parameter and score reason formatting.
+
+## Technical Implementation
+- Pure scoring function `scoreScannerItem` normalizes HTF trend tokens (`bullish`, `bearish`, `neutral`).
+- Preserves complete fail-open behavior: when HTF trend data is omitted, scoring functions identically to single-timeframe evaluation with 0 impact.
+
+## Testing
+- Unit tests: `pnpm test -- tests/unit/market-scanner-scoring.test.js` (19 passing)
+- Integration tests: `pnpm test -- tests/integration/market-scanner-endpoint.test.js` (8 passing)
+- Full test suite: `pnpm test`
+
+## References
+- **GitHub Issue**: #217
+- **Linear**: [CB-86](https://linear.app/knil/issue/CB-86/add-higher-timeframe-trend-alignment-to-scanner-scoring)

--- a/src/controllers/webhooks/handlers/marketScanner/marketScanner.js
+++ b/src/controllers/webhooks/handlers/marketScanner/marketScanner.js
@@ -90,6 +90,7 @@ function postMarketScannerAlert(botOrGetter) {
 				timeframe: parsed.timeframe,
 				now: new Date(),
 				ranked: parsed.ranked === true,
+				htfTrend: parsed.htfTrend,
 			});
 
 			const dryRun = resolveDryRun(req);
@@ -99,8 +100,9 @@ function postMarketScannerAlert(botOrGetter) {
 					success: true,
 					dryRun: true,
 					ranked: parsed.ranked === true,
+					htfTrend: parsed.htfTrend || null,
 					payload: { alertText },
-					scanResults: compactScanResults(scanResults, parsed.ranked === true),
+					scanResults: compactScanResults(scanResults, parsed.ranked === true, parsed.htfTrend),
 					summary: buildSummary(scanResults, []),
 					timedOut,
 					timeoutMs,
@@ -158,8 +160,9 @@ function postMarketScannerAlert(botOrGetter) {
 			return res.status(200).json({
 				success: true,
 				ranked: parsed.ranked === true,
+				htfTrend: parsed.htfTrend || null,
 				alertText,
-				scanResults: compactScanResults(scanResults, parsed.ranked === true),
+				scanResults: compactScanResults(scanResults, parsed.ranked === true, parsed.htfTrend),
 				deliveryResults,
 				requestedChannels,
 				deliveredChannels,
@@ -272,7 +275,7 @@ function buildScanArgs(parsed, scanType) {
 	return args;
 }
 
-function compactScanResults(results, includeScores = false) {
+function compactScanResults(results, includeScores = false, htfTrend = null) {
 	return results.map((result) => {
 		if (result.status === 'error' || result.status === 'timeout') {
 			return {
@@ -289,7 +292,7 @@ function compactScanResults(results, includeScores = false) {
 		};
 
 		if (includeScores && Array.isArray(result.items) && result.items.length > 0) {
-			compact.scores = prepareMarketScannerItems(result, true).map((item) => ({
+			compact.scores = prepareMarketScannerItems(result, true, { htfTrend }).map((item) => ({
 				symbol: item.symbol,
 				score: item._score,
 				reason: item._scoreReason,

--- a/src/services/tradingview/marketScannerReport.js
+++ b/src/services/tradingview/marketScannerReport.js
@@ -62,8 +62,28 @@ function parseMarketScannerRequest(req = {}) {
 	const limit = parseLimit(body);
 	const bbwThreshold = parseBbwThreshold(body);
 	const ranked = parseRanked(body);
+	const htfTrend = parseHtfTrend(body);
 
-	return { exchange, timeframe, scans, limit, bbwThreshold, ranked };
+	return { exchange, timeframe, scans, limit, bbwThreshold, ranked, htfTrend };
+}
+
+function parseHtfTrend(body = {}) {
+	const val = body.htfTrend ?? body.htf_trend ?? body.higherTimeframeTrend ?? body.htf;
+	if (val === undefined || val === null) {
+		return null;
+	}
+	if (typeof val !== 'string') {
+		throw new MarketScannerRequestError('htfTrend must be a string');
+	}
+	const trimmed = val.trim().toLowerCase();
+	if (!trimmed) {
+		return null;
+	}
+	const validTrends = new Set(['bullish', 'bearish', 'neutral', 'up', 'down', 'sideways']);
+	if (!validTrends.has(trimmed)) {
+		throw new MarketScannerRequestError(`Unsupported htfTrend: ${val}`);
+	}
+	return trimmed;
 }
 
 function getRequestBody(req = {}) {
@@ -224,7 +244,7 @@ function buildMarketScannerReport(scanResults = [], options = {}) {
 			return;
 		}
 
-		const itemsToRender = prepareMarketScannerItems(scanResult, ranked);
+		const itemsToRender = prepareMarketScannerItems(scanResult, ranked, options);
 
 		if (itemsToRender.length === 0) {
 			lines.push('No hay.');
@@ -232,14 +252,14 @@ function buildMarketScannerReport(scanResults = [], options = {}) {
 		}
 
 		itemsToRender.forEach((item, index) => {
-			lines.push(formatScanItem(item, index + 1, scanResult.scan, ranked));
+			lines.push(formatScanItem(item, index + 1, scanResult.scan, ranked, options));
 		});
 	});
 
 	return lines.join('\n');
 }
 
-function prepareMarketScannerItems(scanResult = {}, ranked = false) {
+function prepareMarketScannerItems(scanResult = {}, ranked = false, options = {}) {
 	let itemsToRender = scanResult.items || [];
 	if (scanResult.scan === 'top_gainers') {
 		itemsToRender = itemsToRender.filter((item) => typeof item.changePercent === 'number' && item.changePercent > 0);
@@ -254,7 +274,11 @@ function prepareMarketScannerItems(scanResult = {}, ranked = false) {
 	}
 
 	if (ranked) {
-		itemsToRender = rankScannerItems(itemsToRender, scanResult.scan);
+		const rankOpts = {
+			...options,
+			htfTrend: scanResult.htfTrend ?? options.htfTrend ?? null,
+		};
+		itemsToRender = rankScannerItems(itemsToRender, scanResult.scan, rankOpts);
 	}
 
 	return itemsToRender;
@@ -294,7 +318,7 @@ function classifyRiskReward(ratio) {
 	return 'poor';
 }
 
-function formatScanItem(item, rank, scanType, ranked = false) {
+function formatScanItem(item, rank, scanType, ranked = false, options = {}) {
 	const symbol = stripExchange(item.symbol);
 	const priceVal = numberOrNull(item.indicators?.close ?? null);
 	const price = formatCurrency(priceVal);
@@ -317,6 +341,18 @@ function formatScanItem(item, rank, scanType, ranked = false) {
 	} else if (scanType === 'bollinger_scan') {
 		const bbw = numberOrNull(item.bbw ?? null);
 		suffix = ` | BBW ${formatNumber(bbw, 2)}`;
+	}
+
+	const itemHtf = item.htfTrend ?? item.htf_trend ?? item.higherTimeframeTrend ?? options.htfTrend ?? null;
+	if (itemHtf && (!ranked || !item._scoreReason || !item._scoreReason.includes('HTF'))) {
+		const normHtf = String(itemHtf).toLowerCase();
+		if (normHtf === 'bullish' || normHtf === 'up') {
+			suffix += ' | HTF: 🟢 Bullish';
+		} else if (normHtf === 'bearish' || normHtf === 'down') {
+			suffix += ' | HTF: 🔴 Bearish';
+		} else if (normHtf === 'neutral' || normHtf === 'sideways') {
+			suffix += ' | HTF: ⚪ Neutral';
+		}
 	}
 
 	if (ranked && item._score !== undefined) {

--- a/src/services/tradingview/marketScannerScoring.js
+++ b/src/services/tradingview/marketScannerScoring.js
@@ -31,7 +31,19 @@ function scoreScannerItem(item, scanType, options = {}) {
 	const {
 		rsiOversold = 30,
 		rsiOverbought = 70,
+		htfBoost = 10,
+		htfPenalty = 10,
 	} = options;
+
+	const rawHtf = options.htfTrend
+		?? item?.htfTrend
+		?? item?.htf_trend
+		?? item?.higherTimeframeTrend
+		?? item?.indicators?.htfTrend
+		?? item?.indicators?.htf_trend
+		?? null;
+
+	const htfTrend = normalizeHtfTrend(rawHtf);
 
 	const change = numberOrNull(item.changePercent);
 	const rsi = numberOrNull(item.indicators?.RSI ?? null);
@@ -143,6 +155,25 @@ function scoreScannerItem(item, scanType, options = {}) {
 		volatilityScore = 5; // Neutral for non-BB scans
 	}
 
+	// --- Higher-Timeframe Trend Confluence (Boost or Penalty) ---
+	let htfConfluence = 0;
+	if (htfTrend) {
+		const setupDirection = getSetupDirection(scanType, item);
+		if (setupDirection === 'BULLISH') {
+			if (htfTrend === 'BULLISH') {
+				htfConfluence = htfBoost;
+			} else if (htfTrend === 'BEARISH') {
+				htfConfluence = -htfPenalty;
+			}
+		} else if (setupDirection === 'BEARISH') {
+			if (htfTrend === 'BEARISH') {
+				htfConfluence = htfBoost;
+			} else if (htfTrend === 'BULLISH') {
+				htfConfluence = -htfPenalty;
+			}
+		}
+	}
+
 	// --- Chase-entry penalty ---
 	let chasePenalty = 0;
 	if (rsi !== null && volRatio !== null) {
@@ -158,7 +189,7 @@ function scoreScannerItem(item, scanType, options = {}) {
 	}
 
 	// --- Composite score (0-100) ---
-	const rawScore = trendScore + momentumScore + volumeScore + breakoutScore + volatilityScore;
+	const rawScore = trendScore + momentumScore + volumeScore + breakoutScore + volatilityScore + htfConfluence;
 	const finalScore = Math.max(0, Math.min(100, rawScore - chasePenalty));
 
 	// --- Reason text ---
@@ -171,6 +202,11 @@ function scoreScannerItem(item, scanType, options = {}) {
 	}
 	if (volRatio !== null) {
 		parts.push(`Vol ${volRatio.toFixed(1)}x`);
+	}
+	if (htfConfluence > 0) {
+		parts.push(`HTF aligned (+${htfConfluence})`);
+	} else if (htfConfluence < 0) {
+		parts.push(`⚠️ HTF counter-trend (${htfConfluence})`);
 	}
 	if (chasePenalty > 0) {
 		parts.push(`⚠️ chase penalty -${chasePenalty}`);
@@ -207,6 +243,55 @@ function rankScannerItems(items, scanType, options = {}) {
 	});
 
 	return scored.sort((a, b) => b._score - a._score);
+}
+
+function normalizeHtfTrend(value) {
+	if (typeof value !== 'string' || !value.trim()) {
+		return null;
+	}
+	const norm = value.trim().toLowerCase();
+	if (norm === 'bullish' || norm === 'up' || norm === 'long' || norm === 'buy') {
+		return 'BULLISH';
+	}
+	if (norm === 'bearish' || norm === 'down' || norm === 'short' || norm === 'sell') {
+		return 'BEARISH';
+	}
+	if (norm === 'neutral' || norm === 'sideways') {
+		return 'NEUTRAL';
+	}
+	return null;
+}
+
+function getSetupDirection(scanType, item = {}) {
+	if (scanType === 'top_gainers') {
+		return 'BULLISH';
+	}
+	if (scanType === 'top_losers') {
+		return 'BEARISH';
+	}
+	if (typeof item.breakout_type === 'string') {
+		const breakout = item.breakout_type.trim().toLowerCase();
+		if (breakout === 'bullish' || breakout === 'buy') {
+			return 'BULLISH';
+		}
+		if (breakout === 'bearish' || breakout === 'sell') {
+			return 'BEARISH';
+		}
+	}
+	if (typeof item.trading_recommendation === 'string') {
+		const rec = item.trading_recommendation.trim().toLowerCase();
+		if (/\bbuy\b/.test(rec)) {
+			return 'BULLISH';
+		}
+		if (/\bsell\b/.test(rec)) {
+			return 'BEARISH';
+		}
+	}
+	const change = numberOrNull(item.changePercent);
+	if (change !== null) {
+		return change >= 0 ? 'BULLISH' : 'BEARISH';
+	}
+	return 'BULLISH';
 }
 
 function numberOrNull(value) {

--- a/tests/integration/market-scanner-endpoint.test.js
+++ b/tests/integration/market-scanner-endpoint.test.js
@@ -247,4 +247,27 @@ describe('Market Scanner Alert endpoint', () => {
 		expect(res.body.scanResults[0].scores).toBeUndefined();
 		expect(res.body.payload.alertText).not.toContain('/100');
 	});
+
+	it('supports htfTrend parameter and applies higher-timeframe trend confluence in ranking scores', async () => {
+		tradingViewMcpService.callScanTool.mockResolvedValueOnce([
+			{
+				symbol: 'BINANCE:BTCUSDT',
+				changePercent: 4.0,
+				indicators: { close: 65000, RSI: 60 },
+				volume_ratio: 1.5,
+			},
+		]);
+
+		const res = await request(app)
+			.post('/api/webhook/market-scanner-alert')
+			.set('x-api-key', 'test-key')
+			.query({ dryRun: 'true' })
+			.send({ scans: ['top_gainers'], ranked: true, htfTrend: 'bullish' })
+			.expect(200);
+
+		expect(res.body.ranked).toBe(true);
+		expect(res.body.htfTrend).toBe('bullish');
+		expect(res.body.scanResults[0].scores[0].reason).toContain('HTF aligned');
+		expect(res.body.payload.alertText).toContain('HTF aligned');
+	});
 });

--- a/tests/unit/market-scanner-report.test.js
+++ b/tests/unit/market-scanner-report.test.js
@@ -28,6 +28,7 @@ describe('Market Scanner Report', () => {
 				limit: 5,
 				bbwThreshold: 0.05,
 				ranked: false,
+				htfTrend: null,
 			});
 		});
 
@@ -58,7 +59,19 @@ describe('Market Scanner Report', () => {
 				limit: 15,
 				bbwThreshold: 0.02,
 				ranked: false,
+				htfTrend: null,
 			});
+		});
+
+		it('parses and validates htfTrend parameter', () => {
+			const parsedBullish = parseMarketScannerRequest({ body: { htfTrend: ' BULLISH ' } });
+			expect(parsedBullish.htfTrend).toBe('bullish');
+
+			const parsedAlias = parseMarketScannerRequest({ body: { htf_trend: 'bearish' } });
+			expect(parsedAlias.htfTrend).toBe('bearish');
+
+			expect(() => parseMarketScannerRequest({ body: { htfTrend: 123 } })).toThrow('htfTrend must be a string');
+			expect(() => parseMarketScannerRequest({ body: { htfTrend: 'invalid' } })).toThrow('Unsupported htfTrend: invalid');
 		});
 
 		it('clamps limit to [1, 20]', () => {

--- a/tests/unit/market-scanner-scoring.test.js
+++ b/tests/unit/market-scanner-scoring.test.js
@@ -129,6 +129,63 @@ describe('Market Scanner Scoring', () => {
 			const result = scoreScannerItem(item, 'top_gainers');
 			expect(Number.isInteger(result.score)).toBe(true);
 		});
+
+		it('applies boost for aligned higher-timeframe trend (bullish HTF on top gainer)', () => {
+			const item = {
+				symbol: 'BINANCE:BTCUSDT',
+				changePercent: 4.0,
+				indicators: { close: 60000, RSI: 60 },
+				volume_ratio: 1.5,
+			};
+			const unaligned = scoreScannerItem(item, 'top_gainers');
+			const aligned = scoreScannerItem(item, 'top_gainers', { htfTrend: 'bullish' });
+
+			expect(aligned.score).toBeGreaterThan(unaligned.score);
+			expect(aligned.reason).toContain('HTF aligned');
+		});
+
+		it('applies penalty for counter-trend higher-timeframe trend (bearish HTF on top gainer)', () => {
+			const item = {
+				symbol: 'BINANCE:ETHUSDT',
+				changePercent: 4.0,
+				indicators: { close: 3000, RSI: 60 },
+				volume_ratio: 1.5,
+			};
+			const unaligned = scoreScannerItem(item, 'top_gainers');
+			const counterTrend = scoreScannerItem(item, 'top_gainers', { htfTrend: 'bearish' });
+
+			expect(counterTrend.score).toBeLessThan(unaligned.score);
+			expect(counterTrend.reason).toContain('HTF counter-trend');
+		});
+
+		it('applies boost for aligned higher-timeframe trend (bearish HTF on top loser)', () => {
+			const item = {
+				symbol: 'BINANCE:SOLUSDT',
+				changePercent: -4.0,
+				indicators: { close: 140, RSI: 35 },
+				volume_ratio: 1.5,
+			};
+			const aligned = scoreScannerItem(item, 'top_losers', { htfTrend: 'bearish' });
+			const counterTrend = scoreScannerItem(item, 'top_losers', { htfTrend: 'bullish' });
+
+			expect(aligned.score).toBeGreaterThan(counterTrend.score);
+			expect(aligned.reason).toContain('HTF aligned');
+			expect(counterTrend.reason).toContain('HTF counter-trend');
+		});
+
+		it('preserves fail-open behavior when HTF trend is omitted or neutral', () => {
+			const item = {
+				symbol: 'BINANCE:ADAUSDT',
+				changePercent: 3.0,
+				indicators: { close: 0.5, RSI: 55 },
+				volume_ratio: 1.2,
+			};
+			const base = scoreScannerItem(item, 'top_gainers');
+			const neutral = scoreScannerItem(item, 'top_gainers', { htfTrend: 'neutral' });
+
+			expect(base.score).toEqual(neutral.score);
+			expect(base.reason).not.toContain('HTF');
+		});
 	});
 
 	describe('rankScannerItems', () => {


### PR DESCRIPTION
feat: add higher-timeframe trend alignment scoring to market scanner (CB-86)

## Summary
Incorporates higher-timeframe (HTF) trend alignment scoring and counter-trend penalty logic into the market scanner service (`POST /api/webhook/market-scanner-alert`). Candidates matching HTF trend (e.g. bullish HTF for top gainers or bullish breakouts) receive a score boost, while counter-trend setups receive a penalty, reducing false breakout signals and improving setup quality.

## Key Changes
- **`src/services/tradingview/marketScannerScoring.js`**:
  - Extended `scoreScannerItem` to accept `options.htfTrend` (or `item.htfTrend` / `item.htf_trend` / `item.higherTimeframeTrend`).
  - Added HTF setup direction evaluation (`BULLISH` vs `BEARISH`) and applied `htfBoost` (+10 points) or `htfPenalty` (-10 points).
  - Updated score reason text to explicitly include `HTF aligned (+10)` or `⚠️ HTF counter-trend (-10)`.
- **`src/services/tradingview/marketScannerReport.js`**:
  - Added `parseHtfTrend` to `parseMarketScannerRequest` to validate and normalize `htfTrend` input (`bullish`, `bearish`, `neutral`).
  - Updated `prepareMarketScannerItems`, `buildMarketScannerReport`, and `formatScanItem` to propagate and format HTF trend metadata in scanner reports.
- **`src/controllers/webhooks/handlers/marketScanner/marketScanner.js`**:
  - Passed `parsed.htfTrend` to `buildMarketScannerReport` and `compactScanResults`.
- **Tests**:
  - `tests/unit/market-scanner-scoring.test.js`: Verified HTF trend alignment boost, counter-trend penalty, and fail-open fallback when HTF trend is omitted.
  - `tests/integration/market-scanner-endpoint.test.js`: Added integration test for `htfTrend` request parameter and score reason formatting.

## Technical Implementation
- Pure scoring function `scoreScannerItem` normalizes HTF trend tokens (`bullish`, `bearish`, `neutral`).
- Preserves complete fail-open behavior: when HTF trend data is omitted, scoring functions identically to single-timeframe evaluation with 0 impact.

## Testing
- Unit tests: `pnpm test -- tests/unit/market-scanner-scoring.test.js` (19 passing)
- Integration tests: `pnpm test -- tests/integration/market-scanner-endpoint.test.js` (8 passing)
- Full test suite: `pnpm test`

## References
- **GitHub Issue**: #217
- **Linear**: [CB-86](https://linear.app/knil/issue/CB-86/add-higher-timeframe-trend-alignment-to-scanner-scoring)
