### PR TITLE
feat(scanner): add durable preset storage (CB-88)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -282,6 +282,11 @@ MARKET_SCANNER_DEFAULT_EXCHANGE=BINANCE
 # Timeout in milliseconds for scanner webhook process (default: 90000, max: 120000)
 MARKET_SCANNER_TIMEOUT_MS=90000
 
+# Enable independent Firestore persistence for scanner presets (default: false)
+# When disabled, presets use an in-memory fallback and do not survive restarts.
+# The API and /api/status report the effective durable/ephemeral storage mode.
+ENABLE_FIRESTORE_SCANNER_PRESETS=false
+
 # ============================================================================
 # Sentry Monitoring Configuration (Optional)
 # ============================================================================

--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -702,6 +702,18 @@
           },
           "response": [
             {
+              "name": "Storage mode contract",
+              "status": "OK",
+              "code": 201,
+              "body": "{\n  \"success\": true,\n  \"storage\": {\n    \"enabled\": true,\n    \"configured\": true,\n    \"ready\": true,\n    \"status\": \"ready\",\n    \"mode\": \"durable\",\n    \"backend\": \"firestore\"\n  },\n  \"preset\": {\n    \"id\": \"83d1a85e-d433-4aa1-96b9-e62468bf0397\",\n    \"name\": \"Daily Scan\"\n  }\n}"
+            },
+            {
+              "name": "Error (invalid name)",
+              "status": "Bad Request",
+              "code": 400,
+              "body": "{\n  \"error\": \"name must be a string\",\n  \"code\": \"INVALID_REQUEST\"\n}"
+            },
+            {
               "name": "Created",
               "status": "Created",
               "code": 201,
@@ -732,6 +744,12 @@
             }
           },
           "response": [
+            {
+              "name": "Storage mode contract",
+              "status": "OK",
+              "code": 200,
+              "body": "{\n  \"success\": true,\n  \"storage\": {\n    \"enabled\": true,\n    \"configured\": true,\n    \"ready\": true,\n    \"status\": \"ready\",\n    \"mode\": \"durable\",\n    \"backend\": \"firestore\"\n  },\n  \"presets\": []\n}"
+            },
             {
               "name": "Success",
               "status": "OK",
@@ -764,6 +782,12 @@
             }
           },
           "response": [
+            {
+              "name": "Storage mode contract",
+              "status": "OK",
+              "code": 200,
+              "body": "{\n  \"success\": true,\n  \"storage\": {\n    \"enabled\": true,\n    \"configured\": true,\n    \"ready\": true,\n    \"status\": \"ready\",\n    \"mode\": \"durable\",\n    \"backend\": \"firestore\"\n  },\n  \"preset\": {\n    \"id\": \"83d1a85e-d433-4aa1-96b9-e62468bf0397\"\n  }\n}"
+            },
             {
               "name": "Success",
               "status": "OK",
@@ -806,6 +830,12 @@
           },
           "response": [
             {
+              "name": "Storage mode contract",
+              "status": "OK",
+              "code": 200,
+              "body": "{\n  \"success\": true,\n  \"storage\": {\n    \"enabled\": true,\n    \"configured\": true,\n    \"ready\": true,\n    \"status\": \"ready\",\n    \"mode\": \"durable\",\n    \"backend\": \"firestore\"\n  },\n  \"preset\": {\n    \"id\": \"83d1a85e-d433-4aa1-96b9-e62468bf0397\"\n  }\n}"
+            },
+            {
               "name": "Success",
               "status": "OK",
               "code": 200,
@@ -837,6 +867,12 @@
             }
           },
           "response": [
+            {
+              "name": "Storage mode contract",
+              "status": "OK",
+              "code": 200,
+              "body": "{\n  \"success\": true,\n  \"storage\": {\n    \"enabled\": true,\n    \"configured\": true,\n    \"ready\": true,\n    \"status\": \"ready\",\n    \"mode\": \"durable\",\n    \"backend\": \"firestore\"\n  }\n}"
+            },
             {
               "name": "Success",
               "status": "OK",
@@ -925,6 +961,33 @@
               "body": "{\n  \"success\": true,\n  \"dryRun\": true,\n  \"presetId\": \"83d1a85e-d433-4aa1-96b9-e62468bf0397\",\n  \"payload\": {\n    \"alertText\": \"\ud83d\udce1 *SCANNER DE MERCADO \u2014 ...\"\n  },\n  \"scanResults\": [],\n  \"summary\": {\n    \"totalScans\": 1,\n    \"success\": 1,\n    \"error\": 0,\n    \"timeout\": 0,\n    \"totalItems\": 3,\n    \"delivered\": 0\n  },\n  \"timedOut\": false,\n  \"timeoutMs\": 90000,\n  \"requestId\": \"req-dryrun-abc\",\n  \"totalDurationMs\": 1200\n}"
             }
           ]
+        }
+      ]
+    },
+    {
+      "name": "POST Create Scanner Preset (invalid name)",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json", "type": "text" },
+          { "key": "x-api-key", "value": "{{apiKey}}", "type": "text" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": 123\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/scanner-presets",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "scanner-presets"]
+        }
+      },
+      "response": [
+        {
+          "name": "Bad Request",
+          "status": "Bad Request",
+          "code": 400,
+          "body": "{\n  \"error\": \"name must be a string\",\n  \"code\": \"INVALID_REQUEST\"\n}"
         }
       ]
     },

--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ Express + Telegraf-based Telegram bot service with multi-channel alert delivery 
 - `MARKET_SCANNER_DEFAULT_EXCHANGE` - Default exchange when not provided in request (default: `BINANCE`)
 - `MARKET_SCANNER_TIMEOUT_MS` - Timeout in milliseconds for scanner webhook process (default: `90000`, max `120000`)
 
+#### Scanner Preset Storage
+
+- `ENABLE_FIRESTORE_SCANNER_PRESETS` - Enable the scanner-preset Firestore persistence gate independently from alert storage, job storage, and outcome tracking (default: `false`)
+- When Firestore is initialized and writes succeed, scanner-preset responses and `/api/status` report `storage.mode: "durable"` with `backend: "firestore"`.
+- When the flag is disabled, or Firestore initialization/write fails, the service reports `storage.mode: "ephemeral"` with `backend: "memory"`; presets in this mode can be lost on restart or redeploy.
+- `dependencies.scannerPresetStorage` in `/api/status` and `/api/capabilities` exposes `enabled`, `configured`, `ready`, `status`, `mode`, and `backend` without secrets. A `misconfigured` status means a Firestore gate is enabled but the client is unavailable.
+
 ## Setup
 
 ### 1. Install Dependencies

--- a/agents.md
+++ b/agents.md
@@ -1100,6 +1100,7 @@ Scanner presets support an independent `ENABLE_FIRESTORE_SCANNER_PRESETS=true` g
 
 **Core Components**:
 - `src/services/storage/AlertStorageService.js` — Allows scanner-preset initialization without enabling alert, job, or outcome storage.
+- `src/services/storage/firestoreConfig.js` — Centralizes non-secret Firestore credential/runtime readiness checks used by status and scanner-preset storage reporting.
 - `src/services/scannerPresets/ScannerPresetService.js` — Tracks effective storage health and reports the fail-open fallback accurately.
 - `src/controllers/status.js` and `src/controllers/webhooks/handlers/scannerPresets/scannerPresets.js` — Expose storage capability metadata without credentials.
 - `tests/unit/scanner-preset-service.test.js`, `tests/integration/scanner-presets-endpoint.test.js`, and `tests/integration/status-endpoint.test.js` — Cover independent persistence, restart simulation, disabled fallback, and Firestore write failure.

--- a/agents.md
+++ b/agents.md
@@ -143,7 +143,7 @@ Implement the following security practices to safeguard endpoints and credential
 ## Environment and runtime behavior (discoverable)
 - NODE version: `20.x` (see `package.json` engines).
 - Required env vars: `BOT_TOKEN` (throws if missing; even when Telegram bot is disabled).
-- Optional but relevant (non-exhaustive; see feature sections below for full config): `ENABLE_TELEGRAM_BOT`, `PORT`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID`, `ENABLE_WHATSAPP_ALERTS`, `ENABLE_GEMINI_GROUNDING`, `GEMINI_API_KEY`, `ENABLE_LANGFUSE_PROMPTS`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_PROMPT_LABEL`, `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`, `BRAVE_SEARCH_API_KEY`, `BRAVE_SEARCH_ENDPOINT`, `FORCE_BRAVE_SEARCH`, `MODEL_PROVIDER`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `ENABLE_NEWS_MONITOR`, `EXPANDED_ANALYSIS_ALERT_SYMBOLS`, `EXPANDED_ANALYSIS_ALERT_TIMEOUT_MS`, `TRADINGVIEW_MCP_URL`, `TRADINGVIEW_MCP_TIMEOUT_MS`, `TRADINGVIEW_MCP_MAX_RETRIES`, `TRADINGVIEW_MCP_DEFAULT_TIMEFRAME`, `ENABLE_TRADINGVIEW_VOLUME_CONFIRMATION`, `ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT`, `ENABLE_TRADINGVIEW_CONFLUENCE_MULTI_TIMEFRAME`, `ENABLE_SENTRY`, `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_PROFILE_SESSION_SAMPLE_RATE`, `SENTRY_CONSOLE_LOG_LEVELS`, `ENABLE_SENTRY_DEBUG_ROUTE`, `LOG_LEVEL`, `SERVICE_NAME`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `ENABLE_FIRESTORE_ALERT_STORAGE`, `ENABLE_SIGNAL_OUTCOME_TRACKING`, `ENABLE_SHADOW_MODE_OUTCOME_TRACKING` (legacy alias), `ENABLE_MARKET_SCANNER`, `ENABLE_MESSAGE_FOOTER_METADATA`, `FIREBASE_PROJECT_ID`, `FIREBASE_SERVICE_ACCOUNT_JSON`, `GOOGLE_APPLICATION_CREDENTIALS`, `GEMINI_MODEL_NAME_FALLBACK`, `RENDER`, `IS_PULL_REQUEST`, `RENDER_GIT_COMMIT`, `RENDER_GIT_REPO_SLUG`.
+- Optional but relevant (non-exhaustive; see feature sections below for full config): `ENABLE_TELEGRAM_BOT`, `PORT`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ADMIN_NOTIFICATIONS_CHAT_ID`, `ENABLE_WHATSAPP_ALERTS`, `ENABLE_GEMINI_GROUNDING`, `GEMINI_API_KEY`, `ENABLE_LANGFUSE_PROMPTS`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_PROMPT_LABEL`, `LANGFUSE_PROMPT_CACHE_TTL_SECONDS`, `BRAVE_SEARCH_API_KEY`, `BRAVE_SEARCH_ENDPOINT`, `FORCE_BRAVE_SEARCH`, `MODEL_PROVIDER`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `ENABLE_NEWS_MONITOR`, `EXPANDED_ANALYSIS_ALERT_SYMBOLS`, `EXPANDED_ANALYSIS_ALERT_TIMEOUT_MS`, `TRADINGVIEW_MCP_URL`, `TRADINGVIEW_MCP_TIMEOUT_MS`, `TRADINGVIEW_MCP_MAX_RETRIES`, `TRADINGVIEW_MCP_DEFAULT_TIMEFRAME`, `ENABLE_TRADINGVIEW_VOLUME_CONFIRMATION`, `ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT`, `ENABLE_TRADINGVIEW_CONFLUENCE_MULTI_TIMEFRAME`, `ENABLE_SENTRY`, `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_PROFILE_SESSION_SAMPLE_RATE`, `SENTRY_CONSOLE_LOG_LEVELS`, `ENABLE_SENTRY_DEBUG_ROUTE`, `LOG_LEVEL`, `SERVICE_NAME`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `ENABLE_FIRESTORE_ALERT_STORAGE`, `ENABLE_FIRESTORE_SCANNER_PRESETS`, `ENABLE_SIGNAL_OUTCOME_TRACKING`, `ENABLE_SHADOW_MODE_OUTCOME_TRACKING` (legacy alias), `ENABLE_MARKET_SCANNER`, `ENABLE_MESSAGE_FOOTER_METADATA`, `FIREBASE_PROJECT_ID`, `FIREBASE_SERVICE_ACCOUNT_JSON`, `GOOGLE_APPLICATION_CREDENTIALS`, `GEMINI_MODEL_NAME_FALLBACK`, `RENDER`, `IS_PULL_REQUEST`, `RENDER_GIT_COMMIT`, `RENDER_GIT_REPO_SLUG`.
 
 - Bot startup is gated: bot is launched only when `ENABLE_TELEGRAM_BOT === 'true'` and not a preview environment (`RENDER==='true' && IS_PULL_REQUEST==='true'` disables it).
 - Routes under `/api` (e.g. `/api/webhook/alert`) are mounted regardless of bot launch; individual features and notification channels are gated via env flags and per-channel validation.
@@ -153,6 +153,7 @@ Implement the following security practices to safeguard endpoints and credential
   - `telegramChatId` / `whatsappChatId` — optional per-channel destination overrides
   - If `channels` is omitted, delivery still uses the existing broadcast-to-all-enabled-channels behavior.
 - Stored alert read, export, analytics, and replay routes (`GET /api/alerts`, `GET /api/alerts/export`, `GET /api/alerts/summary`, `GET /api/alerts/:alertId`, `POST /api/alerts/:alertId/replay`) are also mounted under `/api`; they require `WEBHOOK_API_KEY` when configured, return `403 FEATURE_DISABLED` unless `ENABLE_FIRESTORE_ALERT_STORAGE=true`, and return `503 STORAGE_UNAVAILABLE` when Firestore is enabled but unreadable.
+- Scanner preset CRUD responses include a non-sensitive `storage` object with the effective `mode` (`durable` or `ephemeral`) and `backend` (`firestore` or `memory`). `ENABLE_FIRESTORE_SCANNER_PRESETS=true` enables Firestore independently; `/api/status` and `/api/capabilities` expose the same state under `dependencies.scannerPresetStorage`.
 
 ---
 
@@ -876,6 +877,7 @@ ENABLE_BINANCE_PRICE_CHECK (003)
 ENABLE_LLM_ALERT_ENRICHMENT (003)
 ENABLE_SENTRY (005)
 ENABLE_FIRESTORE_ALERT_STORAGE (006)
+ENABLE_FIRESTORE_SCANNER_PRESETS (scanner preset persistence)
 ```
 
 **To add new feature**:
@@ -1091,3 +1093,14 @@ The market scanner accepts optional `includeMultiTimeframe` enrichment. When ena
 - `src/services/tradingview/marketScannerScoring.js` — Direction normalization and configurable confluence scoring.
 - `src/services/tradingview/marketScannerReport.js` — Request parsing and Telegram/WhatsApp report markers.
 - `tests/unit/market-scanner-scoring.test.js`, `tests/unit/market-scanner-report.test.js`, `tests/unit/market-scanner.test.js`, and `tests/integration/market-scanner-endpoint.test.js` — Scoring, rendering, fail-open, and endpoint coverage.
+
+## Durable Scanner Preset Storage (CB-88 / Issue #219)
+
+Scanner presets support an independent `ENABLE_FIRESTORE_SCANNER_PRESETS=true` gate. `ScannerPresetService` reuses the lazy Firestore singleton, persists across service instances when available, and falls back to the in-memory `Map` on disabled, initialization, or write failure. Every scanner-preset CRUD success response exposes a non-sensitive `storage` object; `/api/status` and `/api/capabilities` expose the same effective state under `dependencies.scannerPresetStorage`, with `mode: durable|ephemeral` and `backend: firestore|memory`.
+
+**Core Components**:
+- `src/services/storage/AlertStorageService.js` — Allows scanner-preset initialization without enabling alert, job, or outcome storage.
+- `src/services/scannerPresets/ScannerPresetService.js` — Tracks effective storage health and reports the fail-open fallback accurately.
+- `src/controllers/status.js` and `src/controllers/webhooks/handlers/scannerPresets/scannerPresets.js` — Expose storage capability metadata without credentials.
+- `tests/unit/scanner-preset-service.test.js`, `tests/integration/scanner-presets-endpoint.test.js`, and `tests/integration/status-endpoint.test.js` — Cover independent persistence, restart simulation, disabled fallback, and Firestore write failure.
+- `README.md`, `.env.example`, `src/openapi/openapi.json`, and `CabrosBot.postman_collection.json` — Document configuration and response contracts.

--- a/src/controllers/status.js
+++ b/src/controllers/status.js
@@ -2,6 +2,7 @@ const { createPrivateKey } = require('crypto');
 const { accessSync, constants } = require('fs');
 const packageJson = require('../../package.json');
 const sentryService = require('../services/monitoring/SentryService');
+const { scannerPresetService } = require('../services/scannerPresets/ScannerPresetService');
 
 const DEFAULT_TRADINGVIEW_MCP_URL = 'https://tradingview-mcp.onrender.com/mcp';
 const DEFAULT_AZURE_LLM_ENDPOINT = 'https://models.github.ai/inference';
@@ -198,6 +199,7 @@ function getStatus() {
 	const tradingViewVolumeConfirmationEnabled = tradingViewVolumeConfirmationFlagEnabled && tradingViewMcpEnrichmentEnabled;
 	const tradingViewMcpEnabled = tradingViewMcpEnrichmentEnabled || marketScannerEnabled;
 	const firestoreEnabled = isEnabled(process.env.ENABLE_FIRESTORE_ALERT_STORAGE);
+	const firestoreScannerPresetsEnabled = isEnabled(process.env.ENABLE_FIRESTORE_SCANNER_PRESETS);
 	const firestoreJobStorageEnabled = isEnabled(process.env.ENABLE_FIRESTORE_JOB_STORAGE)
 		|| firestoreEnabled;
 	const sentryEnabled = isEnabled(process.env.ENABLE_SENTRY);
@@ -316,6 +318,7 @@ function getStatus() {
 			tradingViewConfluenceEnrichment: process.env.ENABLE_TRADINGVIEW_CONFLUENCE_ENRICHMENT !== 'false',
 			tradingViewConfluenceMultiTimeframe: isEnabled(process.env.ENABLE_TRADINGVIEW_CONFLUENCE_MULTI_TIMEFRAME),
 			firestoreAlertStorage: firestoreEnabled,
+			firestoreScannerPresets: firestoreScannerPresetsEnabled,
 			firestoreJobStorage: firestoreJobStorageEnabled,
 			sentryMonitoring: sentryEnabled,
 			sentryProfiling: sentryService.isProfilingEnabled(),
@@ -362,7 +365,8 @@ function getStatus() {
 				&& hasValue(process.env.CF_AIG_BASE_URL)
 				&& hasValue(process.env.CF_AIG_MODEL || DEFAULT_CF_AIG_MODEL),
 		}),
-		newsMonitorDedup,
+			newsMonitorDedup,
+			scannerPresetStorage: scannerPresetService.getStorageStatus(),
 		},
 	};
 }

--- a/src/controllers/status.js
+++ b/src/controllers/status.js
@@ -1,8 +1,7 @@
-const { createPrivateKey } = require('crypto');
-const { accessSync, constants } = require('fs');
 const packageJson = require('../../package.json');
 const sentryService = require('../services/monitoring/SentryService');
 const { scannerPresetService } = require('../services/scannerPresets/ScannerPresetService');
+const { isFirestoreConfigured } = require('../services/storage/firestoreConfig');
 
 const DEFAULT_TRADINGVIEW_MCP_URL = 'https://tradingview-mcp.onrender.com/mcp';
 const DEFAULT_AZURE_LLM_ENDPOINT = 'https://models.github.ai/inference';
@@ -15,51 +14,6 @@ function isEnabled(value) {
 
 function hasValue(value) {
 	return typeof value === 'string' ? value.trim().length > 0 : value != null;
-}
-
-function isGoogleManagedRuntime() {
-	return (
-		hasValue(process.env.K_SERVICE)
-		|| hasValue(process.env.K_REVISION)
-		|| hasValue(process.env.FUNCTION_TARGET)
-		|| hasValue(process.env.FUNCTION_NAME)
-		|| hasValue(process.env.GAE_SERVICE)
-	);
-}
-
-function hasValidInlineFirestoreCredentials(value) {
-	if (!hasValue(value)) {
-		return false;
-	}
-
-	try {
-		const parsed = JSON.parse(value);
-		const projectId = parsed.projectId || parsed.project_id;
-		const clientEmail = parsed.clientEmail || parsed.client_email;
-		const privateKey = parsed.privateKey || parsed.private_key;
-
-		if (!hasValue(projectId) || !hasValue(clientEmail) || !hasValue(privateKey)) {
-			return false;
-		}
-
-		createPrivateKey({ key: privateKey, format: 'pem' });
-		return true;
-	} catch (error) {
-		return false;
-	}
-}
-
-function hasReadableFile(path) {
-	if (!hasValue(path)) {
-		return false;
-	}
-
-	try {
-		accessSync(path, constants.R_OK);
-		return true;
-	} catch (error) {
-		return false;
-	}
 }
 
 function getModelProvider() {
@@ -242,10 +196,7 @@ function getStatus() {
 	});
 	const firestore = dependencyStatus({
 		enabled: firestoreEnabled,
-		configured:
-			hasValidInlineFirestoreCredentials(process.env.FIREBASE_SERVICE_ACCOUNT_JSON)
-			|| hasReadableFile(process.env.GOOGLE_APPLICATION_CREDENTIALS)
-			|| isGoogleManagedRuntime(),
+		configured: isFirestoreConfigured(),
 	});
 	const firestoreJobStorage = dependencyStatus({
 		enabled: firestoreJobStorageEnabled,

--- a/src/controllers/webhooks/handlers/scannerPresets/scannerPresets.js
+++ b/src/controllers/webhooks/handlers/scannerPresets/scannerPresets.js
@@ -163,6 +163,7 @@ function getPreset(req, res) {
 				return res.status(404).json({
 					success: false,
 					error: 'Preset not found',
+					storage: getStorageMetadata(),
 				});
 			}
 
@@ -195,6 +196,7 @@ function deletePreset(req, res) {
 				return res.status(404).json({
 					success: false,
 					error: 'Preset not found',
+					storage: getStorageMetadata(),
 				});
 			}
 
@@ -226,6 +228,7 @@ function updatePreset(req, res) {
 				return res.status(404).json({
 					success: false,
 					error: 'Preset not found',
+					storage: getStorageMetadata(),
 				});
 			}
 

--- a/src/controllers/webhooks/handlers/scannerPresets/scannerPresets.js
+++ b/src/controllers/webhooks/handlers/scannerPresets/scannerPresets.js
@@ -25,6 +25,10 @@ const {
 const DEFAULT_SCANNER_TIMEOUT_MS = 90000;
 const MAX_SCANNER_TIMEOUT_MS = 120000;
 
+function getStorageMetadata() {
+	return scannerPresetService.getStorageStatus();
+}
+
 function resolveBot(botOrGetter) {
 	if (typeof botOrGetter === 'function') {
 		return botOrGetter();
@@ -99,6 +103,7 @@ function postPreset(req, res) {
 			const preset = await scannerPresetService.createPreset(req.body || {});
 			return res.status(201).json({
 				success: true,
+				storage: getStorageMetadata(),
 				preset,
 			});
 		} catch (error) {
@@ -130,6 +135,7 @@ function listPresets(req, res) {
 			const presets = await scannerPresetService.listPresets();
 			return res.status(200).json({
 				success: true,
+				storage: getStorageMetadata(),
 				presets,
 			});
 		} catch (error) {
@@ -162,6 +168,7 @@ function getPreset(req, res) {
 
 			return res.status(200).json({
 				success: true,
+				storage: getStorageMetadata(),
 				preset,
 			});
 		} catch (error) {
@@ -193,6 +200,7 @@ function deletePreset(req, res) {
 
 			return res.status(200).json({
 				success: true,
+				storage: getStorageMetadata(),
 			});
 		} catch (error) {
 			console.error('[ScannerPresets] Delete failed:', error.message);
@@ -223,6 +231,7 @@ function updatePreset(req, res) {
 
 			return res.status(200).json({
 				success: true,
+				storage: getStorageMetadata(),
 				preset,
 			});
 		} catch (error) {

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -102,13 +102,13 @@
     "/api/scanner-presets": {
       "get": {
         "tags": ["Scanner presets"], "summary": "List scanner presets", "operationId": "listScannerPresets",
-        "responses": { "200": { "$ref": "#/components/responses/JsonResult" }, "500": { "$ref": "#/components/responses/Error" } },
+        "responses": { "200": { "$ref": "#/components/responses/ScannerPresetResult" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       },
       "post": {
         "tags": ["Scanner presets"], "summary": "Create a scanner preset", "operationId": "createScannerPreset",
         "requestBody": { "$ref": "#/components/requestBodies/ScannerPreset" },
-        "responses": { "201": { "$ref": "#/components/responses/JsonResult" }, "400": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "responses": { "201": { "$ref": "#/components/responses/ScannerPresetResult" }, "400": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
     },
@@ -116,20 +116,20 @@
       "get": {
         "tags": ["Scanner presets"], "summary": "Get a scanner preset", "operationId": "getScannerPreset",
         "parameters": [{ "$ref": "#/components/parameters/PresetId" }],
-        "responses": { "200": { "$ref": "#/components/responses/JsonResult" }, "404": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "responses": { "200": { "$ref": "#/components/responses/ScannerPresetResult" }, "404": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       },
       "put": {
         "tags": ["Scanner presets"], "summary": "Update a scanner preset", "operationId": "updateScannerPreset",
         "parameters": [{ "$ref": "#/components/parameters/PresetId" }],
         "requestBody": { "$ref": "#/components/requestBodies/ScannerPreset" },
-        "responses": { "200": { "$ref": "#/components/responses/JsonResult" }, "400": { "$ref": "#/components/responses/Error" }, "404": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "responses": { "200": { "$ref": "#/components/responses/ScannerPresetResult" }, "400": { "$ref": "#/components/responses/Error" }, "404": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       },
       "delete": {
         "tags": ["Scanner presets"], "summary": "Delete a scanner preset", "operationId": "deleteScannerPreset",
         "parameters": [{ "$ref": "#/components/parameters/PresetId" }],
-        "responses": { "200": { "$ref": "#/components/responses/JsonResult" }, "404": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "responses": { "200": { "$ref": "#/components/responses/ScannerPresetResult" }, "404": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
     },
@@ -262,6 +262,7 @@
       "Unauthorized": { "description": "API key rejected", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Unauthorized", "code": "UNAUTHORIZED" } } } },
       "Error": { "description": "Request or service error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Invalid request", "code": "INVALID_REQUEST" } } } },
       "JsonResult": { "description": "Successful JSON response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonObject" } } } },
+      "ScannerPresetResult": { "description": "Scanner preset response including the effective durable or ephemeral storage mode", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ScannerPresetResponse" }, "examples": { "durable": { "value": { "success": true, "storage": { "enabled": true, "configured": true, "ready": true, "status": "ready", "mode": "durable", "backend": "firestore" }, "preset": { "id": "83d1a85e-d433-4aa1-96b9-e62468bf0397", "name": "Daily Scan", "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers"], "limit": 5, "bbwThreshold": 0.05 } } }, "ephemeral": { "value": { "success": true, "storage": { "enabled": true, "configured": false, "ready": false, "status": "misconfigured", "mode": "ephemeral", "backend": "memory" }, "preset": { "id": "83d1a85e-d433-4aa1-96b9-e62468bf0397", "name": "Fallback scan" } } } } } } },
       "DeliveryResult": { "description": "Per-channel delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DeliveryResult" }, "example": { "success": true, "results": [{ "channel": "telegram", "success": true }] } } } },
       "AnalysisResult": { "description": "Analysis and delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonObject" } } } },
       "NewsMonitorAnalysisResult": { "description": "News monitor analysis and delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NewsMonitorResponse" } } } },
@@ -292,7 +293,10 @@
         }
       },
       "VolumeConfirmationRequest": { "type": "object", "required": ["symbol"], "properties": { "symbol": { "type": "string", "pattern": "^[A-Z0-9_]+:[A-Z0-9._-]+$" }, "timeframe": { "type": "string" } } },
-      "ScannerPresetRequest": { "type": "object", "required": ["name"], "properties": { "name": { "type": "string", "minLength": 1 }, "exchange": { "type": "string" }, "timeframe": { "type": "string" }, "scans": { "type": "array", "items": { "type": "string" } }, "limit": { "type": "integer", "minimum": 1, "maximum": 20 }, "bbw_threshold": { "type": "number" } } },
+      "ScannerPresetRequest": { "type": "object", "required": ["name"], "properties": { "name": { "type": "string", "minLength": 1 }, "exchange": { "type": "string" }, "timeframe": { "type": "string" }, "scans": { "type": "array", "items": { "type": "string" } }, "limit": { "type": "integer", "minimum": 1, "maximum": 20 }, "bbwThreshold": { "type": "number" } } },
+      "ScannerPresetStorage": { "type": "object", "required": ["enabled", "configured", "ready", "status", "mode", "backend"], "properties": { "enabled": { "type": "boolean", "description": "Whether any configured Firestore persistence gate is active." }, "configured": { "type": "boolean", "description": "Whether the Firestore client is available for scanner presets." }, "ready": { "type": "boolean" }, "status": { "type": "string", "enum": ["ready", "disabled", "misconfigured"] }, "mode": { "type": "string", "enum": ["durable", "ephemeral"], "description": "durable means Firestore-backed; ephemeral means in-memory fallback and may be lost on restart." }, "backend": { "type": "string", "enum": ["firestore", "memory"] } } },
+      "ScannerPreset": { "type": "object", "properties": { "id": { "type": "string" }, "name": { "type": "string" }, "exchange": { "type": "string" }, "timeframe": { "type": "string" }, "scans": { "type": "array", "items": { "type": "string" } }, "limit": { "type": "integer" }, "bbwThreshold": { "type": "number" }, "createdAt": { "type": "string", "format": "date-time" }, "updatedAt": { "type": "string", "format": "date-time" } } },
+      "ScannerPresetResponse": { "type": "object", "required": ["success", "storage"], "properties": { "success": { "type": "boolean" }, "storage": { "$ref": "#/components/schemas/ScannerPresetStorage" }, "preset": { "$ref": "#/components/schemas/ScannerPreset" }, "presets": { "type": "array", "items": { "$ref": "#/components/schemas/ScannerPreset" } } } },
       "CallbackFields": {
         "type": "object",
         "description": "When callbackUrl is configured, each callback POST includes x-callback-timestamp (ISO-8601), x-callback-event, and a UUID x-callback-delivery-id. If a callback secret is configured (via callbackSecret or JOB_CALLBACK_SIGNING_SECRET), x-callback-signature is sent containing an HMAC-SHA256 hex digest over the newline-delimited timestamp, event, delivery ID, and raw JSON body. The secret itself is never transmitted. Receivers should reject stale timestamps and deduplicate delivery IDs; retries use new IDs and signatures.",
@@ -380,7 +384,7 @@
           "code": { "type": "string", "description": "Machine-readable error code (failed or timed_out jobs only)." }
         }
       },
-      "Status": { "type": "object", "description": "Runtime status. featureFlags.firestoreJobStorage reports the ENABLE_FIRESTORE_JOB_STORAGE gate or the legacy ENABLE_FIRESTORE_ALERT_STORAGE gate; dependencies.firestoreJobStorage reports Firestore credential readiness for that runtime path; featureFlags.newsMonitorTestMode reports ENABLE_NEWS_MONITOR_TEST_MODE without changing news monitor behavior; featureFlags.messageFooterMetadata reports ENABLE_MESSAGE_FOOTER_METADATA and defaults to true unless explicitly set to false; featureFlags.cloudflareAig reports ENABLE_CLOUDFLARE_AIG and dependencies.cloudflareAig reports Cloudflare AI Gateway credential readiness.", "properties": { "service": { "$ref": "#/components/schemas/JsonObject" }, "featureFlags": { "$ref": "#/components/schemas/JsonObject" }, "deliveryChannels": { "$ref": "#/components/schemas/JsonObject" }, "dependencies": { "$ref": "#/components/schemas/JsonObject" } } }
+      "Status": { "type": "object", "description": "Runtime status. featureFlags.firestoreJobStorage reports the ENABLE_FIRESTORE_JOB_STORAGE gate or the legacy ENABLE_FIRESTORE_ALERT_STORAGE gate; featureFlags.firestoreScannerPresets reports ENABLE_FIRESTORE_SCANNER_PRESETS; dependencies.scannerPresetStorage reports the effective durable or ephemeral scanner-preset backend and readiness; dependencies.firestoreJobStorage reports Firestore credential readiness for that runtime path; featureFlags.newsMonitorTestMode reports ENABLE_NEWS_MONITOR_TEST_MODE without changing news monitor behavior; featureFlags.messageFooterMetadata reports ENABLE_MESSAGE_FOOTER_METADATA and defaults to true unless explicitly set to false; featureFlags.cloudflareAig reports ENABLE_CLOUDFLARE_AIG and dependencies.cloudflareAig reports Cloudflare AI Gateway credential readiness.", "properties": { "service": { "$ref": "#/components/schemas/JsonObject" }, "featureFlags": { "$ref": "#/components/schemas/JsonObject" }, "deliveryChannels": { "$ref": "#/components/schemas/JsonObject" }, "dependencies": { "$ref": "#/components/schemas/JsonObject" } } }
     }
   }
 }

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -10,6 +10,7 @@ const {
 	normalizeTradingViewTimeframe,
 	SUPPORTED_MCP_TIMEFRAMES,
 } = require('../tradingview/parseTradingViewSignal');
+const { isFirestoreConfigured } = require('../storage/firestoreConfig');
 
 const COLLECTION_NAME = 'scannerPresets';
 const FIRESTORE_GATE_ENV_VARS = [
@@ -106,7 +107,7 @@ class ScannerPresetService {
 	getStorageStatus() {
 		const firestoreEnabled = FIRESTORE_GATE_ENV_VARS.some((envVar) => process.env[envVar] === 'true');
 		const firestore = this._getFirestore();
-		const durable = Boolean(firestore);
+		const durable = Boolean(firestore) && !this.firestoreUnavailable && isFirestoreConfigured();
 
 		return {
 			enabled: firestoreEnabled,
@@ -306,10 +307,6 @@ class ScannerPresetService {
 	}
 
 	_getFirestore() {
-		if (this.firestoreUnavailable) {
-			return null;
-		}
-
 		return alertStorageService.getFirestore();
 	}
 

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -130,7 +130,7 @@ class ScannerPresetService {
 	}
 
 	async createPreset(params = {}) {
-		const preset = this._buildPreset(params);
+		const preset = this._buildPreset({ ...params, id: undefined });
 		await this._persistPreset(preset);
 		return clonePreset(preset);
 	}

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -355,7 +355,11 @@ class ScannerPresetService {
 			await this._flushPendingPresets(firestore);
 			this.firestoreUnavailable = pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0;
 		} catch (error) {
-			pendingFirestorePresets.set(preset.id, clonePreset(preset));
+			if ((firestoreDeleteGenerations.get(preset.id) || 0) === deleteGenerationAtStart) {
+				pendingFirestorePresets.set(preset.id, clonePreset(preset));
+			} else {
+				pendingFirestorePresets.delete(preset.id);
+			}
 			this.firestoreUnavailable = true;
 			console.warn('[ScannerPresetService] Failed to persist preset to Firestore:', error.message);
 		}

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -345,6 +345,7 @@ class ScannerPresetService {
 			return;
 		}
 
+		pendingFirestorePresets.delete(preset.id);
 		try {
 			await this._writeFirestorePreset(firestore, preset);
 			pendingFirestorePresets.delete(preset.id);

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -27,6 +27,7 @@ const SUPPORTED_TIMEFRAME_ALIASES = new Set([
 // In-memory fallback used when Firestore is unavailable.
 const memoryPresets = new Map();
 const pendingFirestorePresets = new Map();
+const firestoreWriteQueues = new Map();
 
 function clonePreset(preset) {
 	if (!preset) return null;
@@ -317,9 +318,7 @@ class ScannerPresetService {
 		}
 
 		try {
-			await firestore.collection(COLLECTION_NAME).doc(preset.id).set({
-				...clonePreset(preset),
-			});
+			await this._writeFirestorePreset(firestore, preset);
 			pendingFirestorePresets.delete(preset.id);
 			await this._flushPendingPresets(firestore);
 			this.firestoreUnavailable = pendingFirestorePresets.size > 0;
@@ -333,13 +332,29 @@ class ScannerPresetService {
 	async _flushPendingPresets(firestore) {
 		for (const preset of [...pendingFirestorePresets.values()]) {
 			try {
-				await firestore.collection(COLLECTION_NAME).doc(preset.id).set({
-					...clonePreset(preset),
-				});
+				await this._writeFirestorePreset(firestore, preset);
 				pendingFirestorePresets.delete(preset.id);
 			} catch (error) {
 				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to flush pending preset to Firestore:', error.message);
+			}
+		}
+	}
+
+	async _writeFirestorePreset(firestore, preset) {
+		const previousWrite = firestoreWriteQueues.get(preset.id) || Promise.resolve();
+		const currentWrite = previousWrite
+			.catch(() => undefined)
+			.then(() => firestore.collection(COLLECTION_NAME).doc(preset.id).set({
+				...clonePreset(preset),
+			}));
+		firestoreWriteQueues.set(preset.id, currentWrite);
+
+		try {
+			await currentWrite;
+		} finally {
+			if (firestoreWriteQueues.get(preset.id) === currentWrite) {
+				firestoreWriteQueues.delete(preset.id);
 			}
 		}
 	}
@@ -380,6 +395,7 @@ module.exports = {
 	_resetForTesting() {
 		memoryPresets.clear();
 		pendingFirestorePresets.clear();
+		firestoreWriteQueues.clear();
 		scannerPresetService.firestoreUnavailable = false;
 	},
 };

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -13,13 +13,6 @@ const {
 const { isFirestoreConfigured } = require('../storage/firestoreConfig');
 
 const COLLECTION_NAME = 'scannerPresets';
-const FIRESTORE_GATE_ENV_VARS = [
-	'ENABLE_FIRESTORE_SCANNER_PRESETS',
-	'ENABLE_FIRESTORE_ALERT_STORAGE',
-	'ENABLE_FIRESTORE_JOB_STORAGE',
-	'ENABLE_SIGNAL_OUTCOME_TRACKING',
-	'ENABLE_SHADOW_MODE_OUTCOME_TRACKING',
-];
 const DEFAULT_SCAN_LIMIT = 5;
 const MAX_SCAN_LIMIT = 20;
 const DEFAULT_EXCHANGE = 'BINANCE';
@@ -44,6 +37,10 @@ function clonePreset(preset) {
 
 function compareByCreatedAtDesc(a, b) {
 	return String(b.createdAt || '').localeCompare(String(a.createdAt || ''));
+}
+
+function isFirestoreEnabled() {
+	return process.env.ENABLE_FIRESTORE_SCANNER_PRESETS === 'true';
 }
 
 function normalizeScanList(scans) {
@@ -105,7 +102,7 @@ class ScannerPresetService {
 	}
 
 	getStorageStatus() {
-		const firestoreEnabled = FIRESTORE_GATE_ENV_VARS.some((envVar) => process.env[envVar] === 'true');
+		const firestoreEnabled = isFirestoreEnabled();
 		const firestore = this._getFirestore();
 		const durable = Boolean(firestore) && !this.firestoreUnavailable && isFirestoreConfigured();
 
@@ -310,7 +307,7 @@ class ScannerPresetService {
 	}
 
 	_getFirestore() {
-		return alertStorageService.getFirestore();
+		return isFirestoreEnabled() ? alertStorageService.getFirestore() : null;
 	}
 
 	_formatFirestoreDoc(doc) {

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -27,6 +27,7 @@ const SUPPORTED_TIMEFRAME_ALIASES = new Set([
 // In-memory fallback used when Firestore is unavailable.
 const memoryPresets = new Map();
 const pendingFirestorePresets = new Map();
+const inFlightFirestorePresets = new Map();
 const pendingFirestoreDeletes = new Set();
 const firestoreDeleteGenerations = new Map();
 const firestoreWriteQueues = new Map();
@@ -116,6 +117,7 @@ class ScannerPresetService {
 		const durable = Boolean(firestore)
 			&& !this.firestoreUnavailable
 			&& pendingFirestorePresets.size === 0
+			&& inFlightFirestorePresets.size === 0
 			&& pendingFirestoreDeletes.size === 0
 			&& isFirestoreConfigured();
 
@@ -147,13 +149,20 @@ class ScannerPresetService {
 					? snapshot.docs.map((doc) => this._formatFirestoreDoc(doc))
 					: [];
 
-				if (pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0) {
+				if (pendingFirestorePresets.size > 0
+					|| inFlightFirestorePresets.size > 0
+					|| pendingFirestoreDeletes.size > 0) {
 					this.firestoreUnavailable = true;
 					const mergedPresets = new Map(
 						firestorePresets
 							.filter((preset) => !pendingFirestoreDeletes.has(preset.id))
 							.map((preset) => [preset.id, preset]),
 					);
+					for (const [id, operation] of inFlightFirestorePresets.entries()) {
+						if (!pendingFirestoreDeletes.has(id)) {
+							mergedPresets.set(id, clonePreset(operation.preset));
+						}
+					}
 					for (const preset of pendingFirestorePresets.values()) {
 						mergedPresets.set(preset.id, clonePreset(preset));
 					}
@@ -185,11 +194,16 @@ class ScannerPresetService {
 		if (pendingFirestoreDeletes.has(id)) {
 			return null;
 		}
+		if (inFlightFirestorePresets.has(id)) {
+			return clonePreset(inFlightFirestorePresets.get(id).preset);
+		}
 
 		if (firestore) {
 			try {
 				const snapshot = await firestore.collection(COLLECTION_NAME).doc(id).get();
-				this.firestoreUnavailable = pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0;
+				this.firestoreUnavailable = pendingFirestorePresets.size > 0
+					|| inFlightFirestorePresets.size > 0
+					|| pendingFirestoreDeletes.size > 0;
 				if (snapshot && snapshot.exists) {
 					return this._formatFirestoreDoc(snapshot);
 				}
@@ -346,6 +360,8 @@ class ScannerPresetService {
 		}
 
 		pendingFirestorePresets.delete(preset.id);
+		const inFlightWrite = { preset: clonePreset(preset) };
+		inFlightFirestorePresets.set(preset.id, inFlightWrite);
 		try {
 			await this._writeFirestorePreset(firestore, preset);
 			pendingFirestorePresets.delete(preset.id);
@@ -363,6 +379,10 @@ class ScannerPresetService {
 			}
 			this.firestoreUnavailable = true;
 			console.warn('[ScannerPresetService] Failed to persist preset to Firestore:', error.message);
+		} finally {
+			if (inFlightFirestorePresets.get(preset.id) === inFlightWrite) {
+				inFlightFirestorePresets.delete(preset.id);
+			}
 		}
 	}
 
@@ -386,6 +406,8 @@ class ScannerPresetService {
 			}
 			const deleteGenerationAtStart = firestoreDeleteGenerations.get(id) || 0;
 			pendingFirestorePresets.delete(id);
+			const inFlightWrite = { preset: clonePreset(preset) };
+			inFlightFirestorePresets.set(id, inFlightWrite);
 			try {
 				await this._writeFirestorePreset(firestore, preset);
 			} catch (error) {
@@ -395,6 +417,10 @@ class ScannerPresetService {
 				}
 				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to flush pending preset to Firestore:', error.message);
+			} finally {
+				if (inFlightFirestorePresets.get(id) === inFlightWrite) {
+					inFlightFirestorePresets.delete(id);
+				}
 			}
 		}
 	}
@@ -469,6 +495,7 @@ module.exports = {
 	_resetForTesting() {
 		memoryPresets.clear();
 		pendingFirestorePresets.clear();
+		inFlightFirestorePresets.clear();
 		pendingFirestoreDeletes.clear();
 		firestoreDeleteGenerations.clear();
 		firestoreWriteQueues.clear();

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -216,8 +216,11 @@ class ScannerPresetService {
 	}
 
 	async updatePreset(id, params = {}) {
+		const deleteGenerationAtReadStart = firestoreDeleteGenerations.get(id) || 0;
 		const existing = await this.getPreset(id);
-		if (!existing) {
+		if (!existing
+			|| (firestoreDeleteGenerations.get(id) || 0) !== deleteGenerationAtReadStart
+			|| pendingFirestoreDeletes.has(id)) {
 			return null;
 		}
 
@@ -230,8 +233,8 @@ class ScannerPresetService {
 		preset.updatedAt = new Date().toISOString();
 		preset.createdAt = existing.createdAt;
 
-		await this._persistPreset(preset);
-		return clonePreset(preset);
+		const persisted = await this._persistPreset(preset, deleteGenerationAtReadStart);
+		return persisted ? clonePreset(preset) : null;
 	}
 
 	async deletePreset(id) {
@@ -345,9 +348,17 @@ class ScannerPresetService {
 		return normalizeTradingViewTimeframe(raw, '4h');
 	}
 
-	async _persistPreset(preset) {
+	async _persistPreset(preset, expectedDeleteGeneration = null) {
+		const currentDeleteGeneration = firestoreDeleteGenerations.get(preset.id) || 0;
+		if (expectedDeleteGeneration !== null
+			&& (currentDeleteGeneration !== expectedDeleteGeneration || pendingFirestoreDeletes.has(preset.id))) {
+			return false;
+		}
+
 		memoryPresets.set(preset.id, clonePreset(preset));
-		const deleteGenerationAtStart = firestoreDeleteGenerations.get(preset.id) || 0;
+		const deleteGenerationAtStart = expectedDeleteGeneration === null
+			? currentDeleteGeneration
+			: expectedDeleteGeneration;
 		pendingFirestoreDeletes.delete(preset.id);
 
 		const firestore = this._getFirestore();
@@ -355,7 +366,7 @@ class ScannerPresetService {
 			if (isFirestoreEnabled()) {
 				pendingFirestorePresets.set(preset.id, clonePreset(preset));
 			}
-			return;
+			return true;
 		}
 
 		pendingFirestorePresets.delete(preset.id);
@@ -383,6 +394,8 @@ class ScannerPresetService {
 				inFlightFirestorePresets.delete(preset.id);
 			}
 		}
+
+		return true;
 	}
 
 	async _flushPendingDeletes(firestore) {

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -133,6 +133,7 @@ class ScannerPresetService {
 					.collection(COLLECTION_NAME)
 					.orderBy('createdAt', 'desc')
 					.get();
+				this.firestoreUnavailable = false;
 
 				if (snapshot && Array.isArray(snapshot.docs) && snapshot.docs.length > 0) {
 					return snapshot.docs.map((doc) => this._formatFirestoreDoc(doc));
@@ -155,6 +156,7 @@ class ScannerPresetService {
 		if (firestore) {
 			try {
 				const snapshot = await firestore.collection(COLLECTION_NAME).doc(id).get();
+				this.firestoreUnavailable = false;
 				if (snapshot && snapshot.exists) {
 					return this._formatFirestoreDoc(snapshot);
 				}
@@ -200,6 +202,7 @@ class ScannerPresetService {
 					await firestore.collection(COLLECTION_NAME).doc(id).delete();
 					deleted = true;
 				}
+				this.firestoreUnavailable = false;
 			} catch (error) {
 				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to delete preset from Firestore:', error.message);

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -209,6 +209,7 @@ class ScannerPresetService {
 
 		let deleted = false;
 		const firestore = this._getFirestore();
+		pendingFirestorePresets.delete(id);
 		if (firestore) {
 			try {
 				const snapshot = await firestore.collection(COLLECTION_NAME).doc(id).get();
@@ -216,7 +217,6 @@ class ScannerPresetService {
 					await firestore.collection(COLLECTION_NAME).doc(id).delete();
 					deleted = true;
 				}
-				pendingFirestorePresets.delete(id);
 				this.firestoreUnavailable = pendingFirestorePresets.size > 0;
 			} catch (error) {
 				this.firestoreUnavailable = true;

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -26,6 +26,7 @@ const SUPPORTED_TIMEFRAME_ALIASES = new Set([
 
 // In-memory fallback used when Firestore is unavailable.
 const memoryPresets = new Map();
+const pendingFirestorePresets = new Map();
 
 function clonePreset(preset) {
 	if (!preset) return null;
@@ -130,10 +131,22 @@ class ScannerPresetService {
 					.collection(COLLECTION_NAME)
 					.orderBy('createdAt', 'desc')
 					.get();
-				this.firestoreUnavailable = false;
+				const firestorePresets = snapshot && Array.isArray(snapshot.docs)
+					? snapshot.docs.map((doc) => this._formatFirestoreDoc(doc))
+					: [];
 
-				if (snapshot && Array.isArray(snapshot.docs) && snapshot.docs.length > 0) {
-					return snapshot.docs.map((doc) => this._formatFirestoreDoc(doc));
+				if (pendingFirestorePresets.size > 0) {
+					this.firestoreUnavailable = true;
+					const mergedPresets = new Map(firestorePresets.map((preset) => [preset.id, preset]));
+					for (const preset of pendingFirestorePresets.values()) {
+						mergedPresets.set(preset.id, clonePreset(preset));
+					}
+					return [...mergedPresets.values()].sort(compareByCreatedAtDesc);
+				}
+
+				this.firestoreUnavailable = false;
+				if (firestorePresets.length > 0) {
+					return firestorePresets;
 				}
 			} catch (error) {
 				this.firestoreUnavailable = true;
@@ -150,10 +163,14 @@ class ScannerPresetService {
 		}
 
 		const firestore = this._getFirestore();
+		if (pendingFirestorePresets.has(id)) {
+			return clonePreset(pendingFirestorePresets.get(id));
+		}
+
 		if (firestore) {
 			try {
 				const snapshot = await firestore.collection(COLLECTION_NAME).doc(id).get();
-				this.firestoreUnavailable = false;
+				this.firestoreUnavailable = pendingFirestorePresets.size > 0;
 				if (snapshot && snapshot.exists) {
 					return this._formatFirestoreDoc(snapshot);
 				}
@@ -199,7 +216,8 @@ class ScannerPresetService {
 					await firestore.collection(COLLECTION_NAME).doc(id).delete();
 					deleted = true;
 				}
-				this.firestoreUnavailable = false;
+				pendingFirestorePresets.delete(id);
+				this.firestoreUnavailable = pendingFirestorePresets.size > 0;
 			} catch (error) {
 				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to delete preset from Firestore:', error.message);
@@ -292,6 +310,9 @@ class ScannerPresetService {
 
 		const firestore = this._getFirestore();
 		if (!firestore) {
+			if (isFirestoreEnabled()) {
+				pendingFirestorePresets.set(preset.id, clonePreset(preset));
+			}
 			return;
 		}
 
@@ -299,10 +320,27 @@ class ScannerPresetService {
 			await firestore.collection(COLLECTION_NAME).doc(preset.id).set({
 				...clonePreset(preset),
 			});
-			this.firestoreUnavailable = false;
+			pendingFirestorePresets.delete(preset.id);
+			await this._flushPendingPresets(firestore);
+			this.firestoreUnavailable = pendingFirestorePresets.size > 0;
 		} catch (error) {
+			pendingFirestorePresets.set(preset.id, clonePreset(preset));
 			this.firestoreUnavailable = true;
 			console.warn('[ScannerPresetService] Failed to persist preset to Firestore:', error.message);
+		}
+	}
+
+	async _flushPendingPresets(firestore) {
+		for (const preset of [...pendingFirestorePresets.values()]) {
+			try {
+				await firestore.collection(COLLECTION_NAME).doc(preset.id).set({
+					...clonePreset(preset),
+				});
+				pendingFirestorePresets.delete(preset.id);
+			} catch (error) {
+				this.firestoreUnavailable = true;
+				console.warn('[ScannerPresetService] Failed to flush pending preset to Firestore:', error.message);
+			}
 		}
 	}
 
@@ -341,6 +379,7 @@ module.exports = {
 	// Test helper
 	_resetForTesting() {
 		memoryPresets.clear();
+		pendingFirestorePresets.clear();
 		scannerPresetService.firestoreUnavailable = false;
 	},
 };

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -383,11 +383,13 @@ class ScannerPresetService {
 			if (!preset) {
 				continue;
 			}
+			const deleteGenerationAtStart = firestoreDeleteGenerations.get(id) || 0;
 			pendingFirestorePresets.delete(id);
 			try {
 				await this._writeFirestorePreset(firestore, preset);
 			} catch (error) {
-				if (!pendingFirestorePresets.has(id)) {
+				if ((firestoreDeleteGenerations.get(id) || 0) === deleteGenerationAtStart
+					&& !pendingFirestorePresets.has(id)) {
 					pendingFirestorePresets.set(id, preset);
 				}
 				this.firestoreUnavailable = true;

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -30,6 +30,7 @@ const pendingFirestorePresets = new Map();
 const inFlightFirestorePresets = new Map();
 const pendingFirestoreDeletes = new Set();
 const firestoreDeleteGenerations = new Map();
+const pendingFirestoreWriteTokens = new Map();
 const firestoreWriteQueues = new Map();
 
 function clonePreset(preset) {
@@ -364,17 +365,25 @@ class ScannerPresetService {
 		const firestore = this._getFirestore();
 		if (!firestore) {
 			if (isFirestoreEnabled()) {
+				pendingFirestoreWriteTokens.set(preset.id, {});
 				pendingFirestorePresets.set(preset.id, clonePreset(preset));
+			} else {
+				pendingFirestoreWriteTokens.delete(preset.id);
 			}
 			return true;
 		}
 
+		const pendingWriteToken = {};
+		pendingFirestoreWriteTokens.set(preset.id, pendingWriteToken);
 		pendingFirestorePresets.delete(preset.id);
 		const inFlightWrite = { preset: clonePreset(preset) };
 		inFlightFirestorePresets.set(preset.id, inFlightWrite);
 		try {
 			await this._writeFirestorePreset(firestore, preset);
-			pendingFirestorePresets.delete(preset.id);
+			if (pendingFirestoreWriteTokens.get(preset.id) === pendingWriteToken) {
+				pendingFirestorePresets.delete(preset.id);
+				pendingFirestoreWriteTokens.delete(preset.id);
+			}
 			if ((firestoreDeleteGenerations.get(preset.id) || 0) === deleteGenerationAtStart) {
 				pendingFirestoreDeletes.delete(preset.id);
 			}
@@ -382,10 +391,13 @@ class ScannerPresetService {
 			await this._flushPendingPresets(firestore);
 			this.firestoreUnavailable = pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0;
 		} catch (error) {
-			if ((firestoreDeleteGenerations.get(preset.id) || 0) === deleteGenerationAtStart) {
-				pendingFirestorePresets.set(preset.id, clonePreset(preset));
-			} else {
-				pendingFirestorePresets.delete(preset.id);
+			if (pendingFirestoreWriteTokens.get(preset.id) === pendingWriteToken) {
+				if ((firestoreDeleteGenerations.get(preset.id) || 0) === deleteGenerationAtStart) {
+					pendingFirestorePresets.set(preset.id, clonePreset(preset));
+				} else {
+					pendingFirestorePresets.delete(preset.id);
+					pendingFirestoreWriteTokens.delete(preset.id);
+				}
 			}
 			this.firestoreUnavailable = true;
 			console.warn('[ScannerPresetService] Failed to persist preset to Firestore:', error.message);
@@ -417,13 +429,18 @@ class ScannerPresetService {
 				continue;
 			}
 			const deleteGenerationAtStart = firestoreDeleteGenerations.get(id) || 0;
+			const pendingWriteToken = pendingFirestoreWriteTokens.get(id);
 			pendingFirestorePresets.delete(id);
 			const inFlightWrite = { preset: clonePreset(preset) };
 			inFlightFirestorePresets.set(id, inFlightWrite);
 			try {
 				await this._writeFirestorePreset(firestore, preset);
+				if (pendingFirestoreWriteTokens.get(id) === pendingWriteToken) {
+					pendingFirestoreWriteTokens.delete(id);
+				}
 			} catch (error) {
-				if ((firestoreDeleteGenerations.get(id) || 0) === deleteGenerationAtStart
+				if (pendingFirestoreWriteTokens.get(id) === pendingWriteToken
+					&& (firestoreDeleteGenerations.get(id) || 0) === deleteGenerationAtStart
 					&& !pendingFirestorePresets.has(id)) {
 					pendingFirestorePresets.set(id, preset);
 				}
@@ -510,6 +527,7 @@ module.exports = {
 		inFlightFirestorePresets.clear();
 		pendingFirestoreDeletes.clear();
 		firestoreDeleteGenerations.clear();
+		pendingFirestoreWriteTokens.clear();
 		firestoreWriteQueues.clear();
 		scannerPresetService.firestoreUnavailable = false;
 	},

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -28,6 +28,7 @@ const SUPPORTED_TIMEFRAME_ALIASES = new Set([
 const memoryPresets = new Map();
 const pendingFirestorePresets = new Map();
 const pendingFirestoreDeletes = new Set();
+const firestoreDeleteGenerations = new Map();
 const firestoreWriteQueues = new Map();
 
 function clonePreset(preset) {
@@ -44,6 +45,11 @@ function compareByCreatedAtDesc(a, b) {
 
 function isFirestoreEnabled() {
 	return process.env.ENABLE_FIRESTORE_SCANNER_PRESETS === 'true';
+}
+
+function markPendingFirestoreDelete(id) {
+	pendingFirestoreDeletes.add(id);
+	firestoreDeleteGenerations.set(id, (firestoreDeleteGenerations.get(id) || 0) + 1);
 }
 
 function normalizeScanList(scans) {
@@ -225,15 +231,15 @@ class ScannerPresetService {
 		const hadLocalPreset = memoryPresets.has(id) || pendingFirestorePresets.has(id);
 		pendingFirestorePresets.delete(id);
 		if (isFirestoreEnabled() && hadLocalPreset) {
-			pendingFirestoreDeletes.add(id);
+			markPendingFirestoreDelete(id);
 		}
 		if (firestore) {
 			try {
 				const snapshot = await firestore.collection(COLLECTION_NAME).doc(id).get();
 				if ((snapshot && snapshot.exists) || hadLocalPreset) {
 					deleted = Boolean(snapshot && snapshot.exists) || hadLocalPreset;
-					if (snapshot && snapshot.exists && isFirestoreEnabled()) {
-						pendingFirestoreDeletes.add(id);
+					if (snapshot && snapshot.exists && isFirestoreEnabled() && !pendingFirestoreDeletes.has(id)) {
+						markPendingFirestoreDelete(id);
 					}
 					await this._deleteFirestorePreset(firestore, id);
 					pendingFirestoreDeletes.delete(id);
@@ -328,6 +334,8 @@ class ScannerPresetService {
 
 	async _persistPreset(preset) {
 		memoryPresets.set(preset.id, clonePreset(preset));
+		const deleteGenerationAtStart = firestoreDeleteGenerations.get(preset.id) || 0;
+		pendingFirestoreDeletes.delete(preset.id);
 
 		const firestore = this._getFirestore();
 		if (!firestore) {
@@ -340,7 +348,9 @@ class ScannerPresetService {
 		try {
 			await this._writeFirestorePreset(firestore, preset);
 			pendingFirestorePresets.delete(preset.id);
-			pendingFirestoreDeletes.delete(preset.id);
+			if ((firestoreDeleteGenerations.get(preset.id) || 0) === deleteGenerationAtStart) {
+				pendingFirestoreDeletes.delete(preset.id);
+			}
 			await this._flushPendingDeletes(firestore);
 			await this._flushPendingPresets(firestore);
 			this.firestoreUnavailable = pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0;
@@ -453,6 +463,7 @@ module.exports = {
 		memoryPresets.clear();
 		pendingFirestorePresets.clear();
 		pendingFirestoreDeletes.clear();
+		firestoreDeleteGenerations.clear();
 		firestoreWriteQueues.clear();
 		scannerPresetService.firestoreUnavailable = false;
 	},

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -27,6 +27,7 @@ const SUPPORTED_TIMEFRAME_ALIASES = new Set([
 // In-memory fallback used when Firestore is unavailable.
 const memoryPresets = new Map();
 const pendingFirestorePresets = new Map();
+const pendingFirestoreDeletes = new Set();
 const firestoreWriteQueues = new Map();
 
 function clonePreset(preset) {
@@ -106,7 +107,11 @@ class ScannerPresetService {
 	getStorageStatus() {
 		const firestoreEnabled = isFirestoreEnabled();
 		const firestore = this._getFirestore();
-		const durable = Boolean(firestore) && !this.firestoreUnavailable && isFirestoreConfigured();
+		const durable = Boolean(firestore)
+			&& !this.firestoreUnavailable
+			&& pendingFirestorePresets.size === 0
+			&& pendingFirestoreDeletes.size === 0
+			&& isFirestoreConfigured();
 
 		return {
 			enabled: firestoreEnabled,
@@ -136,9 +141,13 @@ class ScannerPresetService {
 					? snapshot.docs.map((doc) => this._formatFirestoreDoc(doc))
 					: [];
 
-				if (pendingFirestorePresets.size > 0) {
+				if (pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0) {
 					this.firestoreUnavailable = true;
-					const mergedPresets = new Map(firestorePresets.map((preset) => [preset.id, preset]));
+					const mergedPresets = new Map(
+						firestorePresets
+							.filter((preset) => !pendingFirestoreDeletes.has(preset.id))
+							.map((preset) => [preset.id, preset]),
+					);
 					for (const preset of pendingFirestorePresets.values()) {
 						mergedPresets.set(preset.id, clonePreset(preset));
 					}
@@ -167,11 +176,14 @@ class ScannerPresetService {
 		if (pendingFirestorePresets.has(id)) {
 			return clonePreset(pendingFirestorePresets.get(id));
 		}
+		if (pendingFirestoreDeletes.has(id)) {
+			return null;
+		}
 
 		if (firestore) {
 			try {
 				const snapshot = await firestore.collection(COLLECTION_NAME).doc(id).get();
-				this.firestoreUnavailable = pendingFirestorePresets.size > 0;
+				this.firestoreUnavailable = pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0;
 				if (snapshot && snapshot.exists) {
 					return this._formatFirestoreDoc(snapshot);
 				}
@@ -210,15 +222,20 @@ class ScannerPresetService {
 
 		let deleted = false;
 		const firestore = this._getFirestore();
+		const hadLocalPreset = memoryPresets.has(id) || pendingFirestorePresets.has(id);
 		pendingFirestorePresets.delete(id);
+		if (isFirestoreEnabled() && hadLocalPreset) {
+			pendingFirestoreDeletes.add(id);
+		}
 		if (firestore) {
 			try {
 				const snapshot = await firestore.collection(COLLECTION_NAME).doc(id).get();
 				if (snapshot && snapshot.exists) {
-					await firestore.collection(COLLECTION_NAME).doc(id).delete();
+					await this._deleteFirestorePreset(firestore, id);
 					deleted = true;
 				}
-				this.firestoreUnavailable = pendingFirestorePresets.size > 0;
+				pendingFirestoreDeletes.delete(id);
+				this.firestoreUnavailable = pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0;
 			} catch (error) {
 				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to delete preset from Firestore:', error.message);
@@ -320,12 +337,26 @@ class ScannerPresetService {
 		try {
 			await this._writeFirestorePreset(firestore, preset);
 			pendingFirestorePresets.delete(preset.id);
+			pendingFirestoreDeletes.delete(preset.id);
+			await this._flushPendingDeletes(firestore);
 			await this._flushPendingPresets(firestore);
-			this.firestoreUnavailable = pendingFirestorePresets.size > 0;
+			this.firestoreUnavailable = pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0;
 		} catch (error) {
 			pendingFirestorePresets.set(preset.id, clonePreset(preset));
 			this.firestoreUnavailable = true;
 			console.warn('[ScannerPresetService] Failed to persist preset to Firestore:', error.message);
+		}
+	}
+
+	async _flushPendingDeletes(firestore) {
+		for (const id of [...pendingFirestoreDeletes]) {
+			try {
+				await this._deleteFirestorePreset(firestore, id);
+				pendingFirestoreDeletes.delete(id);
+			} catch (error) {
+				this.firestoreUnavailable = true;
+				console.warn('[ScannerPresetService] Failed to flush pending preset deletion to Firestore:', error.message);
+			}
 		}
 	}
 
@@ -355,6 +386,22 @@ class ScannerPresetService {
 		} finally {
 			if (firestoreWriteQueues.get(preset.id) === currentWrite) {
 				firestoreWriteQueues.delete(preset.id);
+			}
+		}
+	}
+
+	async _deleteFirestorePreset(firestore, id) {
+		const previousWrite = firestoreWriteQueues.get(id) || Promise.resolve();
+		const currentWrite = previousWrite
+			.catch(() => undefined)
+			.then(() => firestore.collection(COLLECTION_NAME).doc(id).delete());
+		firestoreWriteQueues.set(id, currentWrite);
+
+		try {
+			await currentWrite;
+		} finally {
+			if (firestoreWriteQueues.get(id) === currentWrite) {
+				firestoreWriteQueues.delete(id);
 			}
 		}
 	}
@@ -395,6 +442,7 @@ module.exports = {
 	_resetForTesting() {
 		memoryPresets.clear();
 		pendingFirestorePresets.clear();
+		pendingFirestoreDeletes.clear();
 		firestoreWriteQueues.clear();
 		scannerPresetService.firestoreUnavailable = false;
 	},

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -231,10 +231,13 @@ class ScannerPresetService {
 			try {
 				const snapshot = await firestore.collection(COLLECTION_NAME).doc(id).get();
 				if ((snapshot && snapshot.exists) || hadLocalPreset) {
-					await this._deleteFirestorePreset(firestore, id);
 					deleted = Boolean(snapshot && snapshot.exists) || hadLocalPreset;
+					if (snapshot && snapshot.exists && isFirestoreEnabled()) {
+						pendingFirestoreDeletes.add(id);
+					}
+					await this._deleteFirestorePreset(firestore, id);
+					pendingFirestoreDeletes.delete(id);
 				}
-				pendingFirestoreDeletes.delete(id);
 				this.firestoreUnavailable = pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0;
 			} catch (error) {
 				this.firestoreUnavailable = true;
@@ -361,11 +364,18 @@ class ScannerPresetService {
 	}
 
 	async _flushPendingPresets(firestore) {
-		for (const preset of [...pendingFirestorePresets.values()]) {
+		for (const id of [...pendingFirestorePresets.keys()]) {
+			const preset = pendingFirestorePresets.get(id);
+			if (!preset) {
+				continue;
+			}
+			pendingFirestorePresets.delete(id);
 			try {
 				await this._writeFirestorePreset(firestore, preset);
-				pendingFirestorePresets.delete(preset.id);
 			} catch (error) {
+				if (!pendingFirestorePresets.has(id)) {
+					pendingFirestorePresets.set(id, preset);
+				}
 				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to flush pending preset to Firestore:', error.message);
 			}

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -170,9 +170,7 @@ class ScannerPresetService {
 				}
 
 				this.firestoreUnavailable = false;
-				if (firestorePresets.length > 0) {
-					return firestorePresets;
-				}
+				return firestorePresets;
 			} catch (error) {
 				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to list presets from Firestore:', error.message);
@@ -207,6 +205,7 @@ class ScannerPresetService {
 				if (snapshot && snapshot.exists) {
 					return this._formatFirestoreDoc(snapshot);
 				}
+				return null;
 			} catch (error) {
 				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to read preset from Firestore:', error.message);

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -230,9 +230,9 @@ class ScannerPresetService {
 		if (firestore) {
 			try {
 				const snapshot = await firestore.collection(COLLECTION_NAME).doc(id).get();
-				if (snapshot && snapshot.exists) {
+				if ((snapshot && snapshot.exists) || hadLocalPreset) {
 					await this._deleteFirestorePreset(firestore, id);
-					deleted = true;
+					deleted = Boolean(snapshot && snapshot.exists) || hadLocalPreset;
 				}
 				pendingFirestoreDeletes.delete(id);
 				this.firestoreUnavailable = pendingFirestorePresets.size > 0 || pendingFirestoreDeletes.size > 0;

--- a/src/services/scannerPresets/ScannerPresetService.js
+++ b/src/services/scannerPresets/ScannerPresetService.js
@@ -12,6 +12,13 @@ const {
 } = require('../tradingview/parseTradingViewSignal');
 
 const COLLECTION_NAME = 'scannerPresets';
+const FIRESTORE_GATE_ENV_VARS = [
+	'ENABLE_FIRESTORE_SCANNER_PRESETS',
+	'ENABLE_FIRESTORE_ALERT_STORAGE',
+	'ENABLE_FIRESTORE_JOB_STORAGE',
+	'ENABLE_SIGNAL_OUTCOME_TRACKING',
+	'ENABLE_SHADOW_MODE_OUTCOME_TRACKING',
+];
 const DEFAULT_SCAN_LIMIT = 5;
 const MAX_SCAN_LIMIT = 20;
 const DEFAULT_EXCHANGE = 'BINANCE';
@@ -92,6 +99,25 @@ function normalizeBbwThreshold(bbwThreshold) {
 }
 
 class ScannerPresetService {
+	constructor() {
+		this.firestoreUnavailable = false;
+	}
+
+	getStorageStatus() {
+		const firestoreEnabled = FIRESTORE_GATE_ENV_VARS.some((envVar) => process.env[envVar] === 'true');
+		const firestore = this._getFirestore();
+		const durable = Boolean(firestore);
+
+		return {
+			enabled: firestoreEnabled,
+			configured: durable,
+			ready: durable,
+			status: durable ? 'ready' : firestoreEnabled ? 'misconfigured' : 'disabled',
+			mode: durable ? 'durable' : 'ephemeral',
+			backend: durable ? 'firestore' : 'memory',
+		};
+	}
+
 	async createPreset(params = {}) {
 		const preset = this._buildPreset(params);
 		await this._persistPreset(preset);
@@ -111,6 +137,7 @@ class ScannerPresetService {
 					return snapshot.docs.map((doc) => this._formatFirestoreDoc(doc));
 				}
 			} catch (error) {
+				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to list presets from Firestore:', error.message);
 			}
 		}
@@ -131,6 +158,7 @@ class ScannerPresetService {
 					return this._formatFirestoreDoc(snapshot);
 				}
 			} catch (error) {
+				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to read preset from Firestore:', error.message);
 			}
 		}
@@ -172,6 +200,7 @@ class ScannerPresetService {
 					deleted = true;
 				}
 			} catch (error) {
+				this.firestoreUnavailable = true;
 				console.warn('[ScannerPresetService] Failed to delete preset from Firestore:', error.message);
 			}
 		}
@@ -269,12 +298,18 @@ class ScannerPresetService {
 			await firestore.collection(COLLECTION_NAME).doc(preset.id).set({
 				...clonePreset(preset),
 			});
+			this.firestoreUnavailable = false;
 		} catch (error) {
+			this.firestoreUnavailable = true;
 			console.warn('[ScannerPresetService] Failed to persist preset to Firestore:', error.message);
 		}
 	}
 
 	_getFirestore() {
+		if (this.firestoreUnavailable) {
+			return null;
+		}
+
 		return alertStorageService.getFirestore();
 	}
 
@@ -309,5 +344,6 @@ module.exports = {
 	// Test helper
 	_resetForTesting() {
 		memoryPresets.clear();
+		scannerPresetService.firestoreUnavailable = false;
 	},
 };

--- a/src/services/storage/AlertStorageService.js
+++ b/src/services/storage/AlertStorageService.js
@@ -51,6 +51,7 @@ function isEnabled() {
 
 function canInitializeFirestore() {
 	return isEnabled()
+		|| process.env.ENABLE_FIRESTORE_SCANNER_PRESETS === 'true'
 		|| process.env.ENABLE_FIRESTORE_JOB_STORAGE === 'true'
 		|| process.env.ENABLE_SIGNAL_OUTCOME_TRACKING === 'true'
 		|| process.env.ENABLE_SHADOW_MODE_OUTCOME_TRACKING === 'true';

--- a/src/services/storage/AlertStorageService.js
+++ b/src/services/storage/AlertStorageService.js
@@ -6,7 +6,7 @@
  * Initialization pattern is copied from branch 006-csv-gemini-signals
  * (src/services/csvSignals/firestoreRepository.js):
  *   - Lazy singleton via admin.initializeApp() / admin.firestore()
- *   - Feature-gated: ENABLE_FIRESTORE_ALERT_STORAGE=true required
+ *   - Feature-gated: an enabled storage consumer must be configured
  *   - Fail-open: any Firestore error is caught and logged as a warning;
  *     the alert delivery flow is never blocked or failed by storage errors.
  *

--- a/src/services/storage/firestoreConfig.js
+++ b/src/services/storage/firestoreConfig.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { createPrivateKey } = require('crypto');
-const { accessSync, constants } = require('fs');
+const { accessSync, constants, readFileSync, statSync } = require('fs');
 
 function hasValue(value) {
 	return typeof value === 'string' ? value.trim().length > 0 : value != null;
@@ -46,7 +46,11 @@ function hasReadableCredentialsFile(path) {
 
 	try {
 		accessSync(path, constants.R_OK);
-		return true;
+		if (!statSync(path).isFile()) {
+			return false;
+		}
+
+		return hasValidInlineCredentials(readFileSync(path, 'utf8'));
 	} catch (error) {
 		return false;
 	}

--- a/src/services/storage/firestoreConfig.js
+++ b/src/services/storage/firestoreConfig.js
@@ -2,7 +2,6 @@
 
 const { createPrivateKey } = require('crypto');
 const { accessSync, constants, readFileSync, statSync } = require('fs');
-const { homedir } = require('os');
 const { join } = require('path');
 
 function hasValue(value) {
@@ -27,8 +26,17 @@ function isGoogleManagedRuntime() {
 }
 
 function getWellKnownCredentialsPath() {
-	const homeDirectory = hasValue(process.env.HOME) ? process.env.HOME : homedir();
-	return join(homeDirectory, '.config', 'gcloud', 'application_default_credentials.json');
+	const configRoot = process.platform === 'win32'
+		? process.env.APPDATA
+		: process.env.HOME;
+	if (!hasValue(configRoot)) {
+		return null;
+	}
+
+	const configDirectory = process.platform === 'win32'
+		? configRoot
+		: join(configRoot, '.config');
+	return join(configDirectory, 'gcloud', 'application_default_credentials.json');
 }
 
 function hasValidInlineCredentials(value) {

--- a/src/services/storage/firestoreConfig.js
+++ b/src/services/storage/firestoreConfig.js
@@ -2,6 +2,8 @@
 
 const { createPrivateKey } = require('crypto');
 const { accessSync, constants, readFileSync, statSync } = require('fs');
+const { homedir } = require('os');
+const { join } = require('path');
 
 function hasValue(value) {
 	return typeof value === 'string' ? value.trim().length > 0 : value != null;
@@ -20,7 +22,13 @@ function isGoogleManagedRuntime() {
 		|| hasValue(process.env.FUNCTION_TARGET)
 		|| hasValue(process.env.FUNCTION_NAME)
 		|| hasValue(process.env.GAE_SERVICE)
+		|| ((hasValue(process.env.GCE_METADATA_HOST) || hasValue(process.env.GCE_METADATA_IP)) && hasProjectId())
 	);
+}
+
+function getWellKnownCredentialsPath() {
+	const configDirectory = process.env.CLOUDSDK_CONFIG || join(homedir(), '.config', 'gcloud');
+	return join(configDirectory, 'application_default_credentials.json');
 }
 
 function hasValidInlineCredentials(value) {
@@ -86,6 +94,7 @@ function isFirestoreConfigured() {
 	return (
 		hasValidInlineCredentials(process.env.FIREBASE_SERVICE_ACCOUNT_JSON)
 		|| hasReadableCredentialsFile(process.env.GOOGLE_APPLICATION_CREDENTIALS)
+		|| hasReadableCredentialsFile(getWellKnownCredentialsPath())
 		|| isGoogleManagedRuntime()
 	);
 }

--- a/src/services/storage/firestoreConfig.js
+++ b/src/services/storage/firestoreConfig.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const { createPrivateKey } = require('crypto');
+const { accessSync, constants } = require('fs');
+
+function hasValue(value) {
+	return typeof value === 'string' ? value.trim().length > 0 : value != null;
+}
+
+function isGoogleManagedRuntime() {
+	return (
+		hasValue(process.env.K_SERVICE)
+		|| hasValue(process.env.K_REVISION)
+		|| hasValue(process.env.FUNCTION_TARGET)
+		|| hasValue(process.env.FUNCTION_NAME)
+		|| hasValue(process.env.GAE_SERVICE)
+	);
+}
+
+function hasValidInlineCredentials(value) {
+	if (!hasValue(value)) {
+		return false;
+	}
+
+	try {
+		const parsed = JSON.parse(value);
+		const projectId = parsed.projectId || parsed.project_id;
+		const clientEmail = parsed.clientEmail || parsed.client_email;
+		const privateKey = parsed.privateKey || parsed.private_key;
+
+		if (!hasValue(projectId) || !hasValue(clientEmail) || !hasValue(privateKey)) {
+			return false;
+		}
+
+		createPrivateKey({ key: privateKey, format: 'pem' });
+		return true;
+	} catch (error) {
+		return false;
+	}
+}
+
+function hasReadableCredentialsFile(path) {
+	if (!hasValue(path)) {
+		return false;
+	}
+
+	try {
+		accessSync(path, constants.R_OK);
+		return true;
+	} catch (error) {
+		return false;
+	}
+}
+
+function isFirestoreConfigured() {
+	return (
+		hasValidInlineCredentials(process.env.FIREBASE_SERVICE_ACCOUNT_JSON)
+		|| hasReadableCredentialsFile(process.env.GOOGLE_APPLICATION_CREDENTIALS)
+		|| isGoogleManagedRuntime()
+	);
+}
+
+module.exports = {
+	isFirestoreConfigured,
+};

--- a/src/services/storage/firestoreConfig.js
+++ b/src/services/storage/firestoreConfig.js
@@ -7,6 +7,12 @@ function hasValue(value) {
 	return typeof value === 'string' ? value.trim().length > 0 : value != null;
 }
 
+function hasProjectId() {
+	return hasValue(process.env.FIREBASE_PROJECT_ID)
+		|| hasValue(process.env.GOOGLE_CLOUD_PROJECT)
+		|| hasValue(process.env.GCLOUD_PROJECT);
+}
+
 function isGoogleManagedRuntime() {
 	return (
 		hasValue(process.env.K_SERVICE)
@@ -49,7 +55,8 @@ function hasValidApplicationDefaultCredentials(value) {
 		if (parsed.type === 'authorized_user') {
 			return hasValue(parsed.client_id)
 				&& hasValue(parsed.client_secret)
-				&& hasValue(parsed.refresh_token);
+				&& hasValue(parsed.refresh_token)
+				&& hasProjectId();
 		}
 
 		if (parsed.type === 'external_account') {

--- a/src/services/storage/firestoreConfig.js
+++ b/src/services/storage/firestoreConfig.js
@@ -59,24 +59,6 @@ function hasValidApplicationDefaultCredentials(value) {
 				&& hasProjectId();
 		}
 
-		if (parsed.type === 'external_account') {
-			const credentialSource = parsed.credential_source;
-			const hasFileOrUrlSource = credentialSource
-				&& (hasValue(credentialSource.file) || hasValue(credentialSource.url));
-			const hasExecutableSource = credentialSource
-				&& credentialSource.executable
-				&& hasValue(credentialSource.executable.command);
-			const hasAwsSource = credentialSource
-				&& hasValue(credentialSource.environment_id)
-				&& hasValue(credentialSource.region_url)
-				&& hasValue(credentialSource.regional_cred_verification_url);
-
-			return hasValue(parsed.audience)
-				&& hasValue(parsed.subject_token_type)
-				&& hasValue(parsed.token_url)
-				&& (hasFileOrUrlSource || hasExecutableSource || hasAwsSource);
-		}
-
 		return hasValidInlineCredentials(value);
 	} catch (error) {
 		return false;

--- a/src/services/storage/firestoreConfig.js
+++ b/src/services/storage/firestoreConfig.js
@@ -27,8 +27,8 @@ function isGoogleManagedRuntime() {
 }
 
 function getWellKnownCredentialsPath() {
-	const configDirectory = process.env.CLOUDSDK_CONFIG || join(homedir(), '.config', 'gcloud');
-	return join(configDirectory, 'application_default_credentials.json');
+	const homeDirectory = hasValue(process.env.HOME) ? process.env.HOME : homedir();
+	return join(homeDirectory, '.config', 'gcloud', 'application_default_credentials.json');
 }
 
 function hasValidInlineCredentials(value) {
@@ -67,7 +67,7 @@ function hasValidApplicationDefaultCredentials(value) {
 				&& hasProjectId();
 		}
 
-		return hasValidInlineCredentials(value);
+		return parsed.type === 'service_account' && hasValidInlineCredentials(value);
 	} catch (error) {
 		return false;
 	}

--- a/src/services/storage/firestoreConfig.js
+++ b/src/services/storage/firestoreConfig.js
@@ -53,10 +53,21 @@ function hasValidApplicationDefaultCredentials(value) {
 		}
 
 		if (parsed.type === 'external_account') {
+			const credentialSource = parsed.credential_source;
+			const hasFileOrUrlSource = credentialSource
+				&& (hasValue(credentialSource.file) || hasValue(credentialSource.url));
+			const hasExecutableSource = credentialSource
+				&& credentialSource.executable
+				&& hasValue(credentialSource.executable.command);
+			const hasAwsSource = credentialSource
+				&& hasValue(credentialSource.environment_id)
+				&& hasValue(credentialSource.region_url)
+				&& hasValue(credentialSource.regional_cred_verification_url);
+
 			return hasValue(parsed.audience)
 				&& hasValue(parsed.subject_token_type)
 				&& hasValue(parsed.token_url)
-				&& parsed.credential_source != null;
+				&& (hasFileOrUrlSource || hasExecutableSource || hasAwsSource);
 		}
 
 		return hasValidInlineCredentials(value);

--- a/src/services/storage/firestoreConfig.js
+++ b/src/services/storage/firestoreConfig.js
@@ -91,12 +91,15 @@ function hasReadableCredentialsFile(path) {
 }
 
 function isFirestoreConfigured() {
-	return (
-		hasValidInlineCredentials(process.env.FIREBASE_SERVICE_ACCOUNT_JSON)
-		|| hasReadableCredentialsFile(process.env.GOOGLE_APPLICATION_CREDENTIALS)
-		|| hasReadableCredentialsFile(getWellKnownCredentialsPath())
-		|| isGoogleManagedRuntime()
-	);
+	if (hasValue(process.env.FIREBASE_SERVICE_ACCOUNT_JSON)) {
+		return hasValidInlineCredentials(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+	}
+
+	if (hasValue(process.env.GOOGLE_APPLICATION_CREDENTIALS)) {
+		return hasReadableCredentialsFile(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+	}
+
+	return hasReadableCredentialsFile(getWellKnownCredentialsPath()) || isGoogleManagedRuntime();
 }
 
 module.exports = {

--- a/src/services/storage/firestoreConfig.js
+++ b/src/services/storage/firestoreConfig.js
@@ -39,6 +39,32 @@ function hasValidInlineCredentials(value) {
 	}
 }
 
+function hasValidApplicationDefaultCredentials(value) {
+	if (!hasValue(value)) {
+		return false;
+	}
+
+	try {
+		const parsed = JSON.parse(value);
+		if (parsed.type === 'authorized_user') {
+			return hasValue(parsed.client_id)
+				&& hasValue(parsed.client_secret)
+				&& hasValue(parsed.refresh_token);
+		}
+
+		if (parsed.type === 'external_account') {
+			return hasValue(parsed.audience)
+				&& hasValue(parsed.subject_token_type)
+				&& hasValue(parsed.token_url)
+				&& parsed.credential_source != null;
+		}
+
+		return hasValidInlineCredentials(value);
+	} catch (error) {
+		return false;
+	}
+}
+
 function hasReadableCredentialsFile(path) {
 	if (!hasValue(path)) {
 		return false;
@@ -50,7 +76,7 @@ function hasReadableCredentialsFile(path) {
 			return false;
 		}
 
-		return hasValidInlineCredentials(readFileSync(path, 'utf8'));
+		return hasValidApplicationDefaultCredentials(readFileSync(path, 'utf8'));
 	} catch (error) {
 		return false;
 	}

--- a/tests/integration/scanner-presets-endpoint.test.js
+++ b/tests/integration/scanner-presets-endpoint.test.js
@@ -81,6 +81,10 @@ describe('Scanner presets API integration tests', () => {
 
 		expect(createResponse.body).toEqual(expect.objectContaining({
 			success: true,
+			storage: expect.objectContaining({
+				mode: 'durable',
+				backend: 'firestore',
+			}),
 			preset: expect.objectContaining({
 				id: presetId,
 				name: 'Momentum preset',
@@ -133,6 +137,28 @@ describe('Scanner presets API integration tests', () => {
 			.get(`/api/scanner-presets/${presetId}`)
 			.set('x-api-key', 'test-key')
 			.expect(404);
+	});
+
+	it('reports ephemeral storage when durable scanner persistence is enabled but unavailable', async () => {
+		delete process.env.ENABLE_FIRESTORE_ALERT_STORAGE;
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+		const firestoreAdmin = require('firebase-admin');
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Firestore unavailable'));
+
+		const response = await request(app)
+			.post('/api/scanner-presets')
+			.set('x-api-key', 'test-key')
+			.send({ name: 'Ephemeral preset' })
+			.expect(201);
+
+		expect(response.body.storage).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
+			mode: 'ephemeral',
+			backend: 'memory',
+		});
 	});
 
 	it('runs a saved preset in dry-run mode with the market scanner report', async () => {

--- a/tests/integration/scanner-presets-endpoint.test.js
+++ b/tests/integration/scanner-presets-endpoint.test.js
@@ -152,6 +152,33 @@ describe('Scanner presets API integration tests', () => {
 			.expect(404);
 	});
 
+	it('includes storage metadata on not-found responses', async () => {
+		const missingId = 'missing-preset-id';
+		const expectedStorage = expect.objectContaining({
+			enabled: true,
+			mode: 'durable',
+			backend: 'firestore',
+		});
+
+		const getResponse = await request(app)
+			.get(`/api/scanner-presets/${missingId}`)
+			.set('x-api-key', 'test-key')
+			.expect(404);
+		const updateResponse = await request(app)
+			.put(`/api/scanner-presets/${missingId}`)
+			.set('x-api-key', 'test-key')
+			.send({ name: 'Missing update' })
+			.expect(404);
+		const deleteResponse = await request(app)
+			.delete(`/api/scanner-presets/${missingId}`)
+			.set('x-api-key', 'test-key')
+			.expect(404);
+
+		expect(getResponse.body.storage).toEqual(expectedStorage);
+		expect(updateResponse.body.storage).toEqual(expectedStorage);
+		expect(deleteResponse.body.storage).toEqual(expectedStorage);
+	});
+
 	it('reports ephemeral storage when durable scanner persistence is enabled but unavailable', async () => {
 		delete process.env.ENABLE_FIRESTORE_ALERT_STORAGE;
 		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';

--- a/tests/integration/scanner-presets-endpoint.test.js
+++ b/tests/integration/scanner-presets-endpoint.test.js
@@ -7,12 +7,23 @@ jest.mock('../../src/services/tradingview/TradingViewMcpService', () => ({
 }));
 
 const admin = require('firebase-admin');
+const { generateKeyPairSync } = require('crypto');
 const request = require('supertest');
 const app = require('../../app');
 const { getRoutes } = require('../../src/routes');
 const { initializeNotificationServices } = require('../../src/controllers/webhooks/handlers/alert/alert');
 const { tradingViewMcpService } = require('../../src/services/tradingview/TradingViewMcpService');
 const { _resetForTesting: resetScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+
+const testPrivateKey = generateKeyPairSync('rsa', { modulusLength: 2048 }).privateKey.export({
+	type: 'pkcs1',
+	format: 'pem',
+});
+const validFirestoreServiceAccountJson = JSON.stringify({
+	project_id: 'scanner-preset-test',
+	client_email: 'firebase-adminsdk@test-project.iam.gserviceaccount.com',
+	private_key: testPrivateKey,
+});
 
 describe('Scanner presets API integration tests', () => {
 	const originalEnv = process.env;
@@ -29,6 +40,7 @@ describe('Scanner presets API integration tests', () => {
 			ENABLE_NEWS_MONITOR: 'false',
 			MARKET_SCANNER_TIMEOUT_MS: '1000',
 			TRADINGVIEW_MCP_DEFAULT_TIMEFRAME: '4h',
+			FIREBASE_SERVICE_ACCOUNT_JSON: validFirestoreServiceAccountJson,
 			ENABLE_TELEGRAM_BOT: 'true',
 			BOT_TOKEN: 'test-bot-token',
 			TELEGRAM_CHAT_ID: '123456789',

--- a/tests/integration/scanner-presets-endpoint.test.js
+++ b/tests/integration/scanner-presets-endpoint.test.js
@@ -36,6 +36,7 @@ describe('Scanner presets API integration tests', () => {
 			...originalEnv,
 			WEBHOOK_API_KEY: 'test-key',
 			ENABLE_FIRESTORE_ALERT_STORAGE: 'true',
+			ENABLE_FIRESTORE_SCANNER_PRESETS: 'true',
 			ENABLE_MARKET_SCANNER: 'true',
 			ENABLE_NEWS_MONITOR: 'false',
 			MARKET_SCANNER_TIMEOUT_MS: '1000',

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -912,6 +912,28 @@ describe('Status endpoints', () => {
 		});
 	});
 
+	it('does not fall back to well-known ADC when the explicit path is invalid', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		process.env.GOOGLE_CLOUD_PROJECT = 'well-known-project';
+		tempDir = mkdtempSync(join(tmpdir(), 'cabros-gcloud-'));
+		const wellKnownPath = join(tempDir, 'application_default_credentials.json');
+		writeFileSync(wellKnownPath, validFirestoreServiceAccountJson);
+		process.env.CLOUDSDK_CONFIG = tempDir;
+		process.env.GOOGLE_APPLICATION_CREDENTIALS = join(tempDir, 'missing-explicit.json');
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
+		});
+	});
+
 	it('treats Compute Engine metadata credentials as configured with a project id', async () => {
 		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
 		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -862,7 +862,7 @@ describe('Status endpoints', () => {
 		});
 	});
 
-	it('rejects external-account ADC files without a usable credential source', async () => {
+	it('rejects external-account ADC files unsupported by Firebase Admin', async () => {
 		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
 		tempDir = mkdtempSync(join(tmpdir(), 'cabros-firestore-'));
 		const credentialsPath = join(tempDir, 'external-account.json');
@@ -871,7 +871,7 @@ describe('Status endpoints', () => {
 			audience: '//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider',
 			subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
 			token_url: 'https://sts.googleapis.com/v1/token',
-			credential_source: {},
+			credential_source: { file: '/tmp/subject-token.txt' },
 		}));
 		process.env.GOOGLE_APPLICATION_CREDENTIALS = credentialsPath;
 

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -770,6 +770,44 @@ describe('Status endpoints', () => {
 		});
 	});
 
+	it('does not treat a readable credential directory as configured', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		tempDir = mkdtempSync(join(tmpdir(), 'cabros-firestore-'));
+		process.env.GOOGLE_APPLICATION_CREDENTIALS = tempDir;
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
+		});
+	});
+
+	it('does not treat malformed credential file JSON as configured', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		tempDir = mkdtempSync(join(tmpdir(), 'cabros-firestore-'));
+		const credentialsPath = join(tempDir, 'service-account.json');
+		writeFileSync(credentialsPath, '{"project_id":');
+		process.env.GOOGLE_APPLICATION_CREDENTIALS = credentialsPath;
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
+		});
+	});
+
 	it('treats malformed inline Firestore credentials as misconfigured', async () => {
 		process.env.FIREBASE_SERVICE_ACCOUNT_JSON = '{"project_id":';
 

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -939,6 +939,27 @@ describe('Status endpoints', () => {
 		});
 	});
 
+	it('does not use os.homedir when HOME is unset for ADC discovery', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+		delete process.env.HOME;
+		delete process.env.APPDATA;
+		delete process.env.CLOUDSDK_CONFIG;
+		process.env.GOOGLE_CLOUD_PROJECT = 'home-unset-project';
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
+		});
+	});
+
 	it('does not treat CLOUDSDK_CONFIG as Firebase ADC discovery', async () => {
 		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
 		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -719,6 +719,8 @@ describe('Status endpoints', () => {
 		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
 		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
 		process.env.GOOGLE_CLOUD_PROJECT = 'cabros-project';
+		tempDir = mkdtempSync(join(tmpdir(), 'cabros-gcloud-empty-'));
+		process.env.CLOUDSDK_CONFIG = tempDir;
 
 		const response = await request(app)
 			.get('/api/status')
@@ -885,6 +887,47 @@ describe('Status endpoints', () => {
 			configured: false,
 			ready: false,
 			status: 'misconfigured',
+		});
+	});
+
+	it('treats well-known ADC files as configured', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+		process.env.GOOGLE_CLOUD_PROJECT = 'well-known-project';
+		tempDir = mkdtempSync(join(tmpdir(), 'cabros-gcloud-'));
+		const credentialsPath = join(tempDir, 'application_default_credentials.json');
+		writeFileSync(credentialsPath, validFirestoreServiceAccountJson);
+		process.env.CLOUDSDK_CONFIG = tempDir;
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: true,
+			ready: true,
+			status: 'ready',
+		});
+	});
+
+	it('treats Compute Engine metadata credentials as configured with a project id', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+		process.env.GCE_METADATA_HOST = 'metadata.google.internal';
+		process.env.GOOGLE_CLOUD_PROJECT = 'metadata-project';
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: true,
+			ready: true,
+			status: 'ready',
 		});
 	});
 

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -810,6 +810,7 @@ describe('Status endpoints', () => {
 
 	it('treats a valid authorized-user ADC file as configured', async () => {
 		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		process.env.FIREBASE_PROJECT_ID = 'authorized-user-project';
 		tempDir = mkdtempSync(join(tmpdir(), 'cabros-firestore-'));
 		const credentialsPath = join(tempDir, 'authorized-user.json');
 		writeFileSync(credentialsPath, JSON.stringify({
@@ -830,6 +831,34 @@ describe('Status endpoints', () => {
 			configured: true,
 			ready: true,
 			status: 'ready',
+		});
+	});
+
+	it('rejects authorized-user ADC files without a project id', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		delete process.env.FIREBASE_PROJECT_ID;
+		delete process.env.GOOGLE_CLOUD_PROJECT;
+		delete process.env.GCLOUD_PROJECT;
+		tempDir = mkdtempSync(join(tmpdir(), 'cabros-firestore-'));
+		const credentialsPath = join(tempDir, 'authorized-user.json');
+		writeFileSync(credentialsPath, JSON.stringify({
+			type: 'authorized_user',
+			client_id: 'client-id.apps.googleusercontent.com',
+			client_secret: 'client-secret',
+			refresh_token: 'refresh-token',
+		}));
+		process.env.GOOGLE_APPLICATION_CREDENTIALS = credentialsPath;
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
 		});
 	});
 

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -833,6 +833,32 @@ describe('Status endpoints', () => {
 		});
 	});
 
+	it('rejects external-account ADC files without a usable credential source', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		tempDir = mkdtempSync(join(tmpdir(), 'cabros-firestore-'));
+		const credentialsPath = join(tempDir, 'external-account.json');
+		writeFileSync(credentialsPath, JSON.stringify({
+			type: 'external_account',
+			audience: '//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider',
+			subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+			token_url: 'https://sts.googleapis.com/v1/token',
+			credential_source: {},
+		}));
+		process.env.GOOGLE_APPLICATION_CREDENTIALS = credentialsPath;
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
+		});
+	});
+
 	it('treats malformed inline Firestore credentials as misconfigured', async () => {
 		process.env.FIREBASE_SERVICE_ACCOUNT_JSON = '{"project_id":';
 

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -808,6 +808,31 @@ describe('Status endpoints', () => {
 		});
 	});
 
+	it('treats a valid authorized-user ADC file as configured', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		tempDir = mkdtempSync(join(tmpdir(), 'cabros-firestore-'));
+		const credentialsPath = join(tempDir, 'authorized-user.json');
+		writeFileSync(credentialsPath, JSON.stringify({
+			type: 'authorized_user',
+			client_id: 'client-id.apps.googleusercontent.com',
+			client_secret: 'client-secret',
+			refresh_token: 'refresh-token',
+		}));
+		process.env.GOOGLE_APPLICATION_CREDENTIALS = credentialsPath;
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: true,
+			ready: true,
+			status: 'ready',
+		});
+	});
+
 	it('treats malformed inline Firestore credentials as misconfigured', async () => {
 		process.env.FIREBASE_SERVICE_ACCOUNT_JSON = '{"project_id":';
 

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -4,6 +4,9 @@ const express = require('express');
 const { generateKeyPairSync } = require('crypto');
 const { tmpdir } = require('os');
 const { join } = require('path');
+jest.mock('firebase-admin');
+const admin = require('firebase-admin');
+const alertStorageService = require('../../src/services/storage/AlertStorageService');
 const { getRoutes } = require('../../src/routes');
 
 const testPrivateKey = generateKeyPairSync('rsa', { modulusLength: 2048 }).privateKey.export({
@@ -22,6 +25,9 @@ describe('Status endpoints', () => {
 	let tempDir;
 
 	beforeEach(() => {
+		admin.__resetApps();
+		admin.__resetCollectionState();
+		alertStorageService._resetForTesting();
 		Object.keys(process.env).forEach((key) => {
 			delete process.env[key];
 		});
@@ -111,6 +117,48 @@ describe('Status endpoints', () => {
 			status: 'disabled',
 		});
 		expect(response.body.dependencies.sentry.status).toBe('ready');
+	});
+
+	it('reports scanner presets as ephemeral when no Firestore gate is enabled', async () => {
+		delete process.env.ENABLE_FIRESTORE_ALERT_STORAGE;
+		delete process.env.ENABLE_FIRESTORE_SCANNER_PRESETS;
+		delete process.env.ENABLE_FIRESTORE_JOB_STORAGE;
+		delete process.env.ENABLE_SIGNAL_OUTCOME_TRACKING;
+		delete process.env.ENABLE_SHADOW_MODE_OUTCOME_TRACKING;
+
+		const response = await request(app)
+			.get('/api/capabilities')
+			.set('x-api-key', 'status-key');
+		expect(response.status).toBe(200);
+		expect(response.body.featureFlags.firestoreScannerPresets).toBe(false);
+		expect(response.body.dependencies.scannerPresetStorage).toEqual({
+			enabled: false,
+			configured: false,
+			ready: false,
+			status: 'disabled',
+			mode: 'ephemeral',
+			backend: 'memory',
+		});
+	});
+
+	it('reports durable scanner preset storage from its dedicated Firestore gate', async () => {
+		delete process.env.ENABLE_FIRESTORE_ALERT_STORAGE;
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.featureFlags.firestoreScannerPresets).toBe(true);
+		expect(response.body.dependencies.scannerPresetStorage).toEqual({
+			enabled: true,
+			configured: true,
+			ready: true,
+			status: 'ready',
+			mode: 'durable',
+			backend: 'firestore',
+		});
 	});
 
 	it('reports Cloudflare AI Gateway as disabled by default', async () => {

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -161,6 +161,26 @@ describe('Status endpoints', () => {
 		});
 	});
 
+	it('does not report durable scanner presets from the alert storage gate', async () => {
+		process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+		delete process.env.ENABLE_FIRESTORE_SCANNER_PRESETS;
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.featureFlags.firestoreScannerPresets).toBe(false);
+		expect(response.body.dependencies.scannerPresetStorage).toEqual({
+			enabled: false,
+			configured: false,
+			ready: false,
+			status: 'disabled',
+			mode: 'ephemeral',
+			backend: 'memory',
+		});
+	});
+
 	it('reports scanner preset storage as misconfigured without usable credentials', async () => {
 		delete process.env.ENABLE_FIRESTORE_ALERT_STORAGE;
 		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -161,6 +161,27 @@ describe('Status endpoints', () => {
 		});
 	});
 
+	it('reports scanner preset storage as misconfigured without usable credentials', async () => {
+		delete process.env.ENABLE_FIRESTORE_ALERT_STORAGE;
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+		const response = await request(app)
+			.get('/api/capabilities')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.scannerPresetStorage).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
+			mode: 'ephemeral',
+			backend: 'memory',
+		});
+	});
+
 	it('reports Cloudflare AI Gateway as disabled by default', async () => {
 		const response = await request(app)
 			.get('/api/capabilities')

--- a/tests/integration/status-endpoint.test.js
+++ b/tests/integration/status-endpoint.test.js
@@ -1,4 +1,4 @@
-const { mkdtempSync, rmSync, writeFileSync } = require('fs');
+const { mkdirSync, mkdtempSync, rmSync, writeFileSync } = require('fs');
 const request = require('supertest');
 const express = require('express');
 const { generateKeyPairSync } = require('crypto');
@@ -14,6 +14,7 @@ const testPrivateKey = generateKeyPairSync('rsa', { modulusLength: 2048 }).priva
 	format: 'pem',
 });
 const validFirestoreServiceAccountJson = JSON.stringify({
+	type: 'service_account',
 	project_id: 'x',
 	client_email: 'firebase-adminsdk@test-project.iam.gserviceaccount.com',
 	private_key: testPrivateKey,
@@ -720,7 +721,7 @@ describe('Status endpoints', () => {
 		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
 		process.env.GOOGLE_CLOUD_PROJECT = 'cabros-project';
 		tempDir = mkdtempSync(join(tmpdir(), 'cabros-gcloud-empty-'));
-		process.env.CLOUDSDK_CONFIG = tempDir;
+		process.env.HOME = tempDir;
 
 		const response = await request(app)
 			.get('/api/status')
@@ -769,6 +770,30 @@ describe('Status endpoints', () => {
 			configured: true,
 			ready: true,
 			status: 'ready',
+		});
+	});
+
+	it('does not treat a service-account file without its type as configured', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		tempDir = mkdtempSync(join(tmpdir(), 'cabros-firestore-'));
+		const credentialsPath = join(tempDir, 'service-account-without-type.json');
+		writeFileSync(credentialsPath, JSON.stringify({
+			project_id: 'x',
+			client_email: 'firebase-adminsdk@test-project.iam.gserviceaccount.com',
+			private_key: testPrivateKey,
+		}));
+		process.env.GOOGLE_APPLICATION_CREDENTIALS = credentialsPath;
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
 		});
 	});
 
@@ -895,9 +920,11 @@ describe('Status endpoints', () => {
 		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
 		process.env.GOOGLE_CLOUD_PROJECT = 'well-known-project';
 		tempDir = mkdtempSync(join(tmpdir(), 'cabros-gcloud-'));
-		const credentialsPath = join(tempDir, 'application_default_credentials.json');
+		const credentialsDirectory = join(tempDir, '.config', 'gcloud');
+		mkdirSync(credentialsDirectory, { recursive: true });
+		const credentialsPath = join(credentialsDirectory, 'application_default_credentials.json');
 		writeFileSync(credentialsPath, validFirestoreServiceAccountJson);
-		process.env.CLOUDSDK_CONFIG = tempDir;
+		process.env.HOME = tempDir;
 
 		const response = await request(app)
 			.get('/api/status')
@@ -912,13 +939,39 @@ describe('Status endpoints', () => {
 		});
 	});
 
+	it('does not treat CLOUDSDK_CONFIG as Firebase ADC discovery', async () => {
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+		process.env.GOOGLE_CLOUD_PROJECT = 'cloudsdk-config-project';
+		tempDir = mkdtempSync(join(tmpdir(), 'cabros-gcloud-config-'));
+		writeFileSync(join(tempDir, 'application_default_credentials.json'), validFirestoreServiceAccountJson);
+		process.env.CLOUDSDK_CONFIG = tempDir;
+		const homeDirectory = join(tempDir, 'home-without-adc');
+		mkdirSync(homeDirectory, { recursive: true });
+		process.env.HOME = homeDirectory;
+
+		const response = await request(app)
+			.get('/api/status')
+			.set('x-api-key', 'status-key');
+
+		expect(response.status).toBe(200);
+		expect(response.body.dependencies.firestore).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
+		});
+	});
+
 	it('does not fall back to well-known ADC when the explicit path is invalid', async () => {
 		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
 		process.env.GOOGLE_CLOUD_PROJECT = 'well-known-project';
 		tempDir = mkdtempSync(join(tmpdir(), 'cabros-gcloud-'));
-		const wellKnownPath = join(tempDir, 'application_default_credentials.json');
+		const credentialsDirectory = join(tempDir, '.config', 'gcloud');
+		mkdirSync(credentialsDirectory, { recursive: true });
+		const wellKnownPath = join(credentialsDirectory, 'application_default_credentials.json');
 		writeFileSync(wellKnownPath, validFirestoreServiceAccountJson);
-		process.env.CLOUDSDK_CONFIG = tempDir;
+		process.env.HOME = tempDir;
 		process.env.GOOGLE_APPLICATION_CREDENTIALS = join(tempDir, 'missing-explicit.json');
 
 		const response = await request(app)

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -276,4 +276,50 @@ describe('ScannerPresetService', () => {
 		await Promise.all([triggerPromise, deletePromise]);
 		expect(firestoreAdmin.__mockDocDelete).toHaveBeenCalled();
 	});
+
+	it('does not flush the same pending preset twice concurrently', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		const service = new ScannerPresetService();
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Temporary Firestore write outage'));
+		await service.createPreset({ name: 'Queued value' });
+
+		let releaseFlush;
+		let queuedWrites = 0;
+		const flushGate = new Promise((resolve) => {
+			releaseFlush = resolve;
+		});
+		firestoreAdmin.__mockDocSet.mockImplementation((data) => {
+			if (data.name === 'Trigger one' || data.name === 'Trigger two') {
+				return Promise.resolve();
+			}
+			queuedWrites += 1;
+			return flushGate;
+		});
+
+		const firstTrigger = service.createPreset({ name: 'Trigger one' });
+		await new Promise((resolve) => setImmediate(resolve));
+		const secondTrigger = service.createPreset({ name: 'Trigger two' });
+		await new Promise((resolve) => setImmediate(resolve));
+		releaseFlush();
+		await Promise.all([firstTrigger, secondTrigger]);
+
+		expect(queuedWrites).toBe(1);
+	});
+
+	it('tombstones a remote-only preset when its delete fails', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const scannerPresetModule = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		const service = new scannerPresetModule.ScannerPresetService();
+		const created = await service.createPreset({ name: 'Remote-only preset' });
+		scannerPresetModule._resetForTesting();
+		firestoreAdmin.__mockDocDelete.mockRejectedValueOnce(new Error('Temporary Firestore delete outage'));
+
+		expect(await service.deletePreset(created.id)).toBe(true);
+		expect(await service.listPresets()).toEqual([]);
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -414,4 +414,38 @@ describe('ScannerPresetService', () => {
 		expect(await service.getPreset(queued.id)).toBeNull();
 		expect(service.getStorageStatus().mode).toBe('durable');
 	});
+
+	it('does not flush an older pending value after a newer update starts', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		const service = new ScannerPresetService();
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Temporary Firestore write outage'));
+		const created = await service.createPreset({ name: 'Old value' });
+
+		let releaseNewWrite;
+		const newWriteGate = new Promise((resolve) => {
+			releaseNewWrite = resolve;
+		});
+		const writes = [];
+		firestoreAdmin.__mockDocSet.mockImplementation((data) => {
+			writes.push(data.name);
+			if (data.name === 'New value') {
+				return newWriteGate;
+			}
+			return Promise.resolve();
+		});
+
+		const updatePromise = service.updatePreset(created.id, { name: 'New value' });
+		await new Promise((resolve) => setImmediate(resolve));
+		const triggerPromise = service.createPreset({ name: 'Trigger flush' });
+		await new Promise((resolve) => setImmediate(resolve));
+
+		releaseNewWrite();
+		await Promise.all([updatePromise, triggerPromise]);
+
+		expect(writes.filter((name) => name === 'Old value')).toEqual([]);
+		expect(writes.filter((name) => name === 'New value')).toEqual(['New value']);
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -349,4 +349,33 @@ describe('ScannerPresetService', () => {
 		await updatePromise;
 		expect(await service.listPresets()).toEqual([]);
 	});
+
+	it('does not restore a failed update after a queued delete succeeds', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		const service = new ScannerPresetService();
+		const created = await service.createPreset({ name: 'Original value' });
+		let rejectUpdate;
+		const updateGate = new Promise((resolve, reject) => {
+			rejectUpdate = reject;
+		});
+		firestoreAdmin.__mockDocSet.mockImplementation((data) => (
+			data.name === 'Updated value' ? updateGate : Promise.resolve()
+		));
+
+		const updatePromise = service.updatePreset(created.id, { name: 'Updated value' });
+		await new Promise((resolve) => setImmediate(resolve));
+		firestoreAdmin.__mockDocGet.mockResolvedValueOnce({ exists: true });
+		const deletePromise = service.deletePreset(created.id);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		rejectUpdate(new Error('Temporary Firestore update outage'));
+		expect(await deletePromise).toBe(true);
+		await updatePromise;
+
+		expect(await service.listPresets()).toEqual([]);
+		expect(service.getStorageStatus().mode).toBe('durable');
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -408,9 +408,7 @@ describe('ScannerPresetService', () => {
 		expect(await deletePromise).toBe(true);
 		await triggerPromise;
 
-		expect(await service.listPresets()).toEqual([
-			expect.objectContaining({ name: 'Trigger flush' }),
-	]);
+		expect(await service.listPresets()).toEqual([]);
 		expect(await service.getPreset(queued.id)).toBeNull();
 		expect(service.getStorageStatus().mode).toBe('durable');
 	});
@@ -489,5 +487,19 @@ describe('ScannerPresetService', () => {
 
 		releaseFlush();
 		await triggerPromise;
+	});
+
+	it('treats successful empty Firestore reads as authoritative', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const scannerPresetModule = require('../../src/services/scannerPresets/ScannerPresetService');
+		const { ScannerPresetService } = scannerPresetModule;
+		const firestoreAdmin = require('firebase-admin');
+		const service = new ScannerPresetService();
+		const created = await service.createPreset({ name: 'Externally deleted preset' });
+		firestoreAdmin.__resetCollectionState();
+
+		expect(await service.listPresets()).toEqual([]);
+		expect(await service.getPreset(created.id)).toBeNull();
 	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -230,4 +230,20 @@ describe('ScannerPresetService', () => {
 		await Promise.all([triggerPromise, updatePromise]);
 		expect(newWriteStarted).toBe(true);
 	});
+
+	it('keeps a deletion tombstone when deleting an updated preset during an outage', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		const service = new ScannerPresetService();
+		const created = await service.createPreset({ name: 'Original value' });
+
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Temporary Firestore write outage'));
+		await service.updatePreset(created.id, { name: 'Updated value' });
+		firestoreAdmin.__mockDocGet.mockRejectedValueOnce(new Error('Temporary Firestore read outage'));
+
+		expect(await service.deletePreset(created.id)).toBe(true);
+		expect(await service.listPresets()).toEqual([]);
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -246,4 +246,34 @@ describe('ScannerPresetService', () => {
 		expect(await service.deletePreset(created.id)).toBe(true);
 		expect(await service.listPresets()).toEqual([]);
 	});
+
+	it('queues deletes behind in-flight Firestore writes', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		const service = new ScannerPresetService();
+		const created = await service.createPreset({ name: 'Original value' });
+
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Temporary Firestore write outage'));
+		await service.updatePreset(created.id, { name: 'Updated value' });
+
+		let releaseFlush;
+		const flushGate = new Promise((resolve) => {
+			releaseFlush = resolve;
+		});
+		firestoreAdmin.__mockDocSet.mockImplementation((data) => (
+			data.name === 'Trigger flush' ? Promise.resolve() : flushGate
+		));
+		const triggerPromise = service.createPreset({ name: 'Trigger flush' });
+		await new Promise((resolve) => setImmediate(resolve));
+		firestoreAdmin.__mockDocGet.mockResolvedValueOnce({ exists: false });
+		const deletePromise = service.deletePreset(created.id);
+		await new Promise((resolve) => setImmediate(resolve));
+		expect(firestoreAdmin.__mockDocDelete).not.toHaveBeenCalled();
+
+		releaseFlush();
+		await Promise.all([triggerPromise, deletePromise]);
+		expect(firestoreAdmin.__mockDocDelete).toHaveBeenCalled();
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -1,6 +1,17 @@
 'use strict';
 
+const { generateKeyPairSync } = require('crypto');
 const admin = require('firebase-admin');
+
+const testPrivateKey = generateKeyPairSync('rsa', { modulusLength: 2048 }).privateKey.export({
+	type: 'pkcs1',
+	format: 'pem',
+});
+const validFirestoreServiceAccountJson = JSON.stringify({
+	project_id: 'scanner-preset-test',
+	client_email: 'firebase-adminsdk@test-project.iam.gserviceaccount.com',
+	private_key: testPrivateKey,
+});
 
 describe('ScannerPresetService', () => {
 	beforeEach(() => {
@@ -14,7 +25,8 @@ describe('ScannerPresetService', () => {
 		delete process.env.ENABLE_SIGNAL_OUTCOME_TRACKING;
 		delete process.env.ENABLE_SHADOW_MODE_OUTCOME_TRACKING;
 		delete process.env.FIREBASE_PROJECT_ID;
-		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+		process.env.FIREBASE_SERVICE_ACCOUNT_JSON = validFirestoreServiceAccountJson;
+		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
 	});
 
 	it('persists a created preset across service instances when Firestore storage is enabled', async () => {
@@ -90,6 +102,44 @@ describe('ScannerPresetService', () => {
 
 		expect(created.name).toBe('Fallback preset');
 		expect(service.getStorageStatus()).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
+			mode: 'ephemeral',
+			backend: 'memory',
+		});
+	});
+
+	it('retries Firestore after a transient write failure and reports recovery', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Temporary Firestore outage'));
+		const service = new ScannerPresetService();
+
+		await service.createPreset({ name: 'First attempt' });
+		expect(service.getStorageStatus().mode).toBe('ephemeral');
+
+		await service.createPreset({ name: 'Recovered attempt' });
+		expect(service.getStorageStatus()).toEqual({
+			enabled: true,
+			configured: true,
+			ready: true,
+			status: 'ready',
+			mode: 'durable',
+			backend: 'firestore',
+		});
+	});
+
+	it('does not report durable storage without usable Firestore credentials', () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+
+		expect(new ScannerPresetService().getStorageStatus()).toEqual({
 			enabled: true,
 			configured: false,
 			ready: false,

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -322,4 +322,31 @@ describe('ScannerPresetService', () => {
 		expect(await service.deletePreset(created.id)).toBe(true);
 		expect(await service.listPresets()).toEqual([]);
 	});
+
+	it('keeps a tombstone when a queued delete fails after an in-flight update', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		const service = new ScannerPresetService();
+		const created = await service.createPreset({ name: 'Original value' });
+		let releaseUpdate;
+		const updateGate = new Promise((resolve) => {
+			releaseUpdate = resolve;
+		});
+		firestoreAdmin.__mockDocSet.mockImplementation((data) => (
+			data.name === 'Updated value' ? updateGate : Promise.resolve()
+		));
+
+		const updatePromise = service.updatePreset(created.id, { name: 'Updated value' });
+		await new Promise((resolve) => setImmediate(resolve));
+		firestoreAdmin.__mockDocGet.mockResolvedValueOnce({ exists: true });
+		firestoreAdmin.__mockDocDelete.mockRejectedValueOnce(new Error('Temporary Firestore delete outage'));
+		const deletePromise = service.deletePreset(created.id);
+		releaseUpdate();
+
+		expect(await deletePromise).toBe(true);
+		await updatePromise;
+		expect(await service.listPresets()).toEqual([]);
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -188,4 +188,46 @@ describe('ScannerPresetService', () => {
 		expect(await service.deletePreset(created.id)).toBe(true);
 		expect(await service.listPresets()).toEqual([]);
 	});
+
+	it('serializes pending writes before concurrent updates for the same preset', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Temporary Firestore write outage'));
+		const service = new ScannerPresetService();
+		const created = await service.createPreset({ name: 'Queued old value' });
+
+		let releaseOldWrite;
+		let oldWriteStarted = false;
+		let newWriteStarted = false;
+		const oldWriteGate = new Promise((resolve) => {
+			releaseOldWrite = resolve;
+		});
+		firestoreAdmin.__mockDocSet.mockImplementation((data) => {
+			if (data.name === 'Trigger flush') {
+				return Promise.resolve();
+			}
+			if (data.name === 'Queued old value') {
+				oldWriteStarted = true;
+				return oldWriteGate;
+			}
+			if (data.name === 'New value') {
+				newWriteStarted = true;
+			}
+			return Promise.resolve();
+		});
+
+		const triggerPromise = service.createPreset({ name: 'Trigger flush' });
+		await new Promise((resolve) => setImmediate(resolve));
+		const updatePromise = service.updatePreset(created.id, { name: 'New value' });
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(oldWriteStarted).toBe(true);
+		expect(newWriteStarted).toBe(false);
+
+		releaseOldWrite();
+		await Promise.all([triggerPromise, updatePromise]);
+		expect(newWriteStarted).toBe(true);
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -252,6 +252,42 @@ describe('ScannerPresetService', () => {
 		expect(await originalGetPreset(created.id)).toBeNull();
 	});
 
+	it('preserves a newer failed write when an older write finishes', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const service = new ScannerPresetService();
+		const created = await service.createPreset({ name: 'Original value' });
+		let rejectNewWrite;
+		let releaseOldWrite;
+		const newWrite = new Promise((resolve, reject) => {
+			rejectNewWrite = reject;
+		});
+		const oldWrite = new Promise((resolve) => {
+			releaseOldWrite = resolve;
+		});
+		jest.spyOn(service, 'getPreset').mockResolvedValue(created);
+		jest.spyOn(service, '_writeFirestorePreset')
+			.mockImplementationOnce(() => oldWrite)
+			.mockImplementationOnce(() => newWrite)
+			.mockImplementation(() => Promise.reject(new Error('Recovery write still unavailable')));
+
+		const olderUpdate = service.updatePreset(created.id, { name: 'Older value' });
+		await new Promise((resolve) => setImmediate(resolve));
+		const newerUpdate = service.updatePreset(created.id, { name: 'Newer value' });
+		await new Promise((resolve) => setImmediate(resolve));
+
+		rejectNewWrite(new Error('Temporary Firestore update outage'));
+		await newerUpdate;
+		releaseOldWrite();
+		await olderUpdate;
+
+		expect(await service.listPresets()).toEqual([
+			expect.objectContaining({ id: created.id, name: 'Newer value' }),
+		]);
+		expect(service.getStorageStatus().mode).toBe('ephemeral');
+	});
+
 	it('keeps a deletion tombstone when deleting an updated preset during an outage', async () => {
 		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
 

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -4,10 +4,15 @@ const admin = require('firebase-admin');
 
 describe('ScannerPresetService', () => {
 	beforeEach(() => {
+		jest.clearAllMocks();
 		jest.resetModules();
 		admin.__resetApps();
 		admin.__resetCollectionState();
 		delete process.env.ENABLE_FIRESTORE_ALERT_STORAGE;
+		delete process.env.ENABLE_FIRESTORE_SCANNER_PRESETS;
+		delete process.env.ENABLE_FIRESTORE_JOB_STORAGE;
+		delete process.env.ENABLE_SIGNAL_OUTCOME_TRACKING;
+		delete process.env.ENABLE_SHADOW_MODE_OUTCOME_TRACKING;
 		delete process.env.FIREBASE_PROJECT_ID;
 		delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
 	});
@@ -40,6 +45,57 @@ describe('ScannerPresetService', () => {
 			scans: ['top_gainers', 'volume_breakout_scanner'],
 			limit: 7,
 			bbwThreshold: 0.08,
+		});
+	});
+
+	it('persists a preset across service instances with the dedicated scanner storage flag', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const serviceA = new ScannerPresetService();
+		const created = await serviceA.createPreset({ name: 'Dedicated storage preset' });
+
+		jest.resetModules();
+		const {
+			ScannerPresetService: ReloadedScannerPresetService,
+		} = require('../../src/services/scannerPresets/ScannerPresetService');
+		const fetched = await new ReloadedScannerPresetService().getPreset(created.id);
+
+		expect(fetched).toMatchObject({
+			id: created.id,
+			name: 'Dedicated storage preset',
+		});
+	});
+
+	it('reports the in-memory storage mode when durable storage is disabled', () => {
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+
+		expect(new ScannerPresetService().getStorageStatus()).toEqual({
+			enabled: false,
+			configured: false,
+			ready: false,
+			status: 'disabled',
+			mode: 'ephemeral',
+			backend: 'memory',
+		});
+	});
+
+	it('reports ephemeral storage after a Firestore write failure', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		require('firebase-admin').__mockDocSet.mockRejectedValueOnce(new Error('Firestore unavailable'));
+		const service = new ScannerPresetService();
+		const created = await service.createPreset({ name: 'Fallback preset' });
+
+		expect(created.name).toBe('Fallback preset');
+		expect(service.getStorageStatus()).toEqual({
+			enabled: true,
+			configured: false,
+			ready: false,
+			status: 'misconfigured',
+			mode: 'ephemeral',
+			backend: 'memory',
 		});
 	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -231,6 +231,27 @@ describe('ScannerPresetService', () => {
 		expect(newWriteStarted).toBe(true);
 	});
 
+	it('does not resurrect a preset deleted during the update read phase', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		const service = new ScannerPresetService();
+		const created = await service.createPreset({ name: 'Original value' });
+		const originalGetPreset = service.getPreset.bind(service);
+
+		service.getPreset = jest.fn(async () => {
+			await service.deletePreset(created.id);
+			return created;
+		});
+
+		const updated = await service.updatePreset(created.id, { name: 'Resurrected value' });
+
+		expect(updated).toBeNull();
+		expect(firestoreAdmin.__mockDocSet).toHaveBeenCalledTimes(1);
+		expect(await originalGetPreset(created.id)).toBeNull();
+	});
+
 	it('keeps a deletion tombstone when deleting an updated preset during an outage', async () => {
 		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
 

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -157,4 +157,21 @@ describe('ScannerPresetService', () => {
 			backend: 'firestore',
 		});
 	});
+
+	it('keeps presets from failed writes visible and ephemeral after reads recover', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Temporary Firestore write outage'));
+		const service = new ScannerPresetService();
+
+		const created = await service.createPreset({ name: 'Unsynced preset' });
+		const presets = await service.listPresets();
+
+		expect(presets).toEqual([
+			expect.objectContaining({ id: created.id, name: 'Unsynced preset' }),
+		]);
+		expect(service.getStorageStatus().mode).toBe('ephemeral');
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -29,34 +29,21 @@ describe('ScannerPresetService', () => {
 		delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
 	});
 
-	it('persists a created preset across service instances when Firestore storage is enabled', async () => {
+	it('does not use alert storage as an implicit scanner preset persistence gate', async () => {
 		process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
 
 		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
-		const serviceA = new ScannerPresetService();
-		const created = await serviceA.createPreset({
-			name: 'Momentum preset',
-			exchange: 'binance',
-			timeframe: '1h',
-			scans: ['top_gainers', 'volume_breakout_scanner'],
-			limit: 7,
-			bbwThreshold: 0.08,
-		});
+		const service = new ScannerPresetService();
 
-		jest.resetModules();
-		const {
-			ScannerPresetService: ReloadedScannerPresetService,
-		} = require('../../src/services/scannerPresets/ScannerPresetService');
-		const fetched = await new ReloadedScannerPresetService().getPreset(created.id);
+		await service.createPreset({ name: 'Memory-only preset' });
 
-		expect(fetched).toMatchObject({
-			id: created.id,
-			name: 'Momentum preset',
-			exchange: 'BINANCE',
-			timeframe: '1h',
-			scans: ['top_gainers', 'volume_breakout_scanner'],
-			limit: 7,
-			bbwThreshold: 0.08,
+		expect(service.getStorageStatus()).toEqual({
+			enabled: false,
+			configured: false,
+			ready: false,
+			status: 'disabled',
+			mode: 'ephemeral',
+			backend: 'memory',
 		});
 	});
 

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -174,4 +174,18 @@ describe('ScannerPresetService', () => {
 		]);
 		expect(service.getStorageStatus().mode).toBe('ephemeral');
 	});
+
+	it('does not resurrect a queued write after deleting during a Firestore outage', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Temporary Firestore write outage'));
+		firestoreAdmin.__mockDocGet.mockRejectedValueOnce(new Error('Temporary Firestore read outage'));
+		const service = new ScannerPresetService();
+
+		const created = await service.createPreset({ name: 'Deleted queued preset' });
+		expect(await service.deletePreset(created.id)).toBe(true);
+		expect(await service.listPresets()).toEqual([]);
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -461,4 +461,33 @@ describe('ScannerPresetService', () => {
 		expect(created.id).toMatch(/^[0-9a-f-]{36}$/);
 		expect(service.getStorageStatus().mode).toBe('durable');
 	});
+
+	it('keeps a claimed pending preset visible during recovery', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		const service = new ScannerPresetService();
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Temporary Firestore write outage'));
+		const queued = await service.createPreset({ name: 'Queued recovery value' });
+
+		let releaseFlush;
+		const flushGate = new Promise((resolve) => {
+			releaseFlush = resolve;
+		});
+		firestoreAdmin.__mockDocSet.mockImplementation((data) => (
+			data.name === 'Queued recovery value' ? flushGate : Promise.resolve()
+		));
+
+		const triggerPromise = service.createPreset({ name: 'Trigger recovery' });
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(await service.listPresets()).toEqual(expect.arrayContaining([
+			expect.objectContaining({ id: queued.id, name: 'Queued recovery value' }),
+		]));
+		expect(service.getStorageStatus().mode).toBe('ephemeral');
+
+		releaseFlush();
+		await triggerPromise;
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -148,4 +148,26 @@ describe('ScannerPresetService', () => {
 			backend: 'memory',
 		});
 	});
+
+	it('clears the unavailable state after a successful Firestore read recovery', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		firestoreAdmin.__mockGet.mockRejectedValueOnce(new Error('Temporary Firestore read outage'));
+		const service = new ScannerPresetService();
+
+		await service.listPresets();
+		expect(service.getStorageStatus().mode).toBe('ephemeral');
+
+		await service.listPresets();
+		expect(service.getStorageStatus()).toEqual({
+			enabled: true,
+			configured: true,
+			ready: true,
+			status: 'ready',
+			mode: 'durable',
+			backend: 'firestore',
+		});
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -448,4 +448,17 @@ describe('ScannerPresetService', () => {
 		expect(writes.filter((name) => name === 'Old value')).toEqual([]);
 		expect(writes.filter((name) => name === 'New value')).toEqual(['New value']);
 	});
+
+	it('does not accept caller-supplied create IDs', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const service = new ScannerPresetService();
+
+		const created = await service.createPreset({ id: 'unsafe/path', name: 'Generated ID preset' });
+
+		expect(created.id).not.toBe('unsafe/path');
+		expect(created.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(service.getStorageStatus().mode).toBe('durable');
+	});
 });

--- a/tests/unit/scanner-preset-service.test.js
+++ b/tests/unit/scanner-preset-service.test.js
@@ -378,4 +378,40 @@ describe('ScannerPresetService', () => {
 		expect(await service.listPresets()).toEqual([]);
 		expect(service.getStorageStatus().mode).toBe('durable');
 	});
+
+	it('does not restore a failed pending flush after a queued delete succeeds', async () => {
+		process.env.ENABLE_FIRESTORE_SCANNER_PRESETS = 'true';
+
+		const { ScannerPresetService } = require('../../src/services/scannerPresets/ScannerPresetService');
+		const firestoreAdmin = require('firebase-admin');
+		const service = new ScannerPresetService();
+		firestoreAdmin.__mockDocSet.mockRejectedValueOnce(new Error('Temporary Firestore write outage'));
+		const queued = await service.createPreset({ name: 'Queued value' });
+
+		let rejectFlush;
+		const flushGate = new Promise((resolve, reject) => {
+			rejectFlush = reject;
+		});
+		firestoreAdmin.__mockDocSet.mockImplementation((data) => {
+			if (data.name === 'Queued value') {
+				return flushGate;
+			}
+			return Promise.resolve();
+		});
+
+		const triggerPromise = service.createPreset({ name: 'Trigger flush' });
+		await new Promise((resolve) => setImmediate(resolve));
+		const deletePromise = service.deletePreset(queued.id);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		rejectFlush(new Error('Temporary Firestore flush outage'));
+		expect(await deletePromise).toBe(true);
+		await triggerPromise;
+
+		expect(await service.listPresets()).toEqual([
+			expect.objectContaining({ name: 'Trigger flush' }),
+	]);
+		expect(await service.getPreset(queued.id)).toBeNull();
+		expect(service.getStorageStatus().mode).toBe('durable');
+	});
 });


### PR DESCRIPTION
feat(scanner): add durable preset storage (CB-88)

## Summary

Add an explicit Firestore persistence gate for scanner presets and expose the effective storage backend so callers never mistake the in-memory fallback for durable persistence.

## Key Changes

- Add `ENABLE_FIRESTORE_SCANNER_PRESETS` without coupling scanner presets to alert, job, or outcome-storage flags.
- Preserve fail-open preset CRUD behavior while reporting `durable/firestore` or `ephemeral/memory` after initialization and write failures.
- Expose storage metadata on scanner-preset CRUD responses and under `dependencies.scannerPresetStorage` in `/api/status` and `/api/capabilities`.
- Document configuration and response contracts in README, `.env.example`, OpenAPI, Postman, and agents.md.

## Technical Implementation

- Extend the shared lazy Firestore initializer to recognize the dedicated scanner-preset gate.
- Centralize non-secret Firestore credential/runtime readiness checks so a lazy client is not reported as ready without usable configuration.
- Track per-service Firestore availability so a failed write downgrades the reported mode, retries later operations, and returns to durable status after recovery.
- Keep memory fallback behavior for disabled or unavailable Firestore and reset health state in the test helper.

## Testing

- `pnpm test -- tests/unit/scanner-preset-service.test.js tests/unit/alert-storage-service.test.js tests/integration/scanner-presets-endpoint.test.js tests/integration/status-endpoint.test.js --runInBand`
- `pnpm test` — 73 suites, 1009 tests passed.
- `git diff --check` plus JSON parsing/reference validation for OpenAPI and Postman.

## References

- Fixes #219
- **Linear**: [CB-88](https://linear.app/knil/issue/CB-88/make-scanner-preset-persistence-durable-and-observable)
- **GitHub issue**: https://github.com/francovp/cabros-bot/issues/219
