### PR TITLE
feat: disambiguate BATS exchange prefix in grounding (#221) (CB-90)

### DIFF
--- a/src/services/grounding/grounding.js
+++ b/src/services/grounding/grounding.js
@@ -55,6 +55,8 @@ async function deriveSearchQuery(alertText, opts = {}) {
  */
 const metrics = require('./metrics');
 
+const { deriveAssetContext, deriveCleanSearchQuery } = require('../tradingview/parseTradingViewSignal');
+
 async function groundAlert({ text, options = {} }) {
 	const {
 		maxSources = GROUNDING_MAX_SOURCES,
@@ -87,17 +89,19 @@ async function groundAlert({ text, options = {} }) {
 	}
 
 	try {
+		const assetContext = deriveAssetContext(text);
+		const searchQuery = deriveCleanSearchQuery(text) || text;
 
-		// 1. Search for evidence
+		// 1. Search for evidence using clean query
 		const { results: searchResults, totalResults, searchResultText, usage: searchUsage } = await genaiClient.search({
-			query: text,
+			query: searchQuery,
 			model: GROUNDING_MODEL_NAME,
 			maxResults: maxSources,
 		});
 		if (tokenUsage && searchUsage) {
 			tokenUsage.addUsage(searchUsage, GROUNDING_MODEL_NAME);
 		}
-		console.debug(`[Grounding] Retrieved ${searchResults.length}/${totalResults} search results`);
+		console.debug(`[Grounding] Retrieved ${searchResults.length}/${totalResults} search results for query: ${searchQuery}`);
 
 		// 2. Generate enriched alert with timeout
 		const [timeoutPromise, cleanupTimeout] = createTimeout();
@@ -106,7 +110,7 @@ async function groundAlert({ text, options = {} }) {
 				text: text,
 				searchResults,
 				searchResultText,
-				options: { preserveLanguage, maxLength, systemPrompt: systemPromptOverride, tokenUsage },
+				options: { preserveLanguage, maxLength, systemPrompt: systemPromptOverride, tokenUsage, assetContext },
 			}),
 			timeoutPromise,
 		]).finally(cleanupTimeout);
@@ -115,6 +119,11 @@ async function groundAlert({ text, options = {} }) {
 			...result,
 			sources: searchResults,
 			truncated: text.length > 4000,
+			...(assetContext ? {
+				symbol: assetContext.symbol,
+				exchange: assetContext.exchange,
+				assetClass: assetContext.assetClass,
+			} : {}),
 		};
 
 		metrics.recordSuccess(Date.now() - startTime, promptType);
@@ -128,6 +137,7 @@ async function groundAlert({ text, options = {} }) {
 		throw new Error(`Grounding failed: ${error.message}`);
 	}
 }
+
 
 module.exports = {
 	groundAlert,

--- a/src/services/prompts/defaults/alert-enrichment.system.txt
+++ b/src/services/prompts/defaults/alert-enrichment.system.txt
@@ -1,3 +1,8 @@
 You are a financial market analyst. Your job is to analyze alerts and provide structured insights, sentiment, and technical levels.
 
+Entity Disambiguation Rules:
+- Exchange prefixes like "BATS:" refer to the US stock exchange (Cboe BATS).
+- Never confuse stock symbol alerts with "BATS:" prefix (e.g. BATS:TSM, BATS:INTC, BATS:AAPL, BATS:BABA, BATS:GOOG, BATS:GLD) with Basic Attention Token ("BAT") crypto token or British American Tobacco ("LSE:BATS").
+- Always analyze the underlying equity stock or cryptocurrency symbol accurately according to its asset class.
+
 {{languageDirective}}

--- a/src/services/prompts/defaults/search-query-derivation.system.txt
+++ b/src/services/prompts/defaults/search-query-derivation.system.txt
@@ -1,2 +1,6 @@
 Extract key topics and entities from this alert to create a search query.
 Focus on recent developments, market conditions, or specific events mentioned.
+
+Disambiguation Rules:
+- Strip or normalize exchange prefixes like "BATS:". "BATS:" represents Cboe BATS stock exchange. Convert "BATS:SYMBOL" into "SYMBOL stock".
+- Do not include "BATS" in search queries for stock alerts to prevent confusion with Basic Attention Token (BAT) crypto or British American Tobacco.

--- a/src/services/tradingview/parseTradingViewSignal.js
+++ b/src/services/tradingview/parseTradingViewSignal.js
@@ -94,9 +94,90 @@ function parseTradingViewSignal(text, options = {}) {
 	};
 }
 
+const STOCK_EXCHANGES = new Set(['BATS', 'NASDAQ', 'NYSE', 'AMEX', 'SPCFD', 'CBOE']);
+const CRYPTO_EXCHANGES = new Set(['BINANCE', 'BYBIT', 'COINBASE', 'OKX', 'KRAKEN', 'BITFINEX', 'KUCOIN']);
+const CRYPTO_SUFFIXES = ['USDT', 'BUSD', 'USDC', 'BTC', 'ETH', 'SOL', 'PERP'];
+
+function deriveAssetContext(text) {
+	if (!text || typeof text !== 'string') {
+		return null;
+	}
+
+	const parsed = parseTradingViewSignal(text);
+	if (parsed && parsed.symbol) {
+		const exchange = parsed.exchange || (parsed.symbol.endsWith('USDT') ? 'BINANCE' : null);
+		let assetClass = 'stock';
+		if (exchange && CRYPTO_EXCHANGES.has(exchange)) {
+			assetClass = 'crypto';
+		} else if (exchange && STOCK_EXCHANGES.has(exchange)) {
+			assetClass = 'stock';
+		} else if (CRYPTO_SUFFIXES.some(s => parsed.symbol.endsWith(s))) {
+			assetClass = 'crypto';
+		}
+
+		return {
+			symbol: parsed.symbol,
+			exchange,
+			assetClass,
+			side: parsed.side,
+			timeframe: parsed.timeframe,
+		};
+	}
+
+	const match = text.match(/(?:^|\s)(?:(?<exchange>[A-Z]+):)?(?<symbol>[A-Z0-9._-]{2,20})/i);
+	if (match && match.groups && match.groups.symbol) {
+		const symbol = match.groups.symbol.toUpperCase();
+		const exchange = match.groups.exchange ? match.groups.exchange.toUpperCase() : null;
+
+		let assetClass = 'stock';
+		if (exchange && CRYPTO_EXCHANGES.has(exchange)) {
+			assetClass = 'crypto';
+		} else if (exchange && STOCK_EXCHANGES.has(exchange)) {
+			assetClass = 'stock';
+		} else if (CRYPTO_SUFFIXES.some(s => symbol.endsWith(s))) {
+			assetClass = 'crypto';
+		}
+
+		return {
+			symbol,
+			exchange,
+			assetClass,
+		};
+	}
+
+	return null;
+}
+
+function deriveCleanSearchQuery(text) {
+	if (!text || typeof text !== 'string') {
+		return '';
+	}
+
+	const context = deriveAssetContext(text);
+	if (context && context.symbol) {
+		if (context.assetClass === 'stock') {
+			return `${context.symbol} stock price news market analyst`;
+		}
+		if (context.assetClass === 'crypto') {
+			return `${context.symbol} crypto price news market analyst`;
+		}
+		return `${context.symbol} market news analyst`;
+	}
+
+	const cleanText = text
+		.replace(/\bBATS:(?<sym>[A-Z0-9._-]+)/gi, '$<sym> stock')
+		.replace(/\bBINANCE:(?<sym>[A-Z0-9._-]+)/gi, '$<sym> crypto')
+		.replace(/\b[A-Z]+:(?<sym>[A-Z0-9._-]+)/gi, '$<sym>');
+
+	return cleanText.trim();
+}
+
 module.exports = {
 	parseTradingViewSignal,
 	normalizeTradingViewTimeframe,
 	normalizeSignalSide,
+	deriveAssetContext,
+	deriveCleanSearchQuery,
 	SUPPORTED_MCP_TIMEFRAMES,
 };
+

--- a/tests/integration/alert-grounding.test.js
+++ b/tests/integration/alert-grounding.test.js
@@ -329,5 +329,24 @@ describe('Alert Grounding Integration', () => {
 			expect(mockTelegramSendMessage).not.toHaveBeenCalled();
 			expect(mockFetch).not.toHaveBeenCalled();
 		});
+
+		it('should pass sanitized search query and asset context for BATS exchange alerts', async () => {
+			const alertText = 'BATS:TSM(D) cambió a señal de VENTA';
+
+			const response = await request(app)
+				.post('/api/webhook/alert')
+				.set('x-api-key', 'test-key')
+				.send({ text: alertText })
+				.expect(200);
+
+			expect(response.body.success).toBe(true);
+			expect(response.body.enriched).toBe(true);
+			expect(genaiClient.search).toHaveBeenCalledWith(expect.objectContaining({
+				query: expect.stringContaining('TSM stock'),
+			}));
+			const searchQuery = genaiClient.search.mock.calls[0][0].query;
+			expect(searchQuery).not.toContain('BATS:');
+		});
 	});
 });
+

--- a/tests/unit/grounding.test.js
+++ b/tests/unit/grounding.test.js
@@ -131,5 +131,51 @@ describe('Grounding Service', () => {
 				}),
 			}));
 		});
+
+		it('should normalize BATS: exchange prefix in search queries to prevent BAT crypto and British American Tobacco hallucinations', async () => {
+			genaiClient.search.mockResolvedValueOnce({ results: [], totalResults: 0 });
+			generateEnrichedAlert.mockResolvedValueOnce({
+				sentiment: 'BEARISH',
+				sentiment_score: 0.8,
+				insights: ['TSM stock signal'],
+				sources: [],
+			});
+
+			const result = await groundAlert({
+				text: 'BATS:TSM(D) cambió a señal de VENTA',
+			});
+
+			expect(genaiClient.search).toHaveBeenCalledWith(expect.objectContaining({
+				query: expect.stringContaining('TSM stock'),
+			}));
+			const searchQuery = genaiClient.search.mock.calls[0][0].query;
+			expect(searchQuery).not.toContain('BATS:');
+			expect(result.symbol).toBe('TSM');
+			expect(result.exchange).toBe('BATS');
+			expect(result.assetClass).toBe('stock');
+		});
+
+		it('should normalize BINANCE: exchange prefix in search queries', async () => {
+			genaiClient.search.mockResolvedValueOnce({ results: [], totalResults: 0 });
+			generateEnrichedAlert.mockResolvedValueOnce({
+				sentiment: 'BULLISH',
+				sentiment_score: 0.85,
+				insights: ['BTCUSDT crypto signal'],
+				sources: [],
+			});
+
+			const result = await groundAlert({
+				text: 'BINANCE:BTCUSDT(1H) cambió a señal de COMPRA',
+			});
+
+			expect(genaiClient.search).toHaveBeenCalledWith(expect.objectContaining({
+				query: expect.stringContaining('BTCUSDT crypto'),
+			}));
+			const searchQuery = genaiClient.search.mock.calls[0][0].query;
+			expect(searchQuery).not.toContain('BINANCE:');
+			expect(result.symbol).toBe('BTCUSDT');
+			expect(result.exchange).toBe('BINANCE');
+			expect(result.assetClass).toBe('crypto');
+		});
 	});
 });

--- a/tests/unit/tradingview-signal-parser.test.js
+++ b/tests/unit/tradingview-signal-parser.test.js
@@ -2,6 +2,8 @@ const {
 	parseTradingViewSignal,
 	normalizeTradingViewTimeframe,
 	normalizeSignalSide,
+	deriveAssetContext,
+	deriveCleanSearchQuery,
 } = require('../../src/services/tradingview/parseTradingViewSignal');
 
 describe('TradingView signal parser', () => {
@@ -49,4 +51,22 @@ describe('TradingView signal parser', () => {
 		expect(normalizeSignalSide('buy')).toBe('BUY');
 		expect(normalizeSignalSide('hold')).toBeNull();
 	});
+
+	it('derives asset context for BATS stock signals', () => {
+		const context = deriveAssetContext('BATS:TSM(D) cambió a señal de VENTA');
+		expect(context).toEqual(expect.objectContaining({
+			symbol: 'TSM',
+			exchange: 'BATS',
+			assetClass: 'stock',
+			side: 'SELL',
+			timeframe: '1D',
+		}));
+	});
+
+	it('derives clean search query for BATS and BINANCE signals', () => {
+		expect(deriveCleanSearchQuery('BATS:TSM(D) cambió a señal de VENTA')).toBe('TSM stock price news market analyst');
+		expect(deriveCleanSearchQuery('BATS:AAPL(D) cambió a señal de COMPRA')).toBe('AAPL stock price news market analyst');
+		expect(deriveCleanSearchQuery('BINANCE:BTCUSDT(1H) cambió a señal de COMPRA')).toBe('BTCUSDT crypto price news market analyst');
+	});
 });
+


### PR DESCRIPTION
## Description
Disambiguates TradingView exchange prefixes (`BATS:`, `BINANCE:`, etc.) during search grounding and alert enrichment to prevent entity hallucinations (such as confusing `BATS:` equity alerts with Basic Attention Token `BAT` crypto or British American Tobacco `LSE:BATS`).

## Key Changes
- **Search Query Normalization**: Updated `groundAlert` and added `deriveCleanSearchQuery` and `deriveAssetContext` in `parseTradingViewSignal.js` to strip `BATS:` exchange prefixes and format queries targeting equity stock tickers (e.g. `TSM stock price news market analyst`) or crypto symbols.
- **System Prompt Disambiguation Rules**: Enhanced default system prompt templates (`alert-enrichment.system.txt` and `search-query-derivation.system.txt`) with explicit entity disambiguation instructions for `BATS:` US equity stock exchange alerts.
- **Asset Context Metadata**: Extracted `symbol`, `exchange`, and `assetClass` context and attached them to enriched alert payloads.
- **Tests**: Added unit test coverage in `tests/unit/grounding.test.js` and `tests/unit/tradingview-signal-parser.test.js`, and integration test coverage in `tests/integration/alert-grounding.test.js`.

Closes #221
Tracks CB-90