### PR TITLE
feat(storage): extract symbol and exchange from raw alert text (CB-91)

### DIFF
--- a/context/feat-symbol-extraction-alert-storage-cb-91.md
+++ b/context/feat-symbol-extraction-alert-storage-cb-91.md
@@ -1,0 +1,17 @@
+# feat(storage): extract symbol and exchange from raw alert text (CB-91)
+
+## Summary
+Enhance `AlertStorageService` symbol extraction logic to parse TradingView symbols and exchange prefixes directly from raw alert text when explicit object properties (`symbol`, `enrichmentData.symbol`) are absent, eliminating `unknown` symbol classification in stored alert analytics (`GET /api/alerts/summary`).
+
+## Key Changes
+- **Text Pattern Parsing**: Added `parseSymbolFromText` helper in `AlertStorageService.js` to extract symbols and exchanges from standard TradingView alert formats (`BATS:TSM(D)`, `BINANCE:ETHUSDT(4h)`, `SPCFD:SPX(D)`, `BTCUSDT(1h)`).
+- **Symbol & Exchange Extraction**: Extended `extractSymbolAndExchange` to inspect candidate fields (`data.symbol`, `data.ticker`, `data.enrichmentData.symbol`), falling back to raw `data.text` parsing before returning `{ symbol: 'unknown', exchange: null }`.
+- **Alert Persistence**: Updated `saveAlert` to extract and attach `symbol` and `exchange` properties to stored Firestore document payloads when valid patterns match.
+- **Analytics & Unit Tests**: Added unit tests in `tests/unit/alert-storage-service.test.js` verifying symbol extraction from raw text strings across TradingView formats, and updated summary tests for `bySymbol` metrics.
+
+## Testing
+- Unit tests (`tests/unit/alert-storage-service.test.js`): All 46 tests passing.
+
+## References
+- **Linear**: [CB-91](https://linear.app/knil/issue/CB-91/implement-regex-symbol-extraction-in-alertstorageservice-and-webhook)
+- Closes #222

--- a/src/controllers/webhooks/handlers/alert/alert.js
+++ b/src/controllers/webhooks/handlers/alert/alert.js
@@ -185,10 +185,26 @@ function postAlert(botOrGetter) {
 				deliveredChannels,
 			});
 
+			const extracted = alertStorageService.extractSymbolAndExchange({
+				text: alert.text,
+				enrichmentData: alert.enriched || null,
+			});
+
+			if (alert.enriched && typeof alert.enriched === 'object') {
+				if (!alert.enriched.symbol && extracted.symbol !== 'unknown') {
+					alert.enriched.symbol = extracted.symbol;
+				}
+				if (!alert.enriched.exchange && extracted.exchange) {
+					alert.enriched.exchange = extracted.exchange;
+				}
+			}
+
 			// Fire-and-forget: persist alert to Firestore after responding to the caller.
 			// Errors are caught inside saveAlert — delivery is never blocked by storage.
 			alertStorageService.saveAlert({
 				text: alert.text,
+				symbol: extracted.symbol !== 'unknown' ? extracted.symbol : null,
+				exchange: extracted.exchange || null,
 				enriched,
 				enrichmentData: alert.enriched || null,
 				tokenUsage: tokenUsageJSON,

--- a/src/services/storage/AlertStorageService.js
+++ b/src/services/storage/AlertStorageService.js
@@ -75,7 +75,8 @@ function getDocTimestamp(document) {
 
 function formatAlertDocument(doc) {
 	const data = doc.data() || {};
-	return {
+	const extracted = extractSymbolAndExchange(data);
+	const docObj = {
 		id: doc.id,
 		receivedAt: getDocTimestamp(data),
 		text: typeof data.text === 'string' ? data.text : '',
@@ -87,6 +88,13 @@ function formatAlertDocument(doc) {
 		source: typeof data.source === 'string' ? data.source : null,
 		useTradingViewData: Boolean(data.useTradingViewData),
 	};
+	if (extracted.symbol !== 'unknown') {
+		docObj.symbol = extracted.symbol;
+	}
+	if (extracted.exchange) {
+		docObj.exchange = extracted.exchange;
+	}
+	return docObj;
 }
 
 function getNumericValue(value) {
@@ -101,18 +109,95 @@ function incrementCounter(target, key) {
 	target[normalizedKey] = (target[normalizedKey] || 0) + 1;
 }
 
-function extractAlertSymbol(data) {
-	const candidates = [
-		data.symbol,
-		data.ticker,
-		data.enrichmentData && data.enrichmentData.symbol,
-		data.enrichmentData && data.enrichmentData.ticker,
-		data.enrichmentData && data.enrichmentData.asset,
-		data.enrichmentData && data.enrichmentData.original_symbol,
-	];
+function parseSymbolFromText(text) {
+	if (!text || typeof text !== 'string') {
+		return null;
+	}
 
-	const symbol = candidates.find((candidate) => typeof candidate === 'string' && candidate.trim());
-	return symbol ? symbol.trim().toUpperCase() : 'unknown';
+	const cleaned = text.trim();
+	if (!cleaned) {
+		return null;
+	}
+
+	const exchangeMatch = cleaned.match(/(?:^|\b)(?<exchange>[A-Z0-9]{2,10}):(?<symbol>[A-Z0-9._-]{2,20})(?:\s*\(\s*(?<timeframe>[A-Za-z0-9]+)\s*\))?/i);
+	if (exchangeMatch && exchangeMatch.groups && exchangeMatch.groups.symbol) {
+		const symbol = exchangeMatch.groups.symbol.toUpperCase();
+		const exchange = exchangeMatch.groups.exchange ? exchangeMatch.groups.exchange.toUpperCase() : null;
+		return { symbol, exchange };
+	}
+
+	const timeframeMatch = cleaned.match(/(?:^|\s)(?<symbol>[A-Z0-9._-]{2,20})\s*\(\s*(?<timeframe>[A-Za-z0-9]+)\s*\)/i);
+	if (timeframeMatch && timeframeMatch.groups && timeframeMatch.groups.symbol) {
+		const symbol = timeframeMatch.groups.symbol.toUpperCase();
+		return { symbol, exchange: null };
+	}
+
+	return null;
+}
+
+function extractSymbolAndExchange(data) {
+	if (!data || typeof data !== 'object') {
+		return { symbol: 'unknown', exchange: null };
+	}
+
+	if (typeof data.symbol === 'string' && data.symbol.trim()) {
+		const sym = data.symbol.trim().toUpperCase();
+		if (sym.includes(':')) {
+			const parts = sym.split(':');
+			return { symbol: parts[1], exchange: parts[0] };
+		}
+		return {
+			symbol: sym,
+			exchange: typeof data.exchange === 'string' && data.exchange.trim() ? data.exchange.trim().toUpperCase() : null,
+		};
+	}
+
+	if (typeof data.ticker === 'string' && data.ticker.trim()) {
+		const ticker = data.ticker.trim().toUpperCase();
+		if (ticker.includes(':')) {
+			const parts = ticker.split(':');
+			return { symbol: parts[1], exchange: parts[0] };
+		}
+		return {
+			symbol: ticker,
+			exchange: typeof data.exchange === 'string' && data.exchange.trim() ? data.exchange.trim().toUpperCase() : null,
+		};
+	}
+
+	if (data.enrichmentData && typeof data.enrichmentData === 'object') {
+		const candidates = [
+			data.enrichmentData.symbol,
+			data.enrichmentData.ticker,
+			data.enrichmentData.asset,
+			data.enrichmentData.original_symbol,
+		];
+		const found = candidates.find((c) => typeof c === 'string' && c.trim());
+		if (found) {
+			const sym = found.trim().toUpperCase();
+			if (sym.includes(':')) {
+				const parts = sym.split(':');
+				return { symbol: parts[1], exchange: parts[0] };
+			}
+			const exchange = typeof data.enrichmentData.exchange === 'string' && data.enrichmentData.exchange.trim()
+				? data.enrichmentData.exchange.trim().toUpperCase()
+				: (typeof data.exchange === 'string' && data.exchange.trim() ? data.exchange.trim().toUpperCase() : null);
+			return { symbol: sym, exchange };
+		}
+	}
+
+	if (typeof data.text === 'string' && data.text.trim()) {
+		const parsed = parseSymbolFromText(data.text);
+		if (parsed) {
+			return parsed;
+		}
+	}
+
+	return { symbol: 'unknown', exchange: null };
+}
+
+function extractAlertSymbol(data) {
+	const result = extractSymbolAndExchange(data);
+	return result.symbol;
 }
 
 function addTokenUsage(totals, tokenUsage) {
@@ -412,7 +497,7 @@ function getFirestore() {
  * @param {boolean} params.useTradingViewData - Whether ?useTradingViewData=true was set on the request
  * @returns {Promise<string|null>} The new Firestore document ID, or null on failure/disabled
  */
-async function saveAlert({ text, enriched, enrichmentData, tokenUsage, channels, deliveryResults, useTradingViewData }) {
+async function saveAlert({ text, symbol, exchange, enriched, enrichmentData, tokenUsage, channels, deliveryResults, useTradingViewData }) {
 	if (!isEnabled()) {
 		return null;
 	}
@@ -423,6 +508,7 @@ async function saveAlert({ text, enriched, enrichmentData, tokenUsage, channels,
 	}
 
 	try {
+		const extracted = extractSymbolAndExchange({ text, symbol, exchange, enrichmentData });
 		const document = {
 			receivedAt: admin.firestore.FieldValue.serverTimestamp(),
 			text: typeof text === 'string' ? text.substring(0, 20000) : '',
@@ -434,6 +520,13 @@ async function saveAlert({ text, enriched, enrichmentData, tokenUsage, channels,
 			source: 'webhook',
 			useTradingViewData: Boolean(useTradingViewData),
 		};
+
+		if (extracted.symbol !== 'unknown') {
+			document.symbol = extracted.symbol;
+		}
+		if (extracted.exchange) {
+			document.exchange = extracted.exchange;
+		}
 
 		const docRef = await firestore.collection(COLLECTION_NAME).add(document);
 		console.debug(`[AlertStorageService] Alert stored with ID: ${docRef.id}`);
@@ -777,6 +870,9 @@ module.exports = {
 	summarizeAlerts,
 	exportAlerts,
 	saveReplayAttempt,
+	parseSymbolFromText,
+	extractSymbolAndExchange,
+	extractAlertSymbol,
 	STORAGE_UNAVAILABLE_CODE,
 	INVALID_CURSOR_MESSAGE,
 	parseAlertPaginationCursor,

--- a/tests/unit/alert-storage-service.test.js
+++ b/tests/unit/alert-storage-service.test.js
@@ -876,5 +876,122 @@ describe('AlertStorageService', () => {
 			});
 			expect(JSON.stringify(result)).not.toContain('raw alert text');
 		});
+
+		it('populates bySymbol metrics from plain alert text strings when candidate object properties are missing', async () => {
+			process.env.ENABLE_FIRESTORE_ALERT_STORAGE = 'true';
+			mockGet.mockResolvedValueOnce({
+				empty: false,
+				docs: [
+					buildQueryDoc('alert-1', {
+						receivedAt: buildTimestamp('2026-06-06T12:00:00.000Z'),
+						text: 'BINANCE:ETHUSDT(D) alert triggered',
+						enriched: false,
+						deliveryResults: [],
+						source: 'webhook',
+					}),
+					buildQueryDoc('alert-2', {
+						receivedAt: buildTimestamp('2026-06-06T11:00:00.000Z'),
+						text: 'BATS:TSM(D) cambió a señal de VENTA',
+						enriched: false,
+						deliveryResults: [],
+						source: 'webhook',
+					}),
+					buildQueryDoc('alert-3', {
+						receivedAt: buildTimestamp('2026-06-06T10:00:00.000Z'),
+						text: 'SPCFD:SPX(D) alert triggered',
+						enriched: false,
+						deliveryResults: [],
+						source: 'webhook',
+					}),
+					buildQueryDoc('alert-4', {
+						receivedAt: buildTimestamp('2026-06-06T09:00:00.000Z'),
+						text: 'Alerta sin simbolo',
+						enriched: false,
+						deliveryResults: [],
+						source: 'webhook',
+					}),
+				],
+			});
+
+			const result = await AlertStorageService.summarizeAlerts({
+				from: '2026-06-06T00:00:00.000Z',
+				to: '2026-06-07T00:00:00.000Z',
+			});
+
+			expect(result.bySymbol).toEqual({
+				ETHUSDT: 1,
+				TSM: 1,
+				SPX: 1,
+				unknown: 1,
+			});
+		});
+	});
+
+	describe('symbol extraction helpers', () => {
+		describe('parseSymbolFromText()', () => {
+			it('extracts symbol and exchange from deterministic TradingView alert formats', () => {
+				expect(AlertStorageService.parseSymbolFromText('BINANCE:ETHUSDT(D)')).toEqual({
+					symbol: 'ETHUSDT',
+					exchange: 'BINANCE',
+				});
+				expect(AlertStorageService.parseSymbolFromText('BATS:TSM(D)')).toEqual({
+					symbol: 'TSM',
+					exchange: 'BATS',
+				});
+				expect(AlertStorageService.parseSymbolFromText('SPCFD:SPX(D)')).toEqual({
+					symbol: 'SPX',
+					exchange: 'SPCFD',
+				});
+				expect(AlertStorageService.parseSymbolFromText('BATS:TSM(D) cambió a señal de VENTA')).toEqual({
+					symbol: 'TSM',
+					exchange: 'BATS',
+				});
+				expect(AlertStorageService.parseSymbolFromText('BINANCE:BTCUSDT')).toEqual({
+					symbol: 'BTCUSDT',
+					exchange: 'BINANCE',
+				});
+				expect(AlertStorageService.parseSymbolFromText('BTCUSDT(1h)')).toEqual({
+					symbol: 'BTCUSDT',
+					exchange: null,
+				});
+			});
+
+			it('returns null for unmatched text and safely falls back to unknown', () => {
+				expect(AlertStorageService.parseSymbolFromText('Alerta de prueba sin simbolo')).toBeNull();
+				expect(AlertStorageService.parseSymbolFromText('')).toBeNull();
+				expect(AlertStorageService.parseSymbolFromText(null)).toBeNull();
+			});
+		});
+
+		describe('extractSymbolAndExchange()', () => {
+			it('prefers candidate object properties when available', () => {
+				expect(AlertStorageService.extractSymbolAndExchange({ symbol: 'BATS:AAPL' })).toEqual({
+					symbol: 'AAPL',
+					exchange: 'BATS',
+				});
+				expect(AlertStorageService.extractSymbolAndExchange({
+					enrichmentData: { symbol: 'ETHUSDT', exchange: 'BINANCE' },
+				})).toEqual({
+					symbol: 'ETHUSDT',
+					exchange: 'BINANCE',
+				});
+			});
+
+			it('parses from raw alert text when candidate object properties are absent', () => {
+				expect(AlertStorageService.extractSymbolAndExchange({
+					text: 'BATS:TSM(D) cambió a señal de VENTA',
+				})).toEqual({
+					symbol: 'TSM',
+					exchange: 'BATS',
+				});
+			});
+
+			it('returns unknown symbol and null exchange when no symbol pattern matches', () => {
+				expect(AlertStorageService.extractSymbolAndExchange({ text: 'Not a symbol alert' })).toEqual({
+					symbol: 'unknown',
+					exchange: null,
+				});
+			});
+		});
 	});
 });


### PR DESCRIPTION
# feat(storage): extract symbol and exchange from raw alert text (CB-91)

## Summary
Enhance `AlertStorageService` symbol extraction logic to parse TradingView symbols and exchange prefixes directly from raw alert text when explicit object properties (`symbol`, `enrichmentData.symbol`) are absent, eliminating `unknown` symbol classification in stored alert analytics (`GET /api/alerts/summary`).

## Key Changes
- **Text Pattern Parsing**: Added `parseSymbolFromText` helper in `AlertStorageService.js` to extract symbols and exchanges from standard TradingView alert formats (`BATS:TSM(D)`, `BINANCE:ETHUSDT(4h)`, `SPCFD:SPX(D)`, `BTCUSDT(1h)`).
- **Symbol & Exchange Extraction**: Extended `extractSymbolAndExchange` to inspect candidate fields (`data.symbol`, `data.ticker`, `data.enrichmentData.symbol`), falling back to raw `data.text` parsing before returning `{ symbol: 'unknown', exchange: null }`.
- **Alert Persistence**: Updated `saveAlert` to extract and attach `symbol` and `exchange` properties to stored Firestore document payloads when valid patterns match.
- **Analytics & Unit Tests**: Added unit tests in `tests/unit/alert-storage-service.test.js` verifying symbol extraction from raw text strings across TradingView formats, and updated summary tests for `bySymbol` metrics.

## Testing
- Unit tests (`tests/unit/alert-storage-service.test.js`): All 46 tests passing.

## References
- **Linear**: [CB-91](https://linear.app/knil/issue/CB-91/implement-regex-symbol-extraction-in-alertstorageservice-and-webhook)
- Closes #222
