### PR TITLE
fix(news-monitor): exclude open Binance kline from volume ratio calculation (CB-93)

### DIFF
--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -154,13 +154,65 @@ function getKlineVolume(kline) {
 	return 0;
 }
 
-function calculateVolumeRatio(klines) {
+function isKlineOpen(kline, now = Date.now()) {
+	if (!kline) {
+		return false;
+	}
+
+	if (typeof kline === 'object' && !Array.isArray(kline)) {
+		if (typeof kline.isClosed === 'boolean') return !kline.isClosed;
+		if (typeof kline.closed === 'boolean') return !kline.closed;
+		if (typeof kline.open === 'boolean') return kline.open;
+		if (typeof kline.isComplete === 'boolean') return !kline.isComplete;
+
+		const closeTime = Number(kline.closeTime);
+		if (Number.isFinite(closeTime) && closeTime > 0) {
+			return now <= closeTime;
+		}
+
+		const openTime = Number(kline.openTime);
+		if (Number.isFinite(openTime) && openTime > 0) {
+			return now < openTime + 3600000;
+		}
+
+		return false;
+	}
+
+	if (Array.isArray(kline)) {
+		const closeTime = Number(kline[6]);
+		if (Number.isFinite(closeTime) && closeTime > 0) {
+			return now <= closeTime;
+		}
+
+		const openTime = Number(kline[0]);
+		if (Number.isFinite(openTime) && openTime > 0) {
+			return now < openTime + 3600000;
+		}
+
+		return false;
+	}
+
+	return false;
+}
+
+function calculateVolumeRatio(klines, options = {}) {
 	if (!Array.isArray(klines) || klines.length < 2) {
 		return null;
 	}
 
-	const latestVolume = getKlineVolume(klines[klines.length - 1]);
-	const previousKlines = klines.slice(0, klines.length - 1);
+	const now = typeof options === 'number' ? options : (options && options.now) || Date.now();
+
+	let completedKlines = klines;
+	while (completedKlines.length > 0 && isKlineOpen(completedKlines[completedKlines.length - 1], now)) {
+		completedKlines = completedKlines.slice(0, completedKlines.length - 1);
+	}
+
+	if (completedKlines.length < 2) {
+		return null;
+	}
+
+	const latestVolume = getKlineVolume(completedKlines[completedKlines.length - 1]);
+	const previousKlines = completedKlines.slice(0, completedKlines.length - 1);
 	const sumPreviousVolume = previousKlines.reduce((sum, k) => sum + getKlineVolume(k), 0);
 	const avgPreviousVolume = sumPreviousVolume / previousKlines.length;
 
@@ -994,4 +1046,5 @@ module.exports = {
 	setNotificationManager,
 	calculateVolumeRatio,
 	calculateRSI,
+	isKlineOpen,
 };

--- a/tests/unit/news-monitor-analyzer.test.js
+++ b/tests/unit/news-monitor-analyzer.test.js
@@ -41,6 +41,68 @@ describe('News Monitor Analyzer - Volume & RSI Filtering', () => {
 			const zeroKlines = [{ volume: '0' }, { volume: '0' }];
 			expect(calculateVolumeRatio(zeroKlines)).toBeNull();
 		});
+
+		it('should exclude currently open candle when calculating volume ratio', () => {
+			const now = 1722000000000;
+			const completedKlines = Array.from({ length: 10 }, (_, i) => ({
+				openTime: now - (11 - i) * 3600000,
+				closeTime: now - (10 - i) * 3600000 - 1,
+				volume: '100',
+			}));
+			// Partial open candle with low volume '10' currently forming
+			const openKline = {
+				openTime: now - 1800000,
+				closeTime: now + 1800000,
+				volume: '10',
+			};
+			const klines = [...completedKlines, openKline];
+
+			const ratio = calculateVolumeRatio(klines, { now });
+			expect(ratio).toBe(1.0);
+		});
+
+		it('should exclude open candle in array format klines [openTime, open, high, low, close, volume, closeTime]', () => {
+			const now = 1722000000000;
+			const completedKlines = Array.from({ length: 10 }, (_, i) => [
+				now - (11 - i) * 3600000,
+				'10',
+				'12',
+				'9',
+				'11',
+				'100',
+				now - (10 - i) * 3600000 - 1,
+			]);
+			const openKline = [
+				now - 1800000,
+				'10',
+				'12',
+				'9',
+				'11',
+				'15',
+				now + 1800000,
+			];
+			const klines = [...completedKlines, openKline];
+
+			const ratio = calculateVolumeRatio(klines, { now });
+			expect(ratio).toBe(1.0);
+		});
+
+		it('should return null if excluding open candle leaves fewer than 2 completed candles', () => {
+			const now = 1722000000000;
+			const singleCompleted = [
+				{
+					openTime: now - 3600000,
+					closeTime: now - 1,
+					volume: '100',
+				},
+				{
+					openTime: now - 1800000,
+					closeTime: now + 1800000,
+					volume: '10',
+				},
+			];
+			expect(calculateVolumeRatio(singleCompleted, { now })).toBeNull();
+		});
 	});
 
 	describe('calculateRSI', () => {


### PR DESCRIPTION
## Summary
The news-monitor volume ratio calculation was including the currently forming (open) Binance hourly kline, causing partial volume to improperly lower the volume ratio and trigger false low-volume penalties. This change identifies in-progress open klines and excludes them from the calculation contract.

## Key Changes
- Updated `calculateVolumeRatio` in `src/controllers/webhooks/handlers/newsMonitor/analyzer.js` to identify and exclude trailing open candles before calculating the volume ratio.
- Added `isKlineOpen` helper supporting both object and array format Binance klines with explicit boolean flags (`isClosed`, `closed`, `isComplete`) or `closeTime`/`openTime` timestamp comparisons.
- Exported `isKlineOpen` for reuse and direct testing.
- Added comprehensive unit test coverage in `tests/unit/news-monitor-analyzer.test.js` verifying open candles are excluded, partial volume false penalties are prevented, and insufficient completed kline data returns `null`.

## Technical Implementation
- `isKlineOpen(kline, now)` checks `closeTime` or `openTime` against `now` (default `Date.now()`).
- `calculateVolumeRatio` trims trailing open candles from `klines` array. If fewer than 2 completed candles remain, it returns `null` safely.
- Preserved existing fail-open behavior and compatibility with kline fixtures lacking timestamps.

## Testing
- Ran unit tests `pnpm test -- tests/unit/news-monitor-analyzer.test.js` (15 passing).
- Ran integration tests `pnpm test -- tests/integration/news-monitor-basic.test.js` (23 passing).

## References
- **GitHub Issue**: Fixes #235
- **Linear**: [CB-93](https://linear.app/knil/issue/CB-93/exclude-the-open-binance-kline-from-news-monitor-volume-ratio)
