### PR TITLE
fix: decouple Binance kline timeout from price fetch (CB-94)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1105,3 +1105,11 @@ Scanner presets support an independent `ENABLE_FIRESTORE_SCANNER_PRESETS=true` g
 - `src/controllers/status.js` and `src/controllers/webhooks/handlers/scannerPresets/scannerPresets.js` — Expose storage capability metadata without credentials.
 - `tests/unit/scanner-preset-service.test.js`, `tests/integration/scanner-presets-endpoint.test.js`, and `tests/integration/status-endpoint.test.js` — Cover independent persistence, restart simulation, disabled fallback, and Firestore write failure.
 - `README.md`, `.env.example`, `src/openapi/openapi.json`, and `CabrosBot.postman_collection.json` — Document configuration and response contracts.
+
+## Binance Kline Timeout Isolation (CB-94 / Issue #236)
+
+`NewsAnalyzer.fetchBinancePrice` gives the required Binance price and optional 1h kline enrichment independent five-second lifecycles. A successful `getAvgPrice` result is preserved when `getKlines` hangs, times out, or rejects; optional `volumeRatio` and `rsi` values remain `null`, and Gemini fallback is not triggered. Timer cleanup prevents completed requests from leaving timeout handles active.
+
+**Core Components**:
+- `src/controllers/webhooks/handlers/newsMonitor/analyzer.js` — Independent timeout races and fail-open kline handling.
+- `tests/unit/news-monitor-binance-timeout.test.js` — Regression coverage for a successful price with a never-resolving kline request.

--- a/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
+++ b/src/controllers/webhooks/handlers/newsMonitor/analyzer.js
@@ -588,23 +588,37 @@ class NewsAnalyzer {
 	 */
 	async fetchBinancePrice(symbol) {
 		try {
-			// Wrapper with timeout (~5s)
+			// Keep the price and optional indicator requests on independent 5s budgets.
 			const timeoutMs = 5000;
-			const timeoutPromise = new Promise((_, reject) =>
-				setTimeout(() => reject(new Error('Binance fetch timeout')), timeoutMs),
-			);
+			const runWithTimeout = (promise, fallback, timeoutMessage) => {
+				let timeoutHandle;
+				const timeoutPromise = new Promise((resolve, reject) => {
+					timeoutHandle = setTimeout(() => {
+						if (timeoutMessage) {
+							reject(new Error(timeoutMessage));
+							return;
+						}
+						resolve(fallback);
+					}, timeoutMs);
+				});
+
+				return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeoutHandle));
+			};
 
 			const client = getBinanceClient();
-			const pricePromise = client.getAvgPrice({ symbol });
+			const pricePromise = runWithTimeout(
+				client.getAvgPrice({ symbol }),
+				null,
+				'Binance price fetch timeout',
+			);
 			const klinesPromise = (typeof client.getKlines === 'function')
-				? client.getKlines({ symbol, interval: '1h', limit: 30 }).catch(() => null)
+				? runWithTimeout(
+					Promise.resolve().then(() => client.getKlines({ symbol, interval: '1h', limit: 30 })),
+					null,
+				).catch(() => null)
 				: Promise.resolve(null);
 
-			// Race between the fetch and timeout
-			const [data, klines] = await Promise.race([
-				Promise.all([pricePromise, klinesPromise]),
-				timeoutPromise,
-			]);
+			const [data, klines] = await Promise.all([pricePromise, klinesPromise]);
 
 			console.debug(`[Analyzer] Binance price for ${symbol}: $${data.price}`);
 

--- a/tests/unit/news-monitor-binance-timeout.test.js
+++ b/tests/unit/news-monitor-binance-timeout.test.js
@@ -1,0 +1,42 @@
+const mockGetAvgPrice = jest.fn();
+const mockGetKlines = jest.fn();
+
+jest.mock('binance', () => ({
+	MainClient: jest.fn().mockImplementation(() => ({
+		getAvgPrice: mockGetAvgPrice,
+		getKlines: mockGetKlines,
+	})),
+}));
+
+const { NewsAnalyzer } = require('../../src/controllers/webhooks/handlers/newsMonitor/analyzer');
+
+describe('News Monitor Analyzer - Binance timeout isolation', () => {
+	beforeEach(() => {
+		process.env.ENABLE_BINANCE_PRICE_CHECK = 'true';
+		mockGetAvgPrice.mockResolvedValue({ price: '42000' });
+		mockGetKlines.mockReturnValue(new Promise(() => {}));
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		delete process.env.ENABLE_BINANCE_PRICE_CHECK;
+		jest.useRealTimers();
+		jest.clearAllMocks();
+	});
+
+	it('returns a successful Binance price when optional klines exceed their timeout', async () => {
+		const analyzer = new NewsAnalyzer();
+		analyzer.fetchGeminiPrice = jest.fn();
+
+		const contextPromise = analyzer.getMarketContext('BTCUSDT');
+		await jest.advanceTimersByTimeAsync(5001);
+
+		await expect(contextPromise).resolves.toEqual(expect.objectContaining({
+			price: 42000,
+			source: 'binance',
+			volumeRatio: null,
+			rsi: null,
+		}));
+		expect(analyzer.fetchGeminiPrice).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION

## Summary

Preserve a successful Binance price when optional news-monitor kline enrichment hangs or times out.

## Key Changes

- Added a regression test covering a resolved price with a never-resolving kline request.
- Replaced the shared `Promise.all` timeout with independent bounded lifecycles for price and klines.
- Kept kline timeout and error handling fail-open, returning null optional indicators without invoking Gemini fallback.

## Technical Implementation

`NewsAnalyzer.fetchBinancePrice` now applies separate five-second races with timer cleanup. The price request remains the required result; kline failures resolve to null and do not discard the price.

## Testing

- `pnpm test -- tests/unit/news-monitor-binance-timeout.test.js --runInBand --verbose`
- `pnpm test -- tests/unit/news-monitor-analyzer.test.js --runInBand --verbose`
- `pnpm test -- tests/unit/analyzer.test.js --runInBand --verbose`
- `tests/integration/news-monitor-binance.test.js` was also exercised; it has an existing order-dependent setup failure where different GET cases intermittently return `400 INVALID_REQUEST` while the Binance timeout case passes.

## References

- GitHub Issue: [#236](https://github.com/francovp/cabros-bot/issues/236)
- Linear: [CB-94](https://linear.app/knil/issue/CB-94/decouple-binance-kline-timeout-from-news-monitor-price-fetch-gh-236)
- Merged implementation: [PR #229](https://github.com/francovp/cabros-bot/pull/229)
- Review discussion: [#3651630880](https://github.com/francovp/cabros-bot/pull/229#discussion_r3651630880)
