### PR TITLE
fix: make async jobs idempotent (CB-96)

### DIFF
--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -14,6 +14,11 @@
       "key": "apiKey",
       "value": "your-api-key-here",
       "type": "string"
+    },
+    {
+      "key": "jobIdempotencyKey",
+      "value": "job-request-001",
+      "type": "string"
     }
   ],
   "item": [
@@ -1746,6 +1751,11 @@
                 "key": "x-api-key",
                 "value": "{{apiKey}}",
                 "type": "text"
+              },
+              {
+                "key": "idempotency-key",
+                "value": "{{jobIdempotencyKey}}",
+                "type": "text"
               }
             ],
             "body": {
@@ -1765,6 +1775,24 @@
             }
           },
           "response": [
+            {
+              "name": "Idempotency Replay",
+              "status": "Created",
+              "code": 201,
+              "header": [
+                {
+                  "key": "Idempotency-Replay",
+                  "value": "true"
+                }
+              ],
+              "body": "{\n  \"success\": true,\n  \"jobId\": \"job-uuid-123\",\n  \"status\": \"processing\",\n  \"idempotencyReplayed\": true\n}"
+            },
+            {
+              "name": "Idempotency Key Conflict",
+              "status": "Conflict",
+              "code": 409,
+              "body": "{\n  \"error\": \"Idempotency key was reused with a different payload\",\n  \"code\": \"IDEMPOTENCY_CONFLICT\"\n}"
+            },
             {
               "name": "Create Job with Callback",
               "originalRequest": {
@@ -1889,6 +1917,11 @@
               {
                 "key": "x-api-key",
                 "value": "{{apiKey}}",
+                "type": "text"
+              },
+              {
+                "key": "idempotency-key",
+                "value": "{{jobIdempotencyKey}}",
                 "type": "text"
               }
             ],
@@ -2034,6 +2067,11 @@
                 "key": "x-api-key",
                 "value": "{{apiKey}}",
                 "type": "text"
+              },
+              {
+                "key": "idempotency-key",
+                "value": "{{jobIdempotencyKey}}",
+                "type": "text"
               }
             ],
             "body": {
@@ -2066,6 +2104,11 @@
               {
                 "key": "x-api-key",
                 "value": "{{apiKey}}",
+                "type": "text"
+              },
+              {
+                "key": "idempotency-key",
+                "value": "{{jobIdempotencyKey}}",
                 "type": "text"
               }
             ],
@@ -2153,6 +2196,11 @@
                 "key": "x-api-key",
                 "value": "{{apiKey}}",
                 "type": "text"
+              },
+              {
+                "key": "idempotency-key",
+                "value": "{{jobIdempotencyKey}}",
+                "type": "text"
               }
             ],
             "url": {
@@ -2167,7 +2215,22 @@
                 "retry"
               ]
             }
-          }
+          },
+          "response": [
+            {
+              "name": "Retry Replay",
+              "status": "Created",
+              "code": 201,
+              "header": [{ "key": "Idempotency-Replay", "value": "true" }],
+              "body": "{\n  \"success\": true,\n  \"oldJobId\": \"job-uuid-123\",\n  \"newJobId\": \"job-uuid-456\",\n  \"status\": \"processing\",\n  \"idempotencyReplayed\": true\n}"
+            },
+            {
+              "name": "Retry Idempotency Conflict",
+              "status": "Conflict",
+              "code": 409,
+              "body": "{\n  \"error\": \"Idempotency key was reused with a different payload\",\n  \"code\": \"IDEMPOTENCY_CONFLICT\"\n}"
+            }
+          ]
         },
         {
           "name": "POST Retry Failed Job",
@@ -2177,6 +2240,11 @@
               {
                 "key": "x-api-key",
                 "value": "{{apiKey}}",
+                "type": "text"
+              },
+              {
+                "key": "idempotency-key",
+                "value": "{{jobIdempotencyKey}}",
                 "type": "text"
               }
             ],
@@ -2192,7 +2260,22 @@
                 "retry-failed"
               ]
             }
-          }
+          },
+          "response": [
+            {
+              "name": "Retry Failed Replay",
+              "status": "Created",
+              "code": 201,
+              "header": [{ "key": "Idempotency-Replay", "value": "true" }],
+              "body": "{\n  \"success\": true,\n  \"oldJobId\": \"job-uuid-123\",\n  \"newJobId\": \"job-uuid-789\",\n  \"status\": \"processing\",\n  \"idempotencyReplayed\": true\n}"
+            },
+            {
+              "name": "Retry Failed Idempotency Conflict",
+              "status": "Conflict",
+              "code": 409,
+              "body": "{\n  \"error\": \"Idempotency key was reused with a different payload\",\n  \"code\": \"IDEMPOTENCY_CONFLICT\"\n}"
+            }
+          ]
         }
       ]
     }

--- a/CabrosBot.postman_collection.json
+++ b/CabrosBot.postman_collection.json
@@ -16,8 +16,33 @@
       "type": "string"
     },
     {
-      "key": "jobIdempotencyKey",
-      "value": "job-request-001",
+      "key": "jobCreateIdempotencyKey",
+      "value": "job-create-001",
+      "type": "string"
+    },
+    {
+      "key": "jobCreateCallbackIdempotencyKey",
+      "value": "job-create-callback-001",
+      "type": "string"
+    },
+    {
+      "key": "jobScannerIdempotencyKey",
+      "value": "job-scanner-001",
+      "type": "string"
+    },
+    {
+      "key": "jobScannerCallbackIdempotencyKey",
+      "value": "job-scanner-callback-001",
+      "type": "string"
+    },
+    {
+      "key": "jobRetryIdempotencyKey",
+      "value": "job-retry-001",
+      "type": "string"
+    },
+    {
+      "key": "jobRetryFailedIdempotencyKey",
+      "value": "job-retry-failed-001",
       "type": "string"
     }
   ],
@@ -1754,7 +1779,7 @@
               },
               {
                 "key": "idempotency-key",
-                "value": "{{jobIdempotencyKey}}",
+                "value": "{{jobCreateIdempotencyKey}}",
                 "type": "text"
               }
             ],
@@ -1921,7 +1946,7 @@
               },
               {
                 "key": "idempotency-key",
-                "value": "{{jobIdempotencyKey}}",
+                "value": "{{jobCreateCallbackIdempotencyKey}}",
                 "type": "text"
               }
             ],
@@ -2070,7 +2095,7 @@
               },
               {
                 "key": "idempotency-key",
-                "value": "{{jobIdempotencyKey}}",
+                "value": "{{jobScannerIdempotencyKey}}",
                 "type": "text"
               }
             ],
@@ -2108,7 +2133,7 @@
               },
               {
                 "key": "idempotency-key",
-                "value": "{{jobIdempotencyKey}}",
+                "value": "{{jobScannerCallbackIdempotencyKey}}",
                 "type": "text"
               }
             ],
@@ -2199,7 +2224,7 @@
               },
               {
                 "key": "idempotency-key",
-                "value": "{{jobIdempotencyKey}}",
+                "value": "{{jobRetryIdempotencyKey}}",
                 "type": "text"
               }
             ],
@@ -2244,7 +2269,7 @@
               },
               {
                 "key": "idempotency-key",
-                "value": "{{jobIdempotencyKey}}",
+                "value": "{{jobRetryFailedIdempotencyKey}}",
                 "type": "text"
               }
             ],

--- a/README.md
+++ b/README.md
@@ -736,6 +736,20 @@ For market-scanner jobs, `ranked` and `includeMultiTimeframe` use the same scori
 }
 ```
 
+**Idempotency:** `POST /api/jobs/tradingview-analysis`, `POST /api/jobs/:jobId/retry`, and `POST /api/jobs/:jobId/retry-failed` accept an optional client-generated `idempotency-key` header. Matching concurrent or sequential requests replay the original response and `jobId`/`newJobId` without starting another worker. The first response sends `Idempotency-Replay: false`; a replay sends `Idempotency-Replay: true` and includes `"idempotencyReplayed": true` in the JSON response. Reusing a key with a different request fingerprint returns `409 IDEMPOTENCY_CONFLICT`. Requests without the header retain current behavior.
+
+Example:
+```http
+POST /api/jobs/tradingview-analysis
+idempotency-key: job-create-2026-07-26-001
+```
+
+The idempotency cache is in-memory, bounded, and retained for five minutes by default (`WEBHOOK_IDEMPOTENCY_TTL_MS` can override the TTL).
+
+#### POST /api/jobs/:jobId/retry and /api/jobs/:jobId/retry-failed
+
+Retry a cancelled/failed job or only its failed items. Supply the same `idempotency-key` when retrying a request after a timeout or lost response to receive the original `newJobId` instead of creating another background job.
+
 When `callbackUrl` is configured, each callback POST includes:
 
 - `x-callback-timestamp` - ISO-8601 delivery timestamp; reject stale values outside your freshness window.

--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ POST /api/jobs/tradingview-analysis
 idempotency-key: job-create-2026-07-26-001
 ```
 
-The idempotency cache is in-memory, bounded, and retained for five minutes by default (`WEBHOOK_IDEMPOTENCY_TTL_MS` can override the TTL).
+The idempotency cache is in-memory, bounded, and retained for five minutes by default (`WEBHOOK_IDEMPOTENCY_TTL_MS` can override the TTL). Request fingerprints canonicalize nested object key order while preserving array order.
 
 #### POST /api/jobs/:jobId/retry and /api/jobs/:jobId/retry-failed
 

--- a/agents.md
+++ b/agents.md
@@ -416,9 +416,10 @@ The system provides a `POST /api/webhook/market-scanner-alert` endpoint that run
 The system provides asynchronous job endpoints to support executing both `expanded-analysis` and `market-scanner` workflows in the background, avoiding HTTP gateway timeouts.
 
 **Endpoints**:
-- `POST /api/jobs/tradingview-analysis` — Validates request payloads synchronously, returns `201 Created` with a `jobId`, and starts background execution.
+- `POST /api/jobs/tradingview-analysis` — Validates request payloads synchronously, returns `201 Created` with a `jobId`, and starts background execution. An optional `idempotency-key` header deduplicates concurrent/sequential starts for five minutes.
 - `GET /api/jobs` — Returns a bounded list of sanitized recent jobs, with optional `status`, `type`, and `limit` filters. It merges Firestore-backed records with the in-memory fallback and excludes expired terminal jobs.
 - `GET /api/jobs/:jobId` — Returns the current job status (`pending`, `processing`, `completed`, `failed`), progress, and final analysis/delivery outcomes.
+- `POST /api/jobs/:jobId/retry` and `POST /api/jobs/:jobId/retry-failed` — Recreate a retryable job or only failed items; the same optional `idempotency-key` replay contract returns the original `newJobId` without a second worker.
 
 **Core Components**:
 - `src/services/jobs/JobService.js` — Coordinates job state tracking, background worker execution, progress reports, durable persistence checkpoints, and job eviction (jobs older than 1 hour).
@@ -428,6 +429,7 @@ The system provides asynchronous job endpoints to support executing both `expand
 
 **Failure and Edge Case Behavior**:
 - Sync validation: throws `400` synchronously on invalid inputs before job registration.
+- Idempotency: job-starting POST endpoints reserve the optional `idempotency-key` before validation/worker launch, replay matching responses with `Idempotency-Replay: true` and `idempotencyReplayed: true`, and return `409 IDEMPOTENCY_CONFLICT` when a key is reused with a different request fingerprint. Requests without a key are unchanged.
 - Feature checks: returns `404 FEATURE_DISABLED` if market scanner jobs are created but `ENABLE_MARKET_SCANNER` is not `'true'`.
 - Persistence: `createJob()` and `getJob()` are async because job metadata/results may be written to or read from Firestore.
 - Telegram commands: async `createJob()` rejections must stay inside the command `try/catch` so `replyValidationError()` can return clear command feedback instead of producing unhandled promise rejections.
@@ -739,6 +741,7 @@ See `/specs/TERMINOLOGY_GUIDE.md` for extended discussion and examples.
 - GH-178 / CB-74: `ENABLE_SIGNAL_OUTCOME_TRACKING` is the canonical signal-outcome gate; `ENABLE_SHADOW_MODE_OUTCOME_TRACKING` remains a one-release compatibility alias, and `/api/capabilities` reports the effective gate.
 - GH-182 / CB-77: malformed or no-domain grounding sources count toward the declared UNKNOWN `0.5` quality tier instead of contributing zero; regression coverage lives in `tests/unit/event-detection.test.js`.
 - GH-187 / CB-79: added authenticated `GET /api/jobs` with bounded `status`, `type`, and `limit` filters; `JobRepository.list()` merges Firestore and memory records, while `JobService.listJobs()` omits expired terminal jobs and returns metadata-only summaries.
+- GH-239 / CB-96: job creation, retry, and retry-failed endpoints now use the shared bounded in-memory idempotency middleware, replay matching responses, and reject fingerprint conflicts with `409 IDEMPOTENCY_CONFLICT`; OpenAPI, README, Postman, and integration coverage were updated.
 - GH-183 / CB-78: Azure, OpenRouter, and Cloudflare `llmCallv2()` results now return normalized token usage for downstream `tokenUsage` aggregation; the shared normalizer accepts OpenAI-compatible `prompt_tokens`, `completion_tokens`, and `total_tokens` fields.
 - GH-199 / CB-83: `detect-unused-features` derives disabled flags, status mappings, indirect env lookups, `.env.example` gaps, and Sentry profiling findings from the fresh protected capabilities response and current repository files; dated snapshots are guidance-free and a healthy-data dry run guards against stale issues.
 

--- a/agents.md
+++ b/agents.md
@@ -429,7 +429,7 @@ The system provides asynchronous job endpoints to support executing both `expand
 
 **Failure and Edge Case Behavior**:
 - Sync validation: throws `400` synchronously on invalid inputs before job registration.
-- Idempotency: job-starting POST endpoints reserve the optional `idempotency-key` before validation/worker launch, replay matching responses with `Idempotency-Replay: true` and `idempotencyReplayed: true`, and return `409 IDEMPOTENCY_CONFLICT` when a key is reused with a different request fingerprint. Requests without a key are unchanged.
+- Idempotency: job-starting POST endpoints reserve the optional `idempotency-key` before validation/worker launch, replay matching responses with `Idempotency-Replay: true` and `idempotencyReplayed: true`, and return `409 IDEMPOTENCY_CONFLICT` when a key is reused with a different request fingerprint. Nested object keys are canonicalized for the fingerprint while array order remains significant. Requests without a key are unchanged.
 - Feature checks: returns `404 FEATURE_DISABLED` if market scanner jobs are created but `ENABLE_MARKET_SCANNER` is not `'true'`.
 - Persistence: `createJob()` and `getJob()` are async because job metadata/results may be written to or read from Firestore.
 - Telegram commands: async `createJob()` rejections must stay inside the command `try/catch` so `replyValidationError()` can return clear command feedback instead of producing unhandled promise rejections.

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -144,8 +144,9 @@
     "/api/jobs/tradingview-analysis": {
       "post": {
         "tags": ["Jobs"], "summary": "Create an asynchronous TradingView job", "operationId": "createTradingViewJob",
+        "parameters": [{ "$ref": "#/components/parameters/IdempotencyKey" }],
         "requestBody": { "$ref": "#/components/requestBodies/TradingViewJob" },
-        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/IdempotencyConflict" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
     },
@@ -176,16 +177,16 @@
     "/api/jobs/{jobId}/retry": {
       "post": {
         "tags": ["Jobs"], "summary": "Retry a failed job", "operationId": "retryJob",
-        "parameters": [{ "$ref": "#/components/parameters/JobId" }],
-        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "parameters": [{ "$ref": "#/components/parameters/JobId" }, { "$ref": "#/components/parameters/IdempotencyKey" }],
+        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/IdempotencyConflict" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
     },
     "/api/jobs/{jobId}/retry-failed": {
       "post": {
         "tags": ["Jobs"], "summary": "Retry failed items in a completed job", "operationId": "retryFailedJobItems",
-        "parameters": [{ "$ref": "#/components/parameters/JobId" }],
-        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" } },
+        "parameters": [{ "$ref": "#/components/parameters/JobId" }, { "$ref": "#/components/parameters/IdempotencyKey" }],
+        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/IdempotencyConflict" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
     },
@@ -227,6 +228,7 @@
       "AlertId": { "name": "alertId", "in": "path", "required": true, "schema": { "type": "string" }, "example": "alert-123" },
       "PresetId": { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } },
       "JobId": { "name": "jobId", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } },
+      "IdempotencyKey": { "name": "idempotency-key", "in": "header", "required": false, "schema": { "type": "string", "minLength": 1 }, "description": "Optional client-generated key. Matching concurrent or sequential requests replay the original response and jobId; reuse with a different request fingerprint returns 409 IDEMPOTENCY_CONFLICT. The response includes Idempotency-Replay: false for the first request and true for a replay." },
       "DryRun": { "name": "dryRun", "in": "query", "schema": { "type": "boolean", "default": false } },
       "UseTradingViewData": { "name": "useTradingViewData", "in": "query", "schema": { "type": "boolean", "default": false } },
       "AlertListLimit": { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 } },
@@ -261,6 +263,7 @@
     "responses": {
       "Unauthorized": { "description": "API key rejected", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Unauthorized", "code": "UNAUTHORIZED" } } } },
       "Error": { "description": "Request or service error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Invalid request", "code": "INVALID_REQUEST" } } } },
+      "IdempotencyConflict": { "description": "The idempotency key was reused with a different request fingerprint", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Idempotency key was reused with a different payload", "code": "IDEMPOTENCY_CONFLICT" } } } },
       "JsonResult": { "description": "Successful JSON response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonObject" } } } },
       "ScannerPresetResult": { "description": "Scanner preset response including the effective durable or ephemeral storage mode", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ScannerPresetResponse" }, "examples": { "durable": { "value": { "success": true, "storage": { "enabled": true, "configured": true, "ready": true, "status": "ready", "mode": "durable", "backend": "firestore" }, "preset": { "id": "83d1a85e-d433-4aa1-96b9-e62468bf0397", "name": "Daily Scan", "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers"], "limit": 5, "bbwThreshold": 0.05 } } }, "ephemeral": { "value": { "success": true, "storage": { "enabled": true, "configured": false, "ready": false, "status": "misconfigured", "mode": "ephemeral", "backend": "memory" }, "preset": { "id": "83d1a85e-d433-4aa1-96b9-e62468bf0397", "name": "Fallback scan" } } } } } } },
       "DeliveryResult": { "description": "Per-channel delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DeliveryResult" }, "example": { "success": true, "results": [{ "channel": "telegram", "success": true }] } } } },
@@ -361,6 +364,7 @@
         "type": "object",
         "properties": {
           "success": { "type": "boolean" },
+          "idempotencyReplayed": { "type": "boolean", "description": "Present and true when the response was replayed from a matching idempotency key." },
           "jobId": { "type": "string", "format": "uuid" },
           "type": { "type": "string", "enum": ["expanded-analysis", "market-scanner"] },
           "status": {

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -178,7 +178,7 @@
       "post": {
         "tags": ["Jobs"], "summary": "Retry a failed job", "operationId": "retryJob",
         "parameters": [{ "$ref": "#/components/parameters/JobId" }, { "$ref": "#/components/parameters/IdempotencyKey" }],
-        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/IdempotencyConflict" }, "500": { "$ref": "#/components/responses/Error" } },
+        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/JobConflict" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
     },
@@ -186,7 +186,7 @@
       "post": {
         "tags": ["Jobs"], "summary": "Retry failed items in a completed job", "operationId": "retryFailedJobItems",
         "parameters": [{ "$ref": "#/components/parameters/JobId" }, { "$ref": "#/components/parameters/IdempotencyKey" }],
-        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/IdempotencyConflict" }, "500": { "$ref": "#/components/responses/Error" } },
+        "responses": { "201": { "$ref": "#/components/responses/JobResult" }, "400": { "$ref": "#/components/responses/Error" }, "404": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/JobConflict" }, "500": { "$ref": "#/components/responses/Error" } },
         "security": [{ "ApiKeyHeader": [] }, { "ApiKeyQuery": [] }]
       }
     },
@@ -264,6 +264,7 @@
       "Unauthorized": { "description": "API key rejected", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Unauthorized", "code": "UNAUTHORIZED" } } } },
       "Error": { "description": "Request or service error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Invalid request", "code": "INVALID_REQUEST" } } } },
       "IdempotencyConflict": { "description": "The idempotency key was reused with a different request fingerprint", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "example": { "error": "Idempotency key was reused with a different payload", "code": "IDEMPOTENCY_CONFLICT" } } } },
+      "JobConflict": { "description": "A job retry conflict, either because the job is not retryable or because the idempotency key conflicts with an earlier request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" }, "examples": { "idempotency": { "summary": "Idempotency key conflict", "value": { "error": "Idempotency key was reused with a different payload", "code": "IDEMPOTENCY_CONFLICT" } }, "notRetryable": { "summary": "Job is not retryable", "value": { "success": false, "error": "Job cannot be retried. Current status: completed", "code": "NOT_RETRYABLE" } }, "jobActive": { "summary": "Job is still processing", "value": { "success": false, "error": "Cannot retry a currently processing job.", "code": "JOB_ACTIVE" } }, "missingMetadata": { "summary": "Job metadata is unavailable", "value": { "success": false, "error": "Missing job request metadata for retry.", "code": "MISSING_METADATA" } } } } } },
       "JsonResult": { "description": "Successful JSON response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonObject" } } } },
       "ScannerPresetResult": { "description": "Scanner preset response including the effective durable or ephemeral storage mode", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ScannerPresetResponse" }, "examples": { "durable": { "value": { "success": true, "storage": { "enabled": true, "configured": true, "ready": true, "status": "ready", "mode": "durable", "backend": "firestore" }, "preset": { "id": "83d1a85e-d433-4aa1-96b9-e62468bf0397", "name": "Daily Scan", "exchange": "BINANCE", "timeframe": "4h", "scans": ["top_gainers"], "limit": 5, "bbwThreshold": 0.05 } } }, "ephemeral": { "value": { "success": true, "storage": { "enabled": true, "configured": false, "ready": false, "status": "misconfigured", "mode": "ephemeral", "backend": "memory" }, "preset": { "id": "83d1a85e-d433-4aa1-96b9-e62468bf0397", "name": "Fallback scan" } } } } } } },
       "DeliveryResult": { "description": "Per-channel delivery result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DeliveryResult" }, "example": { "success": true, "results": [{ "channel": "telegram", "success": true }] } } } },

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -45,12 +45,12 @@ function getRoutes(botOrGetter) {
 	router.post('/scanner-presets/:id/run', validateApiKey, postRunPreset(botOrGetter));
 
 	// Async job endpoints
-	router.post('/jobs/tradingview-analysis', validateApiKey, postCreateJob(botOrGetter));
+	router.post('/jobs/tradingview-analysis', validateApiKey, idempotencyMiddleware, postCreateJob(botOrGetter));
 	router.get('/jobs', validateApiKey, getJobList);
 	router.get('/jobs/:jobId', validateApiKey, getJobStatus);
 	router.post('/jobs/:jobId/cancel', validateApiKey, postCancelJob);
-	router.post('/jobs/:jobId/retry', validateApiKey, postRetryJob(botOrGetter));
-	router.post('/jobs/:jobId/retry-failed', validateApiKey, postRetryFailedJob(botOrGetter));
+	router.post('/jobs/:jobId/retry', validateApiKey, idempotencyMiddleware, postRetryJob(botOrGetter));
+	router.post('/jobs/:jobId/retry-failed', validateApiKey, idempotencyMiddleware, postRetryFailedJob(botOrGetter));
 
 	const { getNewsMonitor } = require('../controllers/webhooks/handlers/newsMonitor/newsMonitor');
 	const newsMonitor = getNewsMonitor();

--- a/src/services/storage/IdempotencyService.js
+++ b/src/services/storage/IdempotencyService.js
@@ -67,6 +67,29 @@ class IdempotencyService {
 	}
 
 	/**
+	 * Canonicalize JSON-compatible payloads so object member order does not
+	 * change the idempotency fingerprint while array order remains significant.
+	 * @param {any} payload
+	 * @returns {any}
+	 */
+	canonicalizePayload(payload) {
+		if (Array.isArray(payload)) {
+			return payload.map((item) => this.canonicalizePayload(item));
+		}
+
+		if (payload && typeof payload === 'object') {
+			return Object.keys(payload)
+				.sort()
+				.reduce((canonical, key) => {
+					canonical[key] = this.canonicalizePayload(payload[key]);
+					return canonical;
+				}, {});
+		}
+
+		return payload;
+	}
+
+	/**
 	 * Hash the request body/payload to verify it hasn't changed on retry
 	 * @param {any} payload
 	 * @returns {string} SHA-256 hash of serialized payload
@@ -74,7 +97,7 @@ class IdempotencyService {
 	hashPayload(payload) {
 		const serialized = typeof payload === 'string'
 			? payload
-			: JSON.stringify(payload || {});
+			: JSON.stringify(this.canonicalizePayload(payload || {}));
 		return crypto.createHash('sha256').update(serialized).digest('hex');
 	}
 

--- a/tests/integration/jobs-endpoint.test.js
+++ b/tests/integration/jobs-endpoint.test.js
@@ -132,6 +132,30 @@ describe('Jobs API Integration Tests', () => {
 		expect(replayResponse.body.idempotencyReplayed).toBe(true);
 	});
 
+	it('replays a job request when equivalent object keys arrive in a different order', async () => {
+		tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValue({
+			symbol: 'BINANCE:BTCUSDT',
+			price_data: { close: 65000, change_percent: 1.5 },
+			rsi: { value: 45 },
+		});
+
+		const firstResponse = await request(app)
+			.post('/api/jobs/tradingview-analysis')
+			.set('x-api-key', 'test-key')
+			.set('idempotency-key', 'job-create-reordered-key')
+			.send({ type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] })
+			.expect(201);
+		const replayResponse = await request(app)
+			.post('/api/jobs/tradingview-analysis')
+			.set('x-api-key', 'test-key')
+			.set('idempotency-key', 'job-create-reordered-key')
+			.send({ symbols: ['BINANCE:BTCUSDT'], type: 'expanded-analysis' })
+			.expect(201);
+
+		expect(replayResponse.body.jobId).toBe(firstResponse.body.jobId);
+		expect(replayResponse.body.idempotencyReplayed).toBe(true);
+	});
+
 	it('deduplicates concurrent retries of the same cancelled job', async () => {
 		const timestamp = new Date().toISOString();
 		await jobRepository.save({

--- a/tests/integration/jobs-endpoint.test.js
+++ b/tests/integration/jobs-endpoint.test.js
@@ -8,6 +8,7 @@ const { initializeNotificationServices } = require('../../src/controllers/webhoo
 const { tradingViewMcpService } = require('../../src/services/tradingview/TradingViewMcpService');
 const { jobRepository, _resetForTesting: resetJobRepository } = require('../../src/services/jobs/JobRepository');
 const alertStorageService = require('../../src/services/storage/AlertStorageService');
+const { idempotencyService } = require('../../src/services/storage/IdempotencyService');
 
 jest.mock('../../src/services/tradingview/TradingViewMcpService', () => ({
 	tradingViewMcpService: {
@@ -38,6 +39,7 @@ describe('Jobs API Integration Tests', () => {
 		admin.__resetCollectionState();
 		alertStorageService._resetForTesting();
 		resetJobRepository();
+		idempotencyService.clear();
 
 		mockTelegramSendMessage = jest.fn().mockResolvedValue({ message_id: 'job-msg-id' });
 		mockBot = {
@@ -70,6 +72,172 @@ describe('Jobs API Integration Tests', () => {
 			.post('/api/jobs/tradingview-analysis')
 			.send({ type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] })
 			.expect(401);
+	});
+
+	it('deduplicates concurrent job creation with one idempotency key', async () => {
+		tradingViewMcpService.analyzeSymbolIdentifier.mockImplementation(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			return {
+				symbol: 'BINANCE:BTCUSDT',
+				price_data: { close: 65000, change_percent: 1.5 },
+				rsi: { value: 45 },
+			};
+		});
+
+		const payload = { type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] };
+		const [firstResponse, replayResponse] = await Promise.all([
+			request(app)
+				.post('/api/jobs/tradingview-analysis')
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', 'job-create-concurrent-key')
+				.send(payload),
+			request(app)
+				.post('/api/jobs/tradingview-analysis')
+				.set('x-api-key', 'test-key')
+				.set('idempotency-key', 'job-create-concurrent-key')
+				.send(payload),
+		]);
+
+		expect(firstResponse.status).toBe(201);
+		expect(replayResponse.status).toBe(201);
+		expect(firstResponse.body.jobId).toBe(replayResponse.body.jobId);
+		expect([firstResponse.headers['idempotency-replay'], replayResponse.headers['idempotency-replay']].sort()).toEqual(['false', 'true']);
+
+		await new Promise((resolve) => setTimeout(resolve, 75));
+		expect(tradingViewMcpService.analyzeSymbolIdentifier).toHaveBeenCalledTimes(1);
+	});
+
+	it('replays sequential job creation instead of starting a second job', async () => {
+		tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValue({
+			symbol: 'BINANCE:BTCUSDT',
+			price_data: { close: 65000, change_percent: 1.5 },
+			rsi: { value: 45 },
+		});
+
+		const payload = { type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] };
+		const firstResponse = await request(app)
+			.post('/api/jobs/tradingview-analysis')
+			.set('x-api-key', 'test-key')
+			.set('idempotency-key', 'job-create-sequential-key')
+			.send(payload)
+			.expect(201);
+		const replayResponse = await request(app)
+			.post('/api/jobs/tradingview-analysis')
+			.set('x-api-key', 'test-key')
+			.set('idempotency-key', 'job-create-sequential-key')
+			.send(payload)
+			.expect(201);
+
+		expect(replayResponse.body.jobId).toBe(firstResponse.body.jobId);
+		expect(replayResponse.body.idempotencyReplayed).toBe(true);
+	});
+
+	it('deduplicates concurrent retries of the same cancelled job', async () => {
+		const timestamp = new Date().toISOString();
+		await jobRepository.save({
+			jobId: 'cancelled-job-for-retry',
+			type: 'expanded-analysis',
+			status: 'cancelled',
+			requestMetadata: {
+				type: 'expanded-analysis',
+				symbols: ['BINANCE:BTCUSDT'],
+				timeframe: '1D',
+				includeMultiTimeframe: false,
+				analysisMode: 'standard',
+				timeoutMs: 120000,
+				callbackUrl: null,
+				callbackSecret: null,
+				callbackEvents: ['completed', 'failed', 'cancelled', 'timed_out'],
+			},
+			progress: { total: 1, current: 1, status: 'Cancelled' },
+			fullResults: [],
+			fullScanResults: [],
+			createdAt: timestamp,
+			updatedAt: timestamp,
+		});
+
+		tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValue({
+			symbol: 'BINANCE:BTCUSDT',
+			price_data: { close: 65000, change_percent: 1.5 },
+			rsi: { value: 45 },
+		});
+
+		const retryRequest = () => request(app)
+			.post('/api/jobs/cancelled-job-for-retry/retry')
+			.set('x-api-key', 'test-key')
+			.set('idempotency-key', 'job-retry-concurrent-key');
+		const [firstResponse, replayResponse] = await Promise.all([retryRequest(), retryRequest()]);
+
+		expect(firstResponse.status).toBe(201);
+		expect(replayResponse.status).toBe(201);
+		expect(firstResponse.body.newJobId).toBe(replayResponse.body.newJobId);
+		expect([firstResponse.headers['idempotency-replay'], replayResponse.headers['idempotency-replay']].sort()).toEqual(['false', 'true']);
+	});
+
+	it('deduplicates concurrent retries of failed items', async () => {
+		const timestamp = new Date().toISOString();
+		await jobRepository.save({
+			jobId: 'failed-job-for-item-retry',
+			type: 'expanded-analysis',
+			status: 'failed',
+			requestMetadata: {
+				type: 'expanded-analysis',
+				symbols: ['BINANCE:BTCUSDT', 'BINANCE:ETHUSDT'],
+				timeframe: '1D',
+				includeMultiTimeframe: false,
+				analysisMode: 'standard',
+				timeoutMs: 120000,
+				callbackUrl: null,
+				callbackSecret: null,
+				callbackEvents: ['completed', 'failed', 'cancelled', 'timed_out'],
+			},
+			progress: { total: 2, current: 2, status: 'Failed' },
+			fullResults: [{ symbol: 'BINANCE:BTCUSDT', status: 'analyzed' }],
+			fullScanResults: [],
+			createdAt: timestamp,
+			updatedAt: timestamp,
+		});
+
+		tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValue({
+			symbol: 'BINANCE:ETHUSDT',
+			price_data: { close: 3500, change_percent: 1.5 },
+			rsi: { value: 45 },
+		});
+
+		const retryRequest = () => request(app)
+			.post('/api/jobs/failed-job-for-item-retry/retry-failed')
+			.set('x-api-key', 'test-key')
+			.set('idempotency-key', 'job-retry-failed-concurrent-key');
+		const [firstResponse, replayResponse] = await Promise.all([retryRequest(), retryRequest()]);
+
+		expect(firstResponse.status).toBe(201);
+		expect(replayResponse.status).toBe(201);
+		expect(firstResponse.body.newJobId).toBe(replayResponse.body.newJobId);
+		expect([firstResponse.headers['idempotency-replay'], replayResponse.headers['idempotency-replay']].sort()).toEqual(['false', 'true']);
+	});
+
+	it('rejects an idempotency key reused with a different job request', async () => {
+		tradingViewMcpService.analyzeSymbolIdentifier.mockResolvedValue({
+			symbol: 'BINANCE:BTCUSDT',
+			price_data: { close: 65000, change_percent: 1.5 },
+			rsi: { value: 45 },
+		});
+
+		await request(app)
+			.post('/api/jobs/tradingview-analysis')
+			.set('x-api-key', 'test-key')
+			.set('idempotency-key', 'job-conflict-key')
+			.send({ type: 'expanded-analysis', symbols: ['BINANCE:BTCUSDT'] })
+			.expect(201);
+
+		const conflictResponse = await request(app)
+			.post('/api/jobs/tradingview-analysis')
+			.set('x-api-key', 'test-key')
+			.set('idempotency-key', 'job-conflict-key')
+			.send({ type: 'expanded-analysis', symbols: ['BINANCE:ETHUSDT'] })
+			.expect(409);
+
+		expect(conflictResponse.body.code).toBe('IDEMPOTENCY_CONFLICT');
 	});
 
 	it('returns 401 when GET /api/jobs/:jobId lacks valid api key', async () => {

--- a/tests/unit/idempotency.test.js
+++ b/tests/unit/idempotency.test.js
@@ -45,6 +45,24 @@ describe('Idempotency Service & Middleware', () => {
 			}).toThrow('Idempotency key was reused with a different payload');
 		});
 
+		test('should canonicalize nested object keys while preserving array order', () => {
+			const firstPayload = {
+				body: { type: 'expanded-analysis', options: { timeframe: '1D', mode: 'standard' }, symbols: ['BINANCE:BTCUSDT', 'BINANCE:ETHUSDT'] },
+				query: {},
+			};
+			const equivalentPayload = {
+				query: {},
+				body: { symbols: ['BINANCE:BTCUSDT', 'BINANCE:ETHUSDT'], options: { mode: 'standard', timeframe: '1D' }, type: 'expanded-analysis' },
+			};
+			const reorderedArrayPayload = {
+				body: { type: 'expanded-analysis', options: { timeframe: '1D', mode: 'standard' }, symbols: ['BINANCE:ETHUSDT', 'BINANCE:BTCUSDT'] },
+				query: {},
+			};
+
+			expect(idempotencyService.hashPayload(firstPayload)).toBe(idempotencyService.hashPayload(equivalentPayload));
+			expect(idempotencyService.hashPayload(firstPayload)).not.toBe(idempotencyService.hashPayload(reorderedArrayPayload));
+		});
+
 		test('should honor custom TTL from environment', () => {
 			process.env.WEBHOOK_IDEMPOTENCY_TTL_MS = '1000';
 			expect(idempotencyService.getTtlMs()).toBe(1000);


### PR DESCRIPTION
## Summary

Prevent duplicate asynchronous TradingView analysis or scanner workers when clients retry a job-start request after a lost or delayed response.

## Key Changes

- Applied the shared bounded in-memory idempotency middleware to job creation, retry, and retry-failed routes.
- Matching concurrent/sequential requests replay the original `jobId` or `newJobId`; conflicting fingerprints return `409 IDEMPOTENCY_CONFLICT`.
- Added integration coverage for concurrent creation, sequential replay, both retry flows, and conflicts.
- Documented the `idempotency-key` contract and replay response in OpenAPI, README, `agents.md`, and Postman.

## Technical Implementation

The existing five-minute `idempotencyService` reservation/cache handles in-flight waiters, completed response replay, and fingerprint conflict detection. Middleware remains after `validateApiKey`, preserving protected endpoint authentication and leaving requests without a key unchanged.

## Testing

- `pnpm exec jest tests/integration/jobs-endpoint.test.js --runInBand`: 20/20 passed.
- Idempotency regression selection: 5/5 passed.
- OpenAPI contract/docs: 18/18 passed.
- Full suite: 71 suites/1064 tests passed; 4 unrelated suite-order/state flakes (8 tests) passed when rerun in isolation: `job-service` 38/38, `status-endpoint` 56/56, `news-monitor-alerts` 25/25, and `signal-outcome-integration` 2/2.

## References

- Fixes #239
- GitHub: [Issue #239](https://github.com/francovp/cabros-bot/issues/239)
- Linear: [CB-96](https://linear.app/knil/issue/CB-96/gh-239-make-asynchronous-tradingview-job-starts-idempotent)